### PR TITLE
STBY and RESTART are both non latching and should turn off on transient

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -209,17 +209,18 @@ void CSMcomputer::Timestep(double simt, double simdt)
 				vagc.Standby = 0;
 				// Reset fake DSKYChannel163
 				vagc.DskyChannel163 = 0;
-				// Light OSCILLATOR FAILURE and CMC WARNING bits to signify power transient, and be forceful about it
+				// Light OSCILLATOR FAILURE and CMC WARNING bits to signify power transient, and be forceful about it.
 				InputChannel[033] &= 017777;
 				vagc.InputChannel[033] &= 017777;				
 				OutputChannel[033] &= 017777;				
 				vagc.Ch33Switches &= 017777;
-				// Also, simulate the operation of the VOLTAGE ALARM and light the RESTART light on the DSKY.
+				// Also, simulate the operation of the VOLTAGE ALARM, turn off STABY and RESTART light while power is off.
+				// The RESTART light will come on as soon as the AGC receives power again.
 				// This happens externally to the AGC program. See CSM 104 SYS HBK pg 399
 				vagc.VoltageAlarm = 1;
 				vagc.RestartLight = 1;
-				sat->dsky.LightRestart();
-				sat->dsky2.LightRestart();
+				sat->dsky.ClearStby();
+				sat->dsky2.ClearStby();
 				// Reset last cycling time
 				LastCycled = 0;
 			// We should issue telemetry though.

--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -214,7 +214,7 @@ void CSMcomputer::Timestep(double simt, double simdt)
 				vagc.InputChannel[033] &= 017777;				
 				OutputChannel[033] &= 017777;				
 				vagc.Ch33Switches &= 017777;
-				// Also, simulate the operation of the VOLTAGE ALARM, turn off STABY and RESTART light while power is off.
+				// Also, simulate the operation of the VOLTAGE ALARM, turn off STBY and RESTART light while power is off.
 				// The RESTART light will come on as soon as the AGC receives power again.
 				// This happens externally to the AGC program. See CSM 104 SYS HBK pg 399
 				vagc.VoltageAlarm = 1;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
@@ -189,13 +189,13 @@ void LEMcomputer::Timestep(double simt, double simdt)
 			vagc.Standby = 0;
 			// Reset fake DSKYChannel163
 			vagc.DskyChannel163 = 0;
-			// Light OSCILLATOR FAILURE and LGC WARNING bits to signify power transient, and be forceful about it.
+			// Light OSCILLATOR FAILURE and LGC WARNING bits to signify power transient, and be forceful about it.	
 			// Those two bits are what causes the CWEA to notice.
 			InputChannel[033] &= 017777;
 			vagc.InputChannel[033] &= 017777;
 			OutputChannel[033] &= 017777;
 			vagc.Ch33Switches &= 017777;
-			// Also, simulate the operation of the VOLTAGE ALARM, turn off STABY and RESTART light while power is off.
+			// Also, simulate the operation of the VOLTAGE ALARM, turn off STBY and RESTART light while power is off.
 			// The RESTART light will come on as soon as the AGC receives power again.
 			// This happens externally to the AGC program. See CSM 104 SYS HBK pg 399
 			vagc.VoltageAlarm = 1;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
@@ -189,17 +189,18 @@ void LEMcomputer::Timestep(double simt, double simdt)
 			vagc.Standby = 0;
 			// Reset fake DSKYChannel163
 			vagc.DskyChannel163 = 0;
-			// Light OSCILLATOR FAILURE and LGC WARNING bits to signify power transient, and be forceful about it
+			// Light OSCILLATOR FAILURE and LGC WARNING bits to signify power transient, and be forceful about it.
 			// Those two bits are what causes the CWEA to notice.
 			InputChannel[033] &= 017777;
 			vagc.InputChannel[033] &= 017777;
 			OutputChannel[033] &= 017777;
 			vagc.Ch33Switches &= 017777;
-			// Also, simulate the operation of the VOLTAGE ALARM and light the RESTART light on the DSKY.
+			// Also, simulate the operation of the VOLTAGE ALARM, turn off STABY and RESTART light while power is off.
+			// The RESTART light will come on as soon as the AGC receives power again.
 			// This happens externally to the AGC program. See CSM 104 SYS HBK pg 399
 			vagc.VoltageAlarm = 1;
 			vagc.RestartLight = 1;
-			dsky.LightRestart();
+			dsky.ClearStby();
 
 		// and do nothing more.
 		return;


### PR DESCRIPTION
This pull request is an addition to #64 where I made some standby mode power transient changes.
The STBY and RESTART light are actually non latching and should be turned off on a power loss.