### PR TITLE
CWS Fixes and Tweaks

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/csmcautionwarning.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csmcautionwarning.cpp
@@ -247,15 +247,10 @@ void CSMCautionWarningSystem::TimeStep(double simt)
 	// ISS warning
 	//
 
-	if (aws.ISSWarning) {
+	if (aws.ISSWarning)
 		SetLight(CSM_CWS_ISS_LIGHT, true);
-		// No Master Alarm during lamp test
-		if (aws.TestAlarms) 
-			SetMasterAlarm(false);
-	} 
-	else {
+	else
 		SetLight(CSM_CWS_ISS_LIGHT, false);
-	}
 
 	//
 	// CMC warning
@@ -264,17 +259,11 @@ void CSMCautionWarningSystem::TimeStep(double simt)
 	// Drawing 8.1, square L4 and others.
 	//
 
-	if (aws.TestAlarms) {
+	if (aws.CMCWarning || aws.TestAlarms) { // TestAlarms must be removed after yaAGC implements control over CMC light!
 		SetLight(CSM_CWS_CMC_LIGHT, true);
-		// No Master Alarm during lamp test
-		SetMasterAlarm(false);
-	} else {
-		if (aws.CMCWarning) {
-			SetLight(CSM_CWS_CMC_LIGHT, true); // The real thing
-		} else {
-			SetLight(CSM_CWS_CMC_LIGHT, false);
-		}
 	}
+	else
+		SetLight(CSM_CWS_CMC_LIGHT, false);
 
 	//
 	// PGNS warning, does NOT trigger master alarm 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/cautionwarning.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/cautionwarning.cpp
@@ -156,16 +156,9 @@ void CautionWarningSystem::TimeStep(double simt)
 
 {
 	//
-	// Cycle master alarm light if required, and play sound if appropriate.
+	// Play sound if appropriate.
 	//
 
-	if (simt > MasterAlarmCycleTime){
-		if (MasterAlarm) {
-			MasterAlarmLit = !MasterAlarmLit;
-		}
-		if (MasterAlarm) { // || (UplinkTestState&010) != 0){ -- Incorrect?
-			MasterAlarmCycleTime = simt + 0.25;
-		}
 		if (MasterAlarm && IsPowered() && PlaySounds) {
 			if (!MasterAlarmSound.isPlaying()) {
 				MasterAlarmSound.play(LOOP, 255);
@@ -173,7 +166,6 @@ void CautionWarningSystem::TimeStep(double simt)
 		} else {
 			MasterAlarmSound.stop();
 		}
-	}
 }
 
 void CautionWarningSystem::SystemTimestep(double simdt) 
@@ -184,10 +176,10 @@ void CautionWarningSystem::SystemTimestep(double simdt)
 	if (IsPowered()) {
 		consumption += 11.4;
 		if (MasterAlarmLit)
-			consumption += 2.0;			// This number is just made up for now.
+			consumption += 0.6;			// This number is just made up for now.
 	}
 	if (MasterAlarmLit && LightsPowered())
-		consumption += 1.0;				// This number is just made up for now.
+		consumption += 0.6;				// This number is just made up for now.
 
 	DCPower.DrawPower(consumption);
 }
@@ -195,18 +187,8 @@ void CautionWarningSystem::SystemTimestep(double simdt)
 void CautionWarningSystem::SetMasterAlarm(bool alarm)
 
 {
-	if (MasterAlarm != alarm)
-	{
-		MasterAlarm = alarm;
-
-		//
-		// Always set light state to false. If the alarm is enabled, the next timestep will
-		// take care of lighting it.
-		//
-
-		MasterAlarmLit = false;
-		MasterAlarmCycleTime = MINUS_INFINITY;
-	}
+	MasterAlarm = alarm;
+	MasterAlarmLit = alarm;
 }
 
 //

--- a/Orbitersdk/samples/ProjectApollo/src_sys/cautionwarning.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/cautionwarning.cpp
@@ -53,7 +53,6 @@ CautionWarningSystem::CautionWarningSystem(Sound &mastersound, Sound &buttonsoun
 	LightsFailedRight = 0;
 
 	MasterAlarmLightEnabled = true;
-	MasterAlarmCycleTime = MINUS_INFINITY;
 	MasterAlarm = false;
 	MasterAlarmLit = false;
 	MasterAlarmPressed = false;
@@ -159,13 +158,13 @@ void CautionWarningSystem::TimeStep(double simt)
 	// Play sound if appropriate.
 	//
 
-		if (MasterAlarm && IsPowered() && PlaySounds) {
-			if (!MasterAlarmSound.isPlaying()) {
-				MasterAlarmSound.play(LOOP, 255);
-			}
-		} else {
-			MasterAlarmSound.stop();
+	if (MasterAlarm && IsPowered() && PlaySounds) {
+		if (!MasterAlarmSound.isPlaying()) {
+			MasterAlarmSound.play(LOOP, 255);
 		}
+	} else {
+		MasterAlarmSound.stop();
+	}
 }
 
 void CautionWarningSystem::SystemTimestep(double simdt) 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/cautionwarning.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/cautionwarning.cpp
@@ -233,8 +233,10 @@ bool CautionWarningSystem::CheckMasterAlarmMouseClick(int event)
 void CautionWarningSystem::PushMasterAlarm()
 
 {
-	MasterAlarmSound.stop();
-	SetMasterAlarm(false); 
+	if (IsPowered()) {
+		MasterAlarmSound.stop();
+		SetMasterAlarm(false);
+	}
 	ButtonSound.play(NOLOOP, 255);
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/cautionwarning.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/cautionwarning.h
@@ -347,11 +347,6 @@ protected:
 	bool MasterAlarmLit;
 
 	///
-	/// \brief MET of next master alarm light cycle.
-	///
-	double MasterAlarmCycleTime;
-
-	///
 	/// \brief Sound to use for master alarm.
 	///
 	/// Note that we use a reference here, which must be set in the constructor and

--- a/Orbitersdk/samples/ProjectApollo/src_sys/missiontimer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/missiontimer.cpp
@@ -181,7 +181,7 @@ void EventTimer::SystemTimestep(double simdt)
 void LEMEventTimer::SystemTimestep(double simdt)
 
 {
-	DCPower.DrawPower(12.0);
+	DCPower.DrawPower(11.2);
 	DrawPower(4 * 7 * 0.022);
 }
 


### PR DESCRIPTION
@jalexb88 mentioned there were some differences between our simulation behaviour and in this [video](https://youtu.be/oxgGm8kHuig). From this video it can be clearly seen that as soon as the V35 is run the Master Alarm comes on. It also does not blink.

After discussing this in the IRC channel and examining the related schematics it was concluded that the master alarm is not supposed to blink nor that a light test causes the master alarm to be inhibited.

Our code also checks for the TestAlarms bit (ch13 bit10) in the AGC to be set to determine if a light test is in progress. @thewonderidiot pointed out that this signal is in fact completely internal to the AGC and should not be able to be read by the CWS. This functionality is being retained for now because agc_engine doesn't control the CMC light yet. A comment has been added that it should be removed when this gets added.

Some tweaks have been made to the power consumption values as the previous ones were a bit exaggerated. The consumption has been changed from 2W to 0.6W. This is the same value that is used for the DSKY lamps and might be changed again if better values are found.

Also included is a slight change to the mission timer code. I forgot to adjust the power draw value for the LEM timer.