### PR TITLE
Connect EMS Numerics and timer bugfix

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/satswitches.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satswitches.cpp
@@ -1894,8 +1894,7 @@ void SaturnEMSDvDisplay::Init(SURFHANDLE digits, SwitchRow &row, Saturn *s)
 void SaturnEMSDvDisplay::DoDrawSwitch(double v, SURFHANDLE drawSurface)
 
 {
-	if (Voltage() < SP_MIN_DCVOLTAGE) return;
-	if (Sat->ems.IsOff()) return; 
+	if (Voltage() < SP_MIN_DCVOLTAGE || Sat->ems.IsOff() || !Sat->ems.IsDisplayPowered()) return;
 
 	if (v < 0) {
 		oapiBlt(drawSurface, Digits, 0, 0, 161, 0, 10, 19);

--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -364,7 +364,7 @@ void Saturn::SystemsInit() {
 	eda.Init(this);
 	rjec.Init(this);
 	eca.Init(this);
-	ems.Init(this);
+	ems.Init(this, &EMSMnACircuitBraker, &EMSMnBCircuitBraker, &NumericRotarySwitch, &LightingNumIntLMDCCB);
 	ordeal.Init(this);
 
 	// Telecom initialization

--- a/Orbitersdk/samples/ProjectApollo/src_csm/scs.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/scs.h
@@ -301,13 +301,16 @@ public:
 #define EMS_RSI_CENTER_X        42     //Pixel center on bitmap
 #define EMS_RSI_CENTER_Y        41     //Pixel center on bitmap
 
-class EMS {
+class EMS : public e_object {
 
 public:
 	EMS(PanelSDK &p);
-	void Init(Saturn *vessel);										// Initialization
+	void Init(Saturn *vessel, e_object *a, e_object *b, RotationalSwitch *dimmer, e_object *c);
 	void TimeStep(double MissionTime, double simdt);
 	void SystemTimestep(double simdt);
+	void SaveState(FILEHANDLE scn);                                // SaveState callback
+	void LoadState(FILEHANDLE scn);                                // LoadState callback
+
 	double GetdVRangeCounter() { return dVRangeCounter; };
 	POINT ScribePntArray[EMS_SCROLL_LENGTH_PX*3]; //Thrice the number of pixels in the scrolling direction.
 	POINT RSITriangle[3];
@@ -323,11 +326,10 @@ public:
 	bool IsOff();
 	bool IsdVMode();
 	bool WriteScrollToFile();
-	void SaveState(FILEHANDLE scn);                                // SaveState callback
-	void LoadState(FILEHANDLE scn);                                // LoadState callback
 	
 protected:
 	bool IsPowered();
+	bool IsDisplayPowered();
 	
 	void AccelerometerTimeStep(double simdt);
 	double xacc, xaccG, constG;
@@ -376,6 +378,7 @@ protected:
 
 	PowerMerge DCPower;
 	Saturn *sat;
+	RotationalSwitch *DimmerRotationalSwitch;
 
 	friend class SaturnEMSDvDisplay;
 	friend class SaturnEMSScrollDisplay;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/missiontimer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/missiontimer.cpp
@@ -148,7 +148,7 @@ void MissionTimer::UpdateSeconds(int n)
 bool MissionTimer::IsPowered()
 
 {
-	if (DCPower.Voltage() < 25.0) { return false; } // DC
+	if (DCPower.Voltage() < SP_MIN_DCVOLTAGE) { return false; } // DC
 	return true;
 }
 


### PR DESCRIPTION
I've connected the EMS display to the numerics rotary and breaker similar to #71.
Also a bug has been fixed with the timers that caused them to be corrupted on a scenario load due to the buses taking some time to settle their voltages to nominal levels.