### PR TITLE
yaAGC Warning filter, Remove TestAlarms, Fix caution and warning

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -207,18 +207,20 @@ void CSMcomputer::Timestep(double simt, double simdt)
 				// IO channels are flip-flop based and should reset, but that's difficult, so we'll ignore it.
 				// Reset standby flip-flop
 				vagc.Standby = 0;
-				// Reset fake DSKYChannel163
-				vagc.DskyChannel163 = 0;
-				// Light OSCILLATOR FAILURE and CMC WARNING bits to signify power transient, and be forceful about it.
-				InputChannel[033] &= 017777;
-				vagc.InputChannel[033] &= 017777;				
-				OutputChannel[033] &= 017777;				
-				vagc.Ch33Switches &= 017777;
+				// Turn on EL display and CMC Light (DSKYWarn).
+				SetOutputChannel(0163, 1);
+				// Light OSCILLATOR FAILURE to signify power transient, and be forceful about it.
+				InputChannel[033] &= 037777;
+				vagc.InputChannel[033] &= 037777;				
+				OutputChannel[033] &= 037777;				
+				vagc.Ch33Switches &= 037777;
 				// Also, simulate the operation of the VOLTAGE ALARM, turn off STBY and RESTART light while power is off.
 				// The RESTART light will come on as soon as the AGC receives power again.
 				// This happens externally to the AGC program. See CSM 104 SYS HBK pg 399
 				vagc.VoltageAlarm = 1;
 				vagc.RestartLight = 1;
+				sat->dsky.ClearRestart();
+				sat->dsky2.ClearRestart();
 				sat->dsky.ClearStby();
 				sat->dsky2.ClearStby();
 				// Reset last cycling time

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csmcautionwarning.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csmcautionwarning.cpp
@@ -259,7 +259,7 @@ void CSMCautionWarningSystem::TimeStep(double simt)
 	// Drawing 8.1, square L4 and others.
 	//
 
-	if (aws.CMCWarning || aws.TestAlarms) { // TestAlarms must be removed after yaAGC implements control over CMC light!
+	if (aws.DSKYWarn) {
 		SetLight(CSM_CWS_CMC_LIGHT, true);
 	}
 	else

--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -3216,6 +3216,7 @@ void Saturn::GetAGCWarningStatus(AGCWarningStatus &aws)
 	ChannelValue val11;
 	ChannelValue val13;
 	ChannelValue val33;
+	ChannelValue val163;
 
 	val11 = agc.GetOutputChannel(011);
 	if (val11[ISSWarning]) 
@@ -3223,17 +3224,11 @@ void Saturn::GetAGCWarningStatus(AGCWarningStatus &aws)
 	else
 		aws.ISSWarning = false;
 
-	val13 = agc.GetOutputChannel(013);
-	if (val13[TestAlarms])  
-		aws.TestAlarms = true;
+	val163 = agc.GetOutputChannel(0163);
+	if (val163[Ch163DSKYWarn])
+		aws.DSKYWarn = true;
 	else
-		aws.TestAlarms = false;
-
-	val33 = agc.GetInputChannel(033);
-	if (val33[AGCWarning])
-		aws.CMCWarning = true;
-	else
-		aws.CMCWarning = false;
+		aws.DSKYWarn = false;
 		
 	aws.PGNSWarning = false;
 	// Restart alarm

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -244,9 +244,8 @@ typedef struct {
 /// \ingroup InternalInterface
 ///
 typedef struct {
-	bool CMCWarning;
+	bool DSKYWarn;
 	bool ISSWarning;
-	bool TestAlarms;
 	bool PGNSWarning;
 } AGCWarningStatus;
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
@@ -187,19 +187,20 @@ void LEMcomputer::Timestep(double simt, double simdt)
 			// IO channels are flip-flop based and should reset, but that's difficult, so we'll ignore it.
 			// Reset standby flip-flop
 			vagc.Standby = 0;
-			// Reset fake DSKYChannel163
-			vagc.DskyChannel163 = 0;
+			// Turn on EL display and LGC Light (DSKYWarn).
+			SetOutputChannel(0163, 1);
 			// Light OSCILLATOR FAILURE and LGC WARNING bits to signify power transient, and be forceful about it.	
 			// Those two bits are what causes the CWEA to notice.
-			InputChannel[033] &= 017777;
-			vagc.InputChannel[033] &= 017777;
-			OutputChannel[033] &= 017777;
-			vagc.Ch33Switches &= 017777;
+			InputChannel[033] &= 037777;
+			vagc.InputChannel[033] &= 037777;
+			OutputChannel[033] &= 037777;
+			vagc.Ch33Switches &= 037777;
 			// Also, simulate the operation of the VOLTAGE ALARM, turn off STBY and RESTART light while power is off.
 			// The RESTART light will come on as soon as the AGC receives power again.
 			// This happens externally to the AGC program. See CSM 104 SYS HBK pg 399
 			vagc.VoltageAlarm = 1;
 			vagc.RestartLight = 1;
+			dsky.ClearRestart();
 			dsky.ClearStby();
 
 		// and do nothing more.

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -1209,25 +1209,25 @@ void LEM::SystemsTimestep(double simt, double simdt)
 
 	// Allow ATCA to operate between the FDAI and AGC/AEA so that any changes the FDAI makes
 	// can be shown on the FDAI, but any changes the AGC/AEA make are visible to the ATCA.
-	atca.Timestep(simt);								    // Do Work
-	fdaiLeft.Timestep(MissionTime, simdt);					// Do Work
+	atca.Timestep(simt);
+	fdaiLeft.Timestep(MissionTime, simdt);
 	fdaiRight.Timestep(MissionTime, simdt);
 	fdaiLeft.SystemTimestep(simdt);							// Draw Power
 	fdaiRight.SystemTimestep(simdt);
-	MissionTimerDisplay.Timestep(MissionTime, simdt, false);	// These just do work
+	MissionTimerDisplay.Timestep(MissionTime, simdt, false);
 	EventTimerDisplay.Timestep(MissionTime, simdt, false);
 	JoystickTimestep(simdt);
-	eds.TimeStep();                                         // Do Work
-	optics.TimeStep(simdt);									// Do Work
-	LR.TimeStep(simdt);										// I don't wanna work
-	RR.TimeStep(simdt);										// I just wanna bang on me drum all day
-	RadarTape.TimeStep(MissionTime);						// I just wanna bang on me drum all day
+	eds.TimeStep();
+	optics.TimeStep(simdt);
+	LR.TimeStep(simdt);
+	RR.TimeStep(simdt);
+	RadarTape.TimeStep(MissionTime);
 	RadarTape.SystemTimeStep(simdt);
 	crossPointerLeft.TimeStep(simdt);
 	crossPointerLeft.SystemTimeStep(simdt);
 	crossPointerRight.TimeStep(simdt);
 	crossPointerRight.SystemTimeStep(simdt);
-	SBandSteerable.TimeStep(simdt);							// Back to work...
+	SBandSteerable.TimeStep(simdt);
 	VHF.SystemTimestep(simdt);
 	VHF.TimeStep(simt);
 	SBand.SystemTimestep(simdt);
@@ -3336,13 +3336,15 @@ void LEM_CWEA::TimeStep(double simdt){
 	ChannelValue val11;
 	ChannelValue val13;
 	ChannelValue val30;
-	ChannelValue val33;		
+	ChannelValue val33;	
+	ChannelValue val163;
 
 	if(lem == NULL){ return; }
 	val11 = lem->agc.GetOutputChannel(011);
 	val13 = lem->agc.GetOutputChannel(013);
 	val30 = lem->agc.GetInputChannel(030);
 	val33 = lem->agc.GetInputChannel(033);
+	val163 = lem->agc.GetOutputChannel(0163);
 
 	// 6DS2 ASC PROP LOW
 	// Pressure of either ascent helium tanks below 2773 psia prior to staging, - This reason goes out when stage deadface opens.
@@ -3402,7 +3404,7 @@ void LEM_CWEA::TimeStep(double simdt){
 	// 6DS9 LGC FAILURE
 	// On when any LGC power supply signals a failure, scaler fails, LGC restarts, counter fails, or LGC raises failure signal.
 	// Disabled by Guidance Control switch in AGS position.
-	if((val13[TestAlarms] || val33[LGC] || val33[OscillatorAlarm]) && lem->GuidContSwitch.GetState() == TOGGLESWITCH_UP){
+	if((val163[Ch163DSKYWarn]) && lem->GuidContSwitch.GetState() == TOGGLESWITCH_UP){
 		LightStatus[3][1] = 1;
 	}else{
 		LightStatus[3][1] = 0;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_channels.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_channels.h
@@ -239,7 +239,7 @@ enum ChannelValue32_Bits {
 // Channel 33, Optics
 enum ChannelValue33_Bits {
 	//Spare
-	RRPowerOnAuto = 1,      // RR power on and RR mode = LGC
+	RRPowerOnAuto = 1,		// RR power on and RR mode = LGC
 	RRRangeLowScale,
 	RRDataGood,
 	LRDataGood,
@@ -251,8 +251,20 @@ enum ChannelValue33_Bits {
 	UplinkTooFast,
 	DownlinkTooFast,
 	PIPAFailed,
-	LGC,                // LGC Internal Malfunction
+	AGCWarning,				// AGC Internal use only.
 	OscillatorAlarm
+};
+
+enum ChannelValue163_Bits {
+
+	Ch163DSKYWarn = 0,				///< Turn on the CMC/LGC light.
+	Ch163LightKbRel = 4,			///< Turn on the Keyboard Release light.
+	Ch163FlashVerbNoun,				///< Flash the Verb and Noun displays.			
+	Ch163LightOprErr,				///< Light the Operator Error light
+	Ch163LightRestart,				///< Light the Restart light
+	Ch163LightStandby,				///< Light the Standby light
+	Ch163ELOff,						///< Switch off EL panel power
+
 };
 
 // Channel 34, Downlink 1

--- a/Orbitersdk/samples/ProjectApollo/src_sys/ioChannels.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/ioChannels.h
@@ -231,7 +231,7 @@ enum ChannelValue33_Bits {
         // Spare 1					///< Unused.
 		RangeUnitDataGood = 1,
 		// Spare 1					///< Unused.
-		ZeroOptics_33 = 3,				    ///< Optics ZERO switch
+		ZeroOptics_33 = 3,			///< Optics ZERO switch
 		CMCControl,				    ///< Optics under CMC control
 		// NotUsed 2				///< Unused.
 		// Spare 2					///< Unused.
@@ -239,12 +239,13 @@ enum ChannelValue33_Bits {
 		UplinkTooFast,
 		DownlinkTooFast,
 		PIPAFail,
-		AGCWarning,
+		AGCWarning,					///< AGC Internal use only.
 		AGCOscillatorAlarm,
 } ;
 
 enum ChannelValue163_Bits {
 
+	Ch163DSKYWarn = 0,				///< Turn on the CMC/LGC light.
 	Ch163LightKbRel = 4,			///< Turn on the Keyboard Release light.
 	Ch163FlashVerbNoun,				///< Flash the Verb and Noun displays.			
 	Ch163LightOprErr,				///< Light the Operator Error light

--- a/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine.c
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine.c
@@ -317,6 +317,9 @@
 				 simulation of the Night Watchman's assertion of
 				 its channel 77 bit for 1.28 seconds after each
 				 triggering.
+		04/16/17 MAS	Added a simple linear model of the AGC warning
+				 filter, and added the AGC (CMC/LGC) warning
+				 light status to DSKY channel 163.
   
   The technical documentation for the Apollo Guidance & Navigation (G&N) system,
   or more particularly for the Apollo Guidance Computer (AGC) may be found at 
@@ -454,6 +457,11 @@ FILE *CduLog = NULL;
 // DSKY handling constants and variables.
 #define DSKY_OVERFLOW 81920
 #define DSKY_FLASH_PERIOD 4
+
+#define WARNING_FILTER_INCREMENT  15000
+#define WARNING_FILTER_DECREMENT     15
+#define WARNING_FILTER_MAX       140000
+#define WARNING_FILTER_THRESHOLD  20000
 
 //-----------------------------------------------------------------------------
 // Functions for reading or writing from/to i/o channels.  The reason we have
@@ -1632,7 +1640,7 @@ UpdateDSKY(agc_t *State)
   {
 	unsigned LastChannel163 = State->DskyChannel163;
 
-	State->DskyChannel163 &= ~(DSKY_KEY_REL | DSKY_VN_FLASH | DSKY_OPER_ERR | DSKY_RESTART | DSKY_STBY);
+	State->DskyChannel163 &= ~(DSKY_KEY_REL | DSKY_VN_FLASH | DSKY_OPER_ERR | DSKY_RESTART | DSKY_STBY | DSKY_AGC_WARN);
 
 	if (State->InputChannel[013] & 01000)
 	  // The light test is active. Light RESTART and STBY.
@@ -1651,6 +1659,10 @@ UpdateDSKY(agc_t *State)
 	  State->DskyChannel163 |= DSKY_KEY_REL;
 	if (State->InputChannel[011] & DSKY_OPER_ERR)
 	  State->DskyChannel163 |= DSKY_OPER_ERR;
+
+  // Turn on the AGC warning light if the warning filter is above its threshold
+	if (State->WarningFilter > WARNING_FILTER_THRESHOLD)
+	  State->DskyChannel163 |= DSKY_AGC_WARN;
 
 	// Update the DSKY flash counter based on the DSKY timer
 	while (State->DskyTimer >= DSKY_OVERFLOW)
@@ -1922,6 +1934,28 @@ agc_engine (agc_t * State)
 			  // channel 77 bit
 			  State->NightWatchmanTripped = 0;
 	  }
+	  else if (00 == (07 & State->InputChannel[ChanSCALER1]))
+		{
+		  // Update the warning filter. Once every 160ms, if an input to the filter has been
+		  // generated (or if the light test is active), the filter is charged. Otherwise,
+		  // it slowly discharges. This is being modeled as a simple linear function right now,
+		  // and should be updated when we learn its real implementation details.
+		  if ((0400 == (0777 & State->InputChannel[ChanSCALER1])) &&
+			  (State->GeneratedWarning || (State->InputChannel[013] & 01000)))
+		  {
+			  State->GeneratedWarning = 0;
+			  State->WarningFilter += WARNING_FILTER_INCREMENT;
+			  if (State->WarningFilter > WARNING_FILTER_MAX)
+				  State->WarningFilter = WARNING_FILTER_MAX;
+		  }
+		  else
+		  {
+			  if (State->WarningFilter >= WARNING_FILTER_DECREMENT)
+				  State->WarningFilter -= WARNING_FILTER_DECREMENT;
+			  else
+				  State->WarningFilter = 0;
+		  }
+	  }
 	 
 	  // All the rest of this is switched off during standby.
 	  if (!State->Standby)
@@ -2022,6 +2056,7 @@ agc_engine (agc_t * State)
 			  if (!State->Standby)
 			    {
 				  State->RestartLight = 1;
+				  State->GeneratedWarning = 1;
 				}
 
 		    }

--- a/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine.h
@@ -98,6 +98,9 @@
 		03/26/17 MAS	Added previously-static items from agc_engine.c to agc_t.
 		03/27/17 MAS	Added a bit for Night Watchman's 1.28s-long assertion of
 						its channel 77 bit.
+		04/16/17 MAS    Added a voltage counter and input flag for the AGC
+						warning filter, as well as a channel 163 flag for
+						the AGC (CMC/LGC) warning light.
    
   For more insight, I'd highly recommend looking at the documents
   http://hrst.mit.edu/hrs/apollo/public/archive/1689.pdf and
@@ -244,6 +247,7 @@ extern long random (void);
 #define CH77_RUPT_LOCK      000010
 #define CH77_NIGHT_WATCHMAN 000020
 
+#define DSKY_AGC_WARN 000001
 #define DSKY_KEY_REL  000020
 #define DSKY_VN_FLASH 000040
 #define DSKY_OPER_ERR 000100
@@ -357,6 +361,8 @@ typedef struct
   unsigned ParityFail:1;        // Set when a parity failure is encountered accessing memory (in yaAGC, just hitting banks 44+)
   unsigned CheckParity:1;       // Enable parity checking for fixed memory.
   unsigned RestartLight:1;      // The present state of the RESTART light
+  unsigned GeneratedWarning : 1;  // Whether there is a pending input to the warning filter
+  uint32_t WarningFilter;       // Current voltage of the AGC warning filter
   int VoltageAlarm;         // AGC Voltage Alarm
   uint64_t /*unsigned long long */ DownruptTime;	// Time when next DOWNRUPT occurs.
   int NextZ;                    // Next value for the Z register

--- a/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine_init.c
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine_init.c
@@ -66,6 +66,7 @@
 		                 from agc_engine.c that are now in agc_t.
 		03/27/17 MAS    Fixed a parity-related program loading bug and
                          added initialization of a new night watchman bit.
+		04/16/17 MAS    Added initialization of warning filter variables.
 */
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1300 ) // Microsoft Visual Studio Version 2003 and higher
@@ -258,6 +259,9 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   State->TCTrap = 0;
   State->NoTC = 0;
   State->ParityFail = 0;
+
+  State->WarningFilter = 0;
+  State->GeneratedWarning = 0;
 
   State->RestartLight = 0;
   State->Standby = 0;


### PR DESCRIPTION
yaAGC now simulates the warning filter and drives the warning light (thanks @thewonderidiot :smile:).
TestAlarms has been removed. It was kept until the CMC light got driven by the AGC.

AGC Warning has also been removed from places that use it outside of the AGC itself. This signal is also internal to the AGC.

The power transient code now turns the CMC light on via channel 163, no longer sets AGC Warning and clears the RESTART light if that had been set earlier.

The LGC light now works on the LEM CWEA.