### PR TITLE
Stop LC34 on abort

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -936,6 +936,11 @@ public:
 	/// 
 	virtual void SwitchSelector(int item) = 0;
 
+	///
+	/// \brief Has an abort been initiated?
+	///
+	bool GetAbort() { return secs.BECO(); };
+
 	//
 	// CWS functions.
 	//
@@ -3594,6 +3599,7 @@ protected:
 	IMU imu;
 	IU iu;
 	CSMCautionWarningSystem cws;
+
 	DockingProbe dockingprobe;
 	SECS secs;
 	ELS els;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/secs.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/secs.h
@@ -314,7 +314,7 @@ public:
 
 	bool AbortLightPowerA();
 	bool AbortLightPowerB();
-	bool BECO();
+	virtual bool BECO();
 
 	void SetEDSAbort1(bool set) { MESCA.SetEDSAbortRelay1(set); MESCB.SetEDSAbortRelay1(set); };
 	void SetEDSAbort2(bool set) { MESCA.SetEDSAbortRelay2(set); MESCB.SetEDSAbortRelay2(set); };

--- a/Orbitersdk/samples/ProjectApollo/src_launch/LC34.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/LC34.h
@@ -42,6 +42,7 @@ public:
 
 protected:
 	bool firstTimestepDone;
+	bool abort;
 	int meshindexLUT;
 	int meshindexMSS;
 	double touchdownPointHeight;


### PR DESCRIPTION
When an abort was issued the pad would still move the arms and trigger the liftoff stream.
This prevents such things from happening.