### PR TITLE
Fix DSKY desync, Wire LGC DSKY correctly

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -201,6 +201,7 @@ void CSMcomputer::Timestep(double simt, double simdt)
 				// Reset standby flip-flop
 				vagc.Standby = 0;
 				// Turn on EL display and CMC Light (DSKYWarn).
+				vagc.DskyChannel163 = 1;
 				SetOutputChannel(0163, 1);
 				// Light OSCILLATOR FAILURE to signify power transient, and be forceful about it.
 				vagc.InputChannel[033] &= 037777;				

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
@@ -187,6 +187,7 @@ void LEMcomputer::Timestep(double simt, double simdt)
 			// Reset standby flip-flop
 			vagc.Standby = 0;
 			// Turn on EL display and LGC Light (DSKYWarn).
+			vagc.DskyChannel163 = 1;
 			SetOutputChannel(0163, 1);
 			// Light OSCILLATOR FAILURE and LGC WARNING bits to signify power transient, and be forceful about it.	
 			// Those two bits are what causes the CWEA to notice.

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -439,10 +439,10 @@ void LEM::SystemsInit()
 	// LGC and DSKY
 	LGC_DSKY_CB.MaxAmps = 7.5;
 	LGC_DSKY_CB.WireTo(&CDRs28VBus);
-	agc.WirePower(&LGC_DSKY_CB,&LGC_DSKY_CB);
+	agc.WirePower(&LGC_DSKY_CB, NULL);
 	// The DSKY brightness IS controlled by the ANUN/NUM knob on panel 5, but by means of an isolated section of it.
-	// The source of the isolated section may be from the LGC supply or AC bus. So this may not be correct. If the CB pops, investigate!
-	dsky.Init(&NUM_LTG_AC_CB, &LtgAnunNumKnob);
+	// The source of the isolated section is coming from the LGC supply.
+	dsky.Init(&LGC_DSKY_CB, &LtgAnunNumKnob);
 
 	// AGS stuff
 	asa.Init(this, (Boiler *)Panelsdk.GetPointerByString("ELECTRIC:LEM-ASA-Heater"), (h_Radiator *)Panelsdk.GetPointerByString("HYDRAULIC:LEM-ASA-HSink"));

--- a/Orbitersdk/samples/ProjectApollo/src_sys/dsky.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/dsky.cpp
@@ -218,7 +218,7 @@ void DSKY::Init(e_object *powered, RotationalSwitch *dimmer)
 }
 
 bool DSKY::IsPowered() {
-	if (Voltage() < SP_MIN_ACVOLTAGE){ return false; }
+	if (Voltage() < SP_MIN_DCVOLTAGE){ return false; }
 
 	if (DimmerRotationalSwitch != NULL) {
 		if (DimmerRotationalSwitch->GetState() == 0) {


### PR DESCRIPTION
There was an issue that if the scenario was reloaded when AGC power failed the DSKY would come back on after a reload due to desync in the output channels. Setting it in the AGC next to just the output channel fixes this.

The LGC DSKY used to be wired to the general lighting breaker, This should however be wired to the same breaker as the LGC (LGC/DSKY cb). The dimmer for the display still works.