### PR TITLE
AGS Testing

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/yaAGS/aea_engine.c
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/yaAGS/aea_engine.c
@@ -52,6 +52,9 @@
 				(finally) with what I think is a correct 
 				implementation.
 		2005-08-22 RSB	"unsigned long long" replaced by uint64_t.
+		2017-10-11 MAS	Changed a "1" to "1LL" in LLS mask calculations.
+				This fixes overflow being incorrectly set for
+				certain cases of LLS.
   
   The scans of the original AGS/AEA technical documentation can be found
   at the website listed above.  Also at that site you can find the source code
@@ -983,7 +986,7 @@ aea_engine (ags_t * State)
       // will be the picked-off bits.
       if (i)
         {
-	  llk = (CONST64_2 & ~((1 << (34 - i)) - 1));
+	  llk = (CONST64_2 & ~((CONST64_3 << (34 - i)) - 1));
 	  llj = (lli & llk);
 	  if ((0 == (State->Accumulator & 0400000) && llj != 0) ||
 	      (0 != (State->Accumulator & 0400000) && llj != llk))

--- a/Orbitersdk/samples/ProjectApollo/src_lm/yaAGS/aea_engine.c
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/yaAGS/aea_engine.c
@@ -130,7 +130,6 @@ static const int64_t CONST64_3 = 1i64;
 
 static int abscom_caused_ovf = 0;
 static int abscom_ovf_addr = 0;
-static int abscom_problem_addr = 0;
 
 #if 0
 static int 
@@ -975,8 +974,8 @@ aea_engine (ags_t * State)
         {	
           if (abscom_caused_ovf)
           {
-            abscom_problem_addr = abscom_ovf_addr;
-            fprintf(stderr, "!!!!! ABS/COM OVF ADDR: %04o", abscom_problem_addr);
+            State->AbsComAddr = abscom_ovf_addr;
+            fprintf(stderr, "!!!!! ABS/COM OVF ADDR: %04o", State->AbsComAddr);
           }
 	  AddBacktraceAGS (State);
 	  State->Overflow = 0;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/yaAGS/aea_engine.c
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/yaAGS/aea_engine.c
@@ -1030,11 +1030,15 @@ aea_engine (ags_t * State)
       break;
     case 060:	// COM
       State->Accumulator = (0777777 & -State->Accumulator);
+      if (State->Accumulator == 0400000) // NASSP TEST #1 -- COM NEGMAX -> OVERFLOW
+        State->Overflow = 1;
       break;
     case 062:	// ABS
       i = SignExtend (State->Accumulator);
       if (i < 0 && i > -0400000)
         State->Accumulator = -i;
+      if (State->Accumulator == 0400000) // NASSP TEST #2 -- ABS NEGMAX -> OVERFLOW
+        State->Overflow = 1;
       break;
     case 064:	// INP
       MicrosecondsThisInstruction = Input (State, AddressField, &State->Accumulator);

--- a/Orbitersdk/samples/ProjectApollo/src_lm/yaAGS/aea_engine.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/yaAGS/aea_engine.h
@@ -90,6 +90,7 @@ typedef struct
   int Index;
   int Overflow;
   int Halt;
+  int AbsComAddr;
   // The following variable counts the total number of clock cycles since
   // CPU-startup.  A 64-bit integer is used.
   uint64_t /* unsigned long long */ CycleCounter;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/yaAGS/aea_engine_init.c
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/yaAGS/aea_engine_init.c
@@ -121,6 +121,7 @@ aea_engine_init (ags_t * State, const char *RomImage, const char *CoreDump)
   State->Quotient = 0;
   State->Index = 0;
   State->Overflow = 0;
+  State->AbsComAddr = 0;
   // The discrete outputs and inputs.
   State->OutputPorts[IO_ODISCRETES] = 0777777;
   State->InputPorts[IO_2020] = 0777777;


### PR DESCRIPTION
(Don't merge me!)

This is the first set of tests to try out possible fixes for AEA misbehaviors, as discussed in virtualagc/virtualagc#1052. This first attempt contains very similar instruction tweaks:
1. `COM 400000` now sets the overflow indicator.
2. `ABS 400000` now sets the overflow indicator.

The self-tests still pass with both of these tweaks in place, so at the very least it doesn't seem to break anything fundamental. If this doesn't work or has bad effects on mission software, we should try it with only the ABS change, and then with only the COM change.