### PR TITLE
Remove old hack in AGC power code

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
@@ -92,8 +92,6 @@ ApolloGuidance::ApolloGuidance(SoundLib &s, DSKY &display, IMU &im, CDU &sc, CDU
 	out_file = fopen("ProjectApollo AGC.log", "wt");
 	vagc.out_file = out_file;
 #endif
-
-	PowerConnected = false;
 }
 
 ApolloGuidance::~ApolloGuidance()
@@ -593,14 +591,6 @@ bool ApolloGuidance::IsPowered()
 
 {
 	if (DCPower.Voltage() > SP_MIN_DCVOLTAGE)
-		return true;
-
-	//
-	// Quick hack for now: if no power connected, pretend we
-	// have power.
-	//
-
-	if (!PowerConnected)
 		return true;
 
 	return false;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
@@ -306,7 +306,7 @@ public:
 	/// \param a Power bus 1.
 	/// \param b Power bus 2.
 	///
-	void WirePower(e_object *a, e_object *b) { DCPower.WireToBuses(a, b); PowerConnected = true; };
+	void WirePower(e_object *a, e_object *b) { DCPower.WireToBuses(a, b); };
 
 	///
 	/// \brief Is the AGC supplied with power.
@@ -417,7 +417,6 @@ protected:
 	//
 
 	PowerMerge DCPower;
-	bool PowerConnected;
 
 	///
 	/// \brief The Vessel we're controlling.


### PR DESCRIPTION
That code has been sitting there since 2005.
It checks if the breakers are wired at all. If not it will assume there is power.

Since we are simulating this correctly for as long as I can remember and I don't get any issues when commenting it out, I removed it.