### PR TITLE
Minor fixes:

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnmesh.cpp
@@ -575,6 +575,14 @@ void Saturn::SetCSMStage ()
 	meshidx = AddMesh (hCM, &mesh_dir);
 	SetMeshVisibilityMode (meshidx, MESHVIS_VCEXTERNAL);
 
+	if (LESAttached) {
+		TowerOffset = 4.95;
+		VECTOR3 mesh_dir_tower = mesh_dir + _V(0, 0, TowerOffset);
+
+		meshidx = AddMesh(hsat5tower, &mesh_dir_tower);
+		SetMeshVisibilityMode(meshidx, MESHVIS_VCEXTERNAL);
+	}
+
 	// And the Crew
 	if (Crewed) {
 		cmpidx = AddMesh (hCMP, &mesh_dir);
@@ -824,7 +832,7 @@ void Saturn::SetCMdocktgtMesh() {
 	if (cmdocktgtidx == -1)
 		return;
 
-	if (CMdocktgt) {
+	if (CMdocktgt && ApexCoverAttached) {
 		SetMeshVisibilityMode(cmdocktgtidx, MESHVIS_VCEXTERNAL);
 	}
 	else {
@@ -859,7 +867,14 @@ void Saturn::SetReentryStage ()
 	SetSize(6.0);
 	SetEmptyMass(EmptyMass);
 
-	double Mass = CM_EmptyMass;
+	double Mass = 5430;
+	double ra;
+	if (ApexCoverAttached) {
+		ra = -1.0;
+	}
+	else {
+		ra = -2.2;
+	}
 	double ro = 2;
 	TOUCHDOWNVTX td[4];
 	double x_target = -0.5;
@@ -873,16 +888,16 @@ void Saturn::SetReentryStage ()
 	}
 	td[0].pos.x = -cos(30 * RAD)*ro;
 	td[0].pos.y = -sin(30 * RAD)*ro;
-	td[0].pos.z = -2.2;
+	td[0].pos.z = ra;
 	td[1].pos.x = 0;
 	td[1].pos.y = 1 * ro;
-	td[1].pos.z = -2.2;
+	td[1].pos.z = ra;
 	td[2].pos.x = cos(30 * RAD)*ro;
 	td[2].pos.y = -sin(30 * RAD)*ro;
-	td[2].pos.z = -2.2;
+	td[2].pos.z = ra;
 	td[3].pos.x = 0;
 	td[3].pos.y = 0;
-	td[3].pos.z = 2.2;
+	td[3].pos.z = ra + 5.0;
 
 	SetTouchdownPoints(td, 4);
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnmesh.cpp
@@ -498,7 +498,7 @@ void Saturn::SetCSMStage ()
 
 	SetSize(10);
 	SetCOG_elev(3.5);
-	SetEmptyMass(CM_EmptyMass + SM_EmptyMass);
+	SetEmptyMass(CM_EmptyMass + SM_EmptyMass + (LESAttached ? Abort_Mass : 0.0));
 
 	// ************************* propellant specs **********************************
 

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/Saturn1Abort.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/Saturn1Abort.cpp
@@ -89,13 +89,13 @@ void Sat1Abort1::Setup(bool sm)
 	AddMesh (hSat1intstg, &mesh_dir);
     mesh_dir=_V(0,0,9.25);
 	AddMesh (hSat1stg2, &mesh_dir);
-	mesh_dir=_V(1.85,1.85,19.8);
+	mesh_dir=_V(2.45, 0, 19.8);
     AddMesh (hSat1stg21, &mesh_dir);
-	mesh_dir=_V(-1.85,1.85,19.8);
+	mesh_dir=_V(0, 2.45, 19.8);
     AddMesh (hSat1stg22, &mesh_dir);
-	mesh_dir=_V(1.85,-1.85,19.8);
+	mesh_dir=_V(0, -2.45, 19.8);
     AddMesh (hSat1stg23, &mesh_dir);
-	mesh_dir=_V(-1.85,-1.85,19.8);
+	mesh_dir=_V(-2.45, 0, 19.8);
     AddMesh (hSat1stg24, &mesh_dir);
 	if (sm)
 	{

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/Saturn1Abort2.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/Saturn1Abort2.cpp
@@ -86,13 +86,13 @@ void Sat1Abort2::Setup()
     ClearAttExhaustRefs();
 	VECTOR3 mesh_dir=_V(0,0,9.25-12.25);
     AddMesh (hSat1stg2, &mesh_dir);
-	mesh_dir=_V(1.85,1.85,19.8-12.25);
+	mesh_dir=_V(2.45, 0, 19.8-12.25);
     AddMesh (hSat1stg21, &mesh_dir);
-	mesh_dir=_V(-1.85,1.85,19.8-12.25);
+	mesh_dir=_V(0, 2.45, 19.8-12.25);
     AddMesh (hSat1stg22, &mesh_dir);
-	mesh_dir=_V(1.85,-1.85,19.8-12.25);
+	mesh_dir=_V(0, -2.45, 19.8-12.25);
     AddMesh (hSat1stg23, &mesh_dir);
-	mesh_dir=_V(-1.85,-1.85,19.8-12.25);
+	mesh_dir=_V(-2.45, 0, 19.8-12.25);
     AddMesh (hSat1stg24, &mesh_dir);
 	mesh_dir=_V(0,-0.14,26.6-12.25);
 	AddMesh (hSM, &mesh_dir);


### PR DESCRIPTION
1. If CSM separates from launch vehicle with LES still attached, LES mesh no longer disapears.
2. CM docking target displays incorrectly after Apex cover jettison. (target mesh is floating outside CM) Added check to prevent CM docking target from displaying when Apex Cover is gone.
3. Adjustments to CM touchdown points.
4. S1B abort meshes SLA panels were not positioned correctly. This is now fixed.