### PR TITLE
IMUCase was uninitialized, added to constructor.

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_sys/imu.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/imu.cpp
@@ -94,6 +94,7 @@ void IMU::Init()
 	OurVessel = 0;
 	IMUHeater = 0;
 	IMUHeat = 0;
+	IMUCase = 0;
 	PowerSwitch = 0;
 
 	DoZeroIMUGimbals();


### PR DESCRIPTION
Since I was building in debug mode variables get initialized to a non-null value by the memory allocator. This uncovered an uninitialized variable in the IMU causing a CTD. I've added it to the constructor to explicitly null it,

I recommend everyone that works on the code to build their modules in debug mode to find issues like these.

@indy91 