### PR TITLE
Ignore XRSound Addon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ core
 /readme.txt
 *.log
 *.launchpad.cfg
+XRSound/
+/ikpFlac.dll
+/ikpMP3.dll


### PR DESCRIPTION
I use the XRSound addon with Orbiter2016. When I created a Project Apollo git repo in my Orbiter folder, I noticed that it doesn't ignore the XRSound files, so I added them to the .gitignore file.

I'm new to git/github, so if I've done anything wrong please let me know.