### PR TITLE
Retarget to Win10 SDK

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/ASTP.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/ASTP.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BAE34D87-5EAE-491C-AE6D-73B6B1E487D2}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/ApolloRTCCMFD.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/ApolloRTCCMFD.vcxproj
@@ -34,7 +34,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3F97A697-44DB-4A22-A5F3-7168A990B3C0}</ProjectGuid>
     <RootNamespace>ApolloRTCCMFD</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/CMChute.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/CMChute.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{68F2AA4E-3774-4A03-947D-9890DF0E73C5}</ProjectGuid>
     <RootNamespace>CMChute</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Crawler.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Crawler.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BAAA2ADB-0507-4E33-9E80-23CEE3B74E37}</ProjectGuid>
     <RootNamespace>Crawler</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/EVA.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/EVA.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4427BC2F-CA34-48A6-8EC3-DF7CAC42F11E}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/FloatBag.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/FloatBag.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{FE06FF4C-6772-48C7-9FFB-BCA00CBA8DA1}</ProjectGuid>
     <RootNamespace>FloatBag</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Floodlight.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Floodlight.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectGuid>
     <RootNamespace>Floodlight</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/LC34.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/LC34.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7347CF0C-0A9B-4987-A811-98E7B8008B0D}</ProjectGuid>
     <RootNamespace>LC34</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/LC37.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/LC37.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1DE45393-14EC-4D29-A2F8-61FC60C2C286}</ProjectGuid>
     <RootNamespace>LC34</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/LEM.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/LEM.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1E53A199-CCDF-4FCF-B2E8-5F8FF80AFEC8}</ProjectGuid>
     <RootNamespace>LEM</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/LES.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/LES.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0046609E-6A36-4A27-B328-D2291BF4A163}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/LEVA.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/LEVA.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{433314D0-A173-4041-8DB8-7641B7ED4D08}</ProjectGuid>
     <RootNamespace>LEVA</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/LRV.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/LRV.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C0954BF4-D9FE-40D3-971A-CC70D7E65434}</ProjectGuid>
     <RootNamespace>LRV</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/MCC.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/MCC.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E38D5A31-C96D-437E-A495-4314EF198CEB}</ProjectGuid>
     <RootNamespace>Saturn5NASP</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/ML.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/ML.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D6FBF84B-F71B-4E9E-ABBF-366CA5E1D3B1}</ProjectGuid>
     <RootNamespace>ML</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/MSS.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/MSS.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{365AC3FB-ADDB-4176-94B5-C8118A39C37D}</ProjectGuid>
     <RootNamespace>MSS</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/PanelSDK.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/PanelSDK.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{98EC3BF0-C9FF-4C38-91E1-159D8F3700C1}</ProjectGuid>
     <RootNamespace>PanelSDK</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/ProjectApolloConfigurator.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/ProjectApolloConfigurator.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{73EF2265-3791-4C67-89A0-9DA47D663144}</ProjectGuid>
     <RootNamespace>ProjectApolloConfigurator</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/ProjectApolloMFD.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/ProjectApolloMFD.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{91D2B2E0-D1EC-45B5-AEF4-52D1273652FD}</ProjectGuid>
     <RootNamespace>ProjectApolloMFD</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/SIVb.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/SIVb.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1FD6B39B-FC9F-4219-AB56-4F7D698EEEC4}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat1Abort1.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat1Abort1.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1C98109C-791B-4563-AA9C-D02963D2AEC1}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat1Abort2.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat1Abort2.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D62F2884-7E90-4A13-B41D-1BCFFCB6F6C6}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat5Abort1.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat5Abort1.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BD695BAF-A2E9-4E65-804A-CEBB4A45DF78}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat5Abort2.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat5Abort2.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CCCE5F37-9749-4E83-A9F5-893855CD1850}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat5Abort3.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat5Abort3.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{16DA84DA-79DC-4631-B5A6-4D31433433AD}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat5LMDSC.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Sat5LMDSC.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A3B0AACD-C28C-4E02-9385-901383E91AF5}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn1b.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn1b.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1151EE87-AB2E-4ABD-B0EB-EC5974A0BC9A}</ProjectGuid>
     <RootNamespace>Saturn1b</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5AE2D199-E94E-4E65-A0F5-7242EE0227E9}</ProjectGuid>
     <RootNamespace>Saturn5NASP</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/VAB.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/VAB.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9A4119F5-6936-4C1A-8A40-EBDA0808348A}</ProjectGuid>
     <RootNamespace>VAB</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/s1b.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/s1b.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0A2BCE86-18E7-43DF-9BBF-F11EA7EB3469}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/s1c.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/s1c.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6CD92808-91D8-4A49-BCF9-6FADD43FBC83}</ProjectGuid>
     <RootNamespace>s1c</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/sii.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/sii.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D09FA383-CE66-4640-B8A8-0EA789A8D34A}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/sm.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/sm.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D1B7F820-4A7A-47CB-BDB2-62E8B8C29F61}</ProjectGuid>
     <RootNamespace>sm</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
We're still using the Win 8.1 SDK. This PR changes the targeted SDK to the latest Win 10 SDK,

If anything this removes a build dependency.