### PR TITLE
Add TrackIR config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ core
 XRSound/
 /ikpFlac.dll
 /ikpMP3.dll
+/TrackIR.cfg


### PR DESCRIPTION
I was playing around with TrackIR the other day and noticed git wanted to add my config.
This ignores it.