### PR TITLE
#236 issue fix

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -2184,7 +2184,7 @@ void Saturn::CabinFansSystemTimestep()
 	if (SuitCompressor2->IsOn()) vol += 32;
 
 	if (vol > 0)
-		SuitCompressorSound.play(LOOP, vol + 191);
+		SuitCompressorSound.play(vol + 191);
 	else
 		SuitCompressorSound.stop();
 }

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -4122,8 +4122,8 @@ protected:
 	Sound SepS;
 	Sound CrashBumpS;
 	Sound Psound;
-	Sound CabinFans;
-	Sound SuitCompressorSound;
+	FadeInOutSound CabinFans;
+	FadeInOutSound SuitCompressorSound;
 	Sound SwindowS;
 	Sound SKranz;
 	Sound SExploded;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
@@ -4144,7 +4144,7 @@ void Saturn::CabinFanSound()
 	// Scale volume appropriately based on the expected max voltage (115V per phase)
 	//
 
-	CabinFans.play(LOOP, (int) ((64.0 * volume / 400.0) + 127.0));
+	CabinFans.play((int) ((64.0 * volume / 400.0) + 127.0));
 }
 
 void Saturn::StopCabinFanSound()

--- a/Orbitersdk/samples/ProjectApollo/src_sys/soundlib.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/soundlib.cpp
@@ -661,6 +661,10 @@ bool FadeInOutSound::play(int volume /*= 255*/)
 	double dt; // [s]
 	int freq;  // [Hz] placed here for debug sprintf() to work
 
+	if (currentVolume == -1) { // initial call (first after scenario load) ?
+		currentVolume = volume;
+	}
+
 	if (currentVolume < volume)
 	{
 		dt = oapiGetSimStep();
@@ -676,7 +680,9 @@ bool FadeInOutSound::play(int volume /*= 255*/)
 
 	if (currentVolume)
 	{
-		freq = fMin + (currentVolume * (fMax - fMin) / 255);
+		freq = hasFrequencyShift()
+			? fMin + (currentVolume * (fMax - fMin) / 255)
+			: NULL;
 		Sound::play(LOOP, currentVolume, freq);
 	}
 	else

--- a/Orbitersdk/samples/ProjectApollo/src_sys/soundlib.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/soundlib.cpp
@@ -73,11 +73,11 @@ bool SoundData::isValid()
 	return valid;
 }
 
-bool SoundData::play(int flags, int libflags, int volume, int playvolume)
+bool SoundData::play(int flags, int libflags, int volume, int playvolume, int frequency /*= NULL*/)
 
 {
 	if (valid) {
-		if (!PlayVesselWave(SoundlibId, id, flags, playvolume))
+		if (!PlayVesselWave(SoundlibId, id, flags, playvolume, frequency))
 		{
 			return false;
 		}
@@ -597,7 +597,7 @@ bool Sound::isPlaying()
 	return sd->isPlaying();
 }
 
-bool Sound::play(int flags, int volume)
+bool Sound::play(int flags, int volume, int frequency /*= NULL*/)
 
 {
 	if (valid && sd && sd->isValid()) {
@@ -617,7 +617,7 @@ bool Sound::play(int flags, int volume)
 			vol = sl->GetSoundVolume(soundflags, volume);
 		}
 
-		return sd->play(flags, soundflags, volume, vol);
+		return sd->play(flags, soundflags, volume, vol, frequency);
 	}
 
 	return false;
@@ -653,6 +653,46 @@ void Sound::SetSoundData(SoundData *s)
 	}
 	else {
 		valid = false;
+	}
+}
+
+bool FadeInOutSound::play(int volume /*= 255*/)
+{
+	double dt; // [s]
+	int freq;  // [Hz] placed here for debug sprintf() to work
+
+	if (currentVolume < volume)
+	{
+		dt = oapiGetSimStep();
+		currentVolume += int(round(double(riseSlope) * dt));
+		if (currentVolume > volume) { currentVolume = volume; } // limit (upper)
+	}
+	else if (currentVolume > volume)
+	{
+		dt = oapiGetSimStep();
+		currentVolume -= int(round(double(fadeSlope) * dt));
+		if (currentVolume < 0) { currentVolume = 0; } // limit (lower)
+	}
+
+	if (currentVolume)
+	{
+		freq = fMin + (currentVolume * (fMax - fMin) / 255);
+		Sound::play(LOOP, currentVolume, freq);
+	}
+	else
+	{
+		Sound::stop();
+	}
+
+	// sprintf(oapiDebugString(), "vol: %d/%d [%d Hz]", currentVolume, volume, freq);
+	return currentVolume == volume;
+}
+
+void FadeInOutSound::stop()
+{
+	// We stop the sound only once (will do no harm and it will save a bit of processor time)
+	if (currentVolume) {
+		play(0);
 	}
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/soundlib.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/soundlib.h
@@ -37,7 +37,7 @@ public:
 	virtual ~SoundData();
 	bool isValid();
 	bool isPlaying();
-	bool play(int flags, int libflags, int volume, int playvolume);
+	bool play(int flags, int libflags, int volume, int playvolume, int frequency = NULL);
 	void stop();
 	void done();
 	void setID(int num) { id = num; };
@@ -81,7 +81,7 @@ public:
 	bool isPlaying();
 	void setFlags(int fl);
 	void clearFlags(int fl);
-	bool play(int flags = NOLOOP, int volume = 255);
+	bool play(int flags = NOLOOP, int volume = 255, int frequency = NULL);
 	void stop();
 	void done();
 	void SetSoundData(SoundData *s);
@@ -95,6 +95,22 @@ protected:
 	SoundData *sd;
 	SoundLib *sl;
 };
+
+class FadeInOutSound : public Sound {
+public:
+	bool play(int volume = 255);
+	void stop();
+
+	void setRiseTime(int seconds) { riseSlope = 255 / seconds; }
+	void setFadeTime(int seconds) { fadeSlope = 255 / seconds; }
+private:
+	int riseSlope     = 255 / 4; // [vol/sec]
+	int fadeSlope     = 255 / 6; // [vol/sec]
+	int fMin          =  3000;   // [Hz]
+	int fMax          = 22050;   // [Hz]
+	int currentVolume = 0;       // "lagging" volume level
+};
+
 
 #define SOUNDFLAG_1XORLESS		0x0001
 #define SOUNDFLAG_1XONLY		0x0002

--- a/Orbitersdk/samples/ProjectApollo/src_sys/soundlib.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/soundlib.h
@@ -103,12 +103,17 @@ public:
 
 	void setRiseTime(int seconds) { riseSlope = 255 / seconds; }
 	void setFadeTime(int seconds) { fadeSlope = 255 / seconds; }
+
+	void setFrequencyShift(int minFreq, int maxFreq) { fMin = minFreq; fMax = maxFreq; }
+	void clearFrequencyShift() { fMin = fMax = NULL; }
+	bool hasFrequencyShift() const { return fMin != NULL && fMax != NULL; }
+
 private:
 	int riseSlope     = 255 / 4; // [vol/sec]
 	int fadeSlope     = 255 / 6; // [vol/sec]
 	int fMin          =  3000;   // [Hz]
 	int fMax          = 22050;   // [Hz]
-	int currentVolume = 0;       // "lagging" volume level
+	int currentVolume = -1;      // "lagging" volume level
 };
 
 


### PR DESCRIPTION
Hi,

here's my proposal for the cabin fan sound (issue #236).

It's a small extension to the SoundLib that implements a kind of "inert volume follower".
Each time the volume is changed (via `play(...)` ) the current playing volume is getting there in a ramp-up rsp. -down manner.

Additionally to the volume ramp-up & -down I have added a frequency ramping.
This might be overkill for some sounds, but feel free to refactor this into a different class.

The impact on code using the sound is minimal:
- Change type from Sound to FadeInOutSound
- calls to play don't need the first (LOOP) parameter.

The current implementation is currently using the standard rise- and fall-times (4 seconds and 6 seconds). These values are of course arbitrary but they sound good ;)

The implementation is not using the three individual sounds from [here](http://www.ibiblio.org/mscorbit/mscforum/index.php?topic=2686).
Although the samples Dan proposed are very nice, I could not get a satisfactory result using them as there was almost always a "gap" in the transition between startup- and sustain-sound.

Therefore I chose this different approach.
