### PR TITLE
Various Fixes:

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3716,6 +3716,9 @@ void Saturn::GenericLoadStateSetup()
 
 	soundlib.SoundOptionOnOff(PLAYCABINAIRCONDITIONING, FALSE);
 
+	// Disable Rolling, landing, speedbrake, crash sound. This causes issues in Orbiter 2016.
+	soundlib.SoundOptionOnOff(PLAYLANDINGANDGROUNDSOUND, FALSE);
+
 	//
 	// We do our own countdown, so ignore the standard one.
 	//

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -381,6 +381,9 @@ void LEM::Init()
 	///		  Enable before CSM docking
 	soundlib.SoundOptionOnOff(PLAYRADARBIP, FALSE);
 
+	// Disable Rolling, landing, speedbrake, crash sound. This causes issues in Orbiter 2016.
+	soundlib.SoundOptionOnOff(PLAYLANDINGANDGROUNDSOUND, FALSE);
+
 	strncpy(AudioLanguage, "English", 64);
 	soundlib.SetLanguage(AudioLanguage);
 	SoundsLoaded = false;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lempanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lempanel.cpp
@@ -1956,8 +1956,8 @@ bool LEM::clbkLoadPanel (int id) {
 
 		oapiRegisterPanelArea(AID_LEM_UTILITY_LT, _R(151, 112, 335, 141), PANEL_REDRAW_ALWAYS, PANEL_MOUSE_DOWN, PANEL_MAP_BACKGROUND);
 
-		SetCameraDefaultDirection(_V(0.0, 1.0, 0.0));
-		oapiCameraSetCockpitDir(0, 0);
+		SetCameraDefaultDirection(_V(0.0, -1.0, 0.0));
+		oapiCameraSetCockpitDir(180 * RAD, 0);
 		break;
 
 	case LMPANEL_FWDHATCH: // LEM Forward Hatch

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -174,10 +174,10 @@ void LEM::SystemsInit()
 
 	// ECA #1 (DESCENT stage, LMP 28V DC bus)
 	ECA_1a.Init(this, Battery1, 2); // Battery 1 starts on LV
-	ECA_1b.Init(this, Battery2, 0);
+	ECA_1b.Init(this, Battery2, 2);
 
 	// ECA #2 (DESCENT stage, CDR 28V DC bus)
-	ECA_2a.Init(this, Battery3, 0);
+	ECA_2a.Init(this, Battery3, 2);
 	ECA_2b.Init(this, Battery4, 2); 
 
 	// ECA #1 and #2 are JETTISONED with the descent stage.

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
@@ -149,10 +149,10 @@ void LEM::SetView() {
 					break;
 				case LMPANEL_RNDZWINDOW:
 					if (stage == 2) {
-						SetCameraOffset(_V(-0.598, 0.65, 1.106));
+						SetCameraOffset(_V(-0.598, 0.15, 1.106));
 					}
 					else {
-						SetCameraOffset(_V(-0.598, 2.40, 1.106));
+						SetCameraOffset(_V(-0.598, 1.90, 1.106));
 					}
 					break;
 				case LMPANEL_LEFTPANEL:
@@ -181,10 +181,10 @@ void LEM::SetView() {
 					break;
 				case LMPANEL_DOCKVIEW:
 					if (stage == 2) {
-						SetCameraOffset(_V(-0.598, 0.65, 1.106));
+						SetCameraOffset(_V(-0.598, 0.15, 1.106));
 					}
 					else {
-						SetCameraOffset(_V(-0.598, 2.40, 1.106));
+						SetCameraOffset(_V(-0.598, 1.90, 1.106));
 					}
 					break;
 				
@@ -198,10 +198,10 @@ void LEM::SetView() {
 					break;
 				case LMPANEL_UPPERHATCH:
 					if (stage == 2) {
-						SetCameraOffset(_V(0, -0.35, 0));
+						SetCameraOffset(_V(0, -0.55, 0));
 					}
 					else {
-						SetCameraOffset(_V(0, 1.40, 0));
+						SetCameraOffset(_V(0, 1.20, 0));
 					}
 					break;
 				case LMPANEL_FWDHATCH:
@@ -219,7 +219,7 @@ void LEM::SetView() {
 	}
 
 	//
-	// Change FOV for the LPD window, AOT zoom and docking view
+	// Change FOV for the LPD window and AOT zoom
 	//
 	if (InPanel && PanelId == LMPANEL_LPDWINDOW) {
 	   // if this is the first time we've been here, save the current FOV
@@ -227,8 +227,10 @@ void LEM::SetView() {
 			SaveFOV = oapiCameraAperture();
 			InFOV = false;
 		}
-		//set FOV to 60 degrees
-		oapiCameraSetAperture(RAD * 30.0);
+		//set FOV to 60 degrees (except for lower resolutions)
+		DWORD w, h;
+		oapiGetViewportSize(&w, &h);
+		oapiCameraSetAperture(atan(tan(RAD*30.0)*min(h / 1080.0, 1.0)));
 	}
 	else if (PanelId == LMPANEL_AOTZOOM) {
 		// if this is the first time we've been here, save the current FOV
@@ -240,15 +242,6 @@ void LEM::SetView() {
 		DWORD w, h;
 		oapiGetViewportSize(&w, &h);
 		oapiCameraSetAperture(atan(tan(RAD*30.0)*min(h / 1050.0, 1.0)));
-	}
-	else if (PanelId == LMPANEL_DOCKVIEW) {
-		// if this is the first time we've been here, save the current FOV
-		if (InFOV) {
-			SaveFOV = oapiCameraAperture();
-			InFOV = false;
-		}
-		//set FOV to 40 degrees
-		oapiCameraSetAperture(RAD * 20.0);
 	}
     else {
 		if(InFOV == false) {

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_eps.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_eps.cpp
@@ -269,8 +269,8 @@ void LEM_XLBControl::UpdateFlow(double dt) {
 	case -1:
 		// If the CSM latch is reset, turn on the LV taps on batteries 1 and 4.
 		// And reset the latch to zero
-		lem->ECA_1a.input = 2; lem->ECA_1b.input = 0;
-		lem->ECA_2a.input = 0; lem->ECA_2b.input = 2;
+		lem->ECA_1a.input = 2; lem->ECA_1b.input = 2;
+		lem->ECA_2a.input = 2; lem->ECA_2b.input = 2;
 		lem->CSMToLEMPowerConnector.csm_power_latch = 0;
 		break;
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/sat5mesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/sat5mesh.cpp
@@ -1243,7 +1243,7 @@ void SaturnV::SeparateStage (int new_stage)
 		vs2.vrot.y = 0.0;
 		vs2.vrot.z = 0.0;
 
-		CrashBumpS.play(NOLOOP, 150);
+		//CrashBumpS.play(NOLOOP, 150);
 
 		char VName[256], *CName;
 


### PR DESCRIPTION
- Disable Rolling, landing, speedbrake, crash sound which causes issues in Orbiter 2016.
- Removed crash sound that is played at interstage separation from SII flight
- FOV is set according to users resolution in the LM LPD view, up to a max FOV of 60
- Removed FOV 40 being set in LM dock view (fwd COAS) Like the CSM forward COAS, the user can adjust FOV at their discretion
- Rotated the LM upper hatch view 180 degrees so to correspond with reality
- Adjusted various camera offset positions in the LM
- Initialize LM batteries 2 & 3 to low voltage as per documenation (LM-8 and prior)
- Resetting CSM power to LM will now set LM batteries 1 to 4 to low voltage (LM-8 and prior)