### PR TITLE
A few updates/fixes to the LM:

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -290,6 +290,7 @@ void LEM::Init()
 
 	InVC = false;
 	InPanel = false;
+	ExtView = false;
 	CheckPanelIdInTimestep = false;
 	RefreshPanelIdInTimestep = false;
 	InFOV = true;
@@ -881,6 +882,18 @@ void LEM::clbkPreStep (double simt, double simdt, double mjd) {
 		return;
 	}
 
+	if (!ExtView && !oapiCameraInternal()) {
+		ExtView = true;
+		SetLMMeshVis();
+		if (!InFOV) oapiCameraSetAperture(SaveFOV);
+	}
+
+	if (ExtView && oapiCameraInternal()) {
+		ExtView = false;
+		SetLMMeshVis();
+		SetView();
+	}
+
 	//
 	// Update mission time.
 	//
@@ -946,7 +959,7 @@ void LEM::clbkPostStep(double simt, double simdt, double mjd)
 	ViewOffsety *= 0.95;
 	ViewOffsetz *= 0.95;
 
-	if (th_hover[0])
+	if (th_hover[0] && !ExtView)
 	{
 		if ((GetThrusterLevel(th_hover[0]) > 0) && (InVC || (InPanel && PanelId == LMPANEL_LPDWINDOW)))
 		{
@@ -1479,6 +1492,9 @@ void LEM::clbkSetClassCaps (FILEHANDLE cfg) {
 		ProcessConfigFileLine(hFile, line);
 	}
 	oapiCloseFile(hFile, FILE_IN);
+
+	// Load LM meshes here
+	SetMeshes();
 }
 
 void LEM::clbkPostCreation()

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -427,6 +427,7 @@ public:
 	void SetGenericStageState(int stat);
 	void PostLoadSetup(bool define_anims = true);
 	void DefineAnimations();
+	void SetMeshes();
 
 	void RCSHeaterSwitchToggled(ToggleSwitch *s, int *pump);
 	void PanelSwitchToggled(ToggleSwitch *s);
@@ -1551,6 +1552,7 @@ protected:
 
 	bool InVC;
 	bool InPanel;
+	bool ExtView;
 	bool InFOV;  
 	int  PanelId; 
 	double SaveFOV;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
@@ -64,6 +64,9 @@ static PARTICLESTREAMSPEC lunar_dust = {
 	PARTICLESTREAMSPEC::ATM_PLOG, -0.1, 0.1
 };
 
+VECTOR3 mesh_asc = _V(0.00, 0.99, 0.00);
+VECTOR3 mesh_dsc = _V(0.00, -1.25, 0.00);
+
 void LEM::ToggleEVA()
 
 {
@@ -138,7 +141,6 @@ void LEM::SetLmVesselDockStage()
 	SetPitchMomentScale (0);
 	SetYawMomentScale (0);
 	SetLiftCoeffFunc (0); 
-	ClearMeshes(true);
 	ClearBeacons();
 	ClearExhaustRefs();
 	ClearAttExhaustRefs();
@@ -181,25 +183,8 @@ void LEM::SetLmVesselDockStage()
 
 	SetTouchdownPoints(td, 7);
 
-	VECTOR3 mesh_asc = _V(0.00, 0.99, 0.00);
-	VECTOR3 mesh_dsc = _V(0.00, -1.25, 0.00);
-
-	// Ascent Stage Mesh
-	ascidx = AddMesh(hLMAscent, &mesh_asc);
-
-	// VC Mesh
-	vcidx = AddMesh(hLMVC, &mesh_asc);
-
-	// Descent Stage Mesh
-	if (NoLegs)
-	{
-		dscidx = AddMesh(hLMDescentNoLeg, &mesh_dsc);
-	}
-	else
-	{
-		dscidx = AddMesh(hLMDescent, &mesh_dsc);
-	}
-
+	// Configure meshes if needed
+	if (NoLegs) InsertMesh(hLMDescentNoLeg, dscidx, &mesh_dsc);
 	SetLMMeshVis();
 
 	if (!ph_Dsc)
@@ -382,12 +367,11 @@ void LEM::SetLmAscentHoverStage()
 
 	SetTouchdownPoints(td, 4);
 
-	VECTOR3 mesh_asc=_V(0.00, -1.75, 0.00);
-
-	// Vessel Meshes
+	// Configure meshes if needed
+	VECTOR3 mesh_shift = _V(0.00, -1.75, 0.00);
 	DelMesh(dscidx);
 	dscidx = -1;
-	ShiftMeshes(mesh_asc);
+	ShiftMeshes(mesh_shift);
 
 	if (!ph_Asc)
 	{
@@ -555,7 +539,7 @@ void LEM::SetLMMeshVisAsc() {
 	if (ascidx == -1)
 		return;
 
-	if (InPanel && (PanelId == LMPANEL_AOTZOOM || PanelId == LMPANEL_UPPERHATCH)) {
+	if (!ExtView && InPanel && (PanelId == LMPANEL_AOTZOOM || PanelId == LMPANEL_UPPERHATCH)) {
 		SetMeshVisibilityMode(ascidx, MESHVIS_ALWAYS);
 	}
 	else
@@ -569,7 +553,7 @@ void LEM::SetLMMeshVisVC() {
 	if (vcidx == -1)
 		return;
 
-	if (InPanel && PanelId == LMPANEL_LPDWINDOW) {
+	if (!ExtView && InPanel && PanelId == LMPANEL_LPDWINDOW) {
 		SetMeshVisibilityMode(vcidx, MESHVIS_ALWAYS);
 	}
 	else
@@ -583,7 +567,7 @@ void LEM::SetLMMeshVisDsc() {
 	if (dscidx == -1)
 		return;
 
-	if (InPanel && PanelId == LMPANEL_LPDWINDOW) {
+	if (!ExtView && InPanel && PanelId == LMPANEL_LPDWINDOW) {
 		SetMeshVisibilityMode(dscidx, MESHVIS_ALWAYS);
 	}
 	else
@@ -781,6 +765,18 @@ void LEM::AddDust() {
 		AddExhaustStream(th_dust[i], &lunar_dust);
 	}
 	thg_dust = CreateThrusterGroup(th_dust, 4, THGROUP_USER);
+}
+
+void LEM::SetMeshes() {
+
+	// Ascent Stage Mesh
+	ascidx = AddMesh(hLMAscent, &mesh_asc);
+
+	// VC Mesh
+	vcidx = AddMesh(hLMVC, &mesh_asc);
+
+	// Descent Stage Mesh
+	dscidx = AddMesh(hLMDescent, &mesh_dsc);
 }
 
 void LEMLoadMeshes()

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -1562,7 +1562,9 @@ void LEM::SystemsTimestep(double simt, double simdt)
 	// Debug tests //
 
 	// Mesh Index Order
-	//sprintf(oapiDebugString(), "ascidx %i dscidx %i fwdhatch %i ovhdhatch %i lmdrogue %i lpdasc %i lpddscret %i lpddscext %i probeidx %i", ascidx, dscidx, fwdhatch, ovhdhatch, lmdrogue, lpdasc, lpddscret, lpddscext, probeidx);
+	//sprintf(oapiDebugString(), "ascidx %i vcidx %i dscidx %i", ascidx, vcidx, dscidx);
+
+	//sprintf(oapiDebugString(), "InPanel %d InVC %d ExtView %d InFOV %d", InPanel, InVC, ExtView, InFOV);
 
 	//ECS Debug Lines//
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
@@ -203,6 +203,8 @@ void LEM::SetView() {
 					else {
 						SetCameraOffset(_V(0, 1.20, 0));
 					}
+					SetCameraDefaultDirection(_V(0.0, -1.0, 0.0));
+					oapiCameraSetCockpitDir(180 * RAD, 0);
 					break;
 				case LMPANEL_FWDHATCH:
 					if (stage == 2) {
@@ -232,7 +234,7 @@ void LEM::SetView() {
 		oapiGetViewportSize(&w, &h);
 		oapiCameraSetAperture(atan(tan(RAD*30.0)*min(h / 1080.0, 1.0)));
 	}
-	else if (PanelId == LMPANEL_AOTZOOM) {
+	else if (InPanel && PanelId == LMPANEL_AOTZOOM) {
 		// if this is the first time we've been here, save the current FOV
 		if (InFOV) {
 			SaveFOV = oapiCameraAperture();


### PR DESCRIPTION
- Add flag to indicate when camera is internal/external to update meshes/views accordingly (fixes wrong view when in upper hatch view and going to external and back to internal view)
- FOV handling now reads the new flag for proper restoration of previous FOV when going to external view from LPD or AOT windows.
- LM mesh loading has been moved to clbkSetClassCaps. This fixes an issue where when the LM is initially created (SIVB separation), the DEVMESHHANDLE's (crew, drogue, probes) are not properly initialized.