### PR TITLE
No longer update touchdown points with current mass at lunar contact …

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -1104,9 +1104,6 @@ void LEM::SetGenericStageState(int stat)
 		SetLmVesselDockStage();
 		SetLmVesselHoverStage();
 
-		// Update touchdown points with current mass
-		if (Landed) HoverStageTouchdownPoints(GetMass());
-
 		if (CDREVA_IP) {
 			SetupEVA();
 		}

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
@@ -255,9 +255,9 @@ void LEM::SetLmVesselHoverStage()
 	ClearExhaustRefs();
 	ClearAttExhaustRefs();
 
-	double Mass = 7137.75;
+	double td_mass = 7137.75;
 
-	if (!NoLegs) HoverStageTouchdownPoints(Mass);
+	if (!NoLegs) HoverStageTouchdownPoints(td_mass);
 
 	if (!ph_Dsc){  
 		ph_Dsc  = CreatePropellantResource(DescentFuelMassKg); //2nd stage Propellant
@@ -521,9 +521,6 @@ void LEM::SeparateStage (UINT stage)
 void LEM::SetLmLandedMesh() {
 
 	Landed = true;
-
-	// Update touchdown points with current mass
-	HoverStageTouchdownPoints(GetMass());
 
 	HideProbes();
 }


### PR DESCRIPTION
…& scenario loading on the lunar surface and instead just use an average mass like previously. Fixes issue where LM sometimes slides around on the lunar surface.