### PR TITLE
CSM Optics improvement

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -653,30 +653,43 @@ bool CMOptics::PaintShaftDisplay(SURFHANDLE surf, SURFHANDLE digits){
 }
 
 bool CMOptics::PaintTrunnionDisplay(SURFHANDLE surf, SURFHANDLE digits){
-	int value = (int)(TeleTrunion*1000.0*DEG);
+	int value = (int)(TeleTrunion*100.0*DEG);
 	if (value < 0) { value += 36000; }
 	return PaintDisplay(surf, digits, value);
 }
 
 bool CMOptics::PaintDisplay(SURFHANDLE surf, SURFHANDLE digits, int value){
 	int srx, sry, digit[5];
-	int x=value;	
+	int x=value;
 	digit[0] = (x%10);
 	digit[1] = (x%100)/10;
 	digit[2] = (x%1000)/100;
 	digit[3] = (x%10000)/1000;
 	digit[4] = x/10000;
-	sry = (int)(digit[0] * 1.2);
+
 	srx = 8 + (digit[4] * 25);
-	oapiBlt(surf, digits, 0, 0, srx, 33, 9, 12, SURF_PREDEF_CK);
+	if (digit[4])
+		sry = 33;
+	else
+		sry = 22;
+	oapiBlt(surf, digits, 0, 0, srx, sry, 9, 12, SURF_PREDEF_CK);
+
 	srx = 8 + (digit[3] * 25);
-	oapiBlt(surf, digits, 10, 0, srx, 33, 9, 12, SURF_PREDEF_CK);
+	if (digit[4] || digit[3])
+		sry = 33;
+	else
+		sry = 22;
+	oapiBlt(surf, digits, 10, 0, srx, sry, 9, 12, SURF_PREDEF_CK);
+
 	srx = 8 + (digit[2] * 25);
 	oapiBlt(surf, digits, 20, 0, srx, 33, 9, 12, SURF_PREDEF_CK);
 	srx = 8 + (digit[1] * 25);
 	oapiBlt(surf, digits, 30, 0, srx, 33, 9, 12, SURF_PREDEF_CK);
 	srx = 8 + (digit[0] * 25);
+	sry = (int)(digit[0] * 1.2);
 	oapiBlt(surf, digits, 40, 0, srx, 33, 9, 12, SURF_PREDEF_CK);
+
+	oapiColourFill(surf, oapiGetColour(255, 255, 255), 29, 5, 1, 2);
 	return true;
 }
 
@@ -830,9 +843,9 @@ void CMOptics::TimeStep(double simdt) {
 	{
 		SextShaft = -270.0*RAD;
 	}
-	if (SextTrunion < 0.0)
+	if (SextTrunion < -59.0*RAD)
 	{
-		SextTrunion = 0.0;
+		SextTrunion = -59.0*RAD;
 	}
 	if (SextTrunion > 59.0*RAD)
 	{
@@ -877,9 +890,9 @@ void CMOptics::TimeStep(double simdt) {
 		TeleShaft = -270.0*RAD;
 		TeleShaftRate = 0.0;
 	}
-	if (TeleTrunion < 0.0)
+	if (TeleTrunion < -59.0*RAD)
 	{
-		TeleTrunion = 0.0;
+		TeleTrunion = -59.0*RAD;
 		TeleTrunionRate = 0.0;
 	}
 	if (TeleTrunion > 59.0*RAD)

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -3956,6 +3956,8 @@ protected:
 	double *ReticleLine[2][2]; //[SCT=0 | SXT=1][X=0 | Y=1]
 	POINT *ReticlePoint;
 
+	double PanelPixelHeight;
+
 	//
 	// Virtual cockpit
 	//

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -2049,9 +2049,7 @@ void Saturn::SetView(double offset, bool update_direction)
 				FovSave = oapiCameraAperture();
 				FovFixed = true;
 			}
-			DWORD w, h;
-			oapiGetViewportSize(&w, &h);
-			oapiCameraSetAperture(atan(0.000029418*((double)h))); //1.8deg FOV for 534px; tan(0.9*PI/180)/534 = 2.9418e-5
+			oapiCameraSetAperture(atan(0.000029418*PanelPixelHeight)); //1.8deg FOV for 534px; tan(0.9*PI/180)/534 = 2.9418e-5
 
 		}
 		else if (InPanel && PanelId == SATPANEL_TELESCOPE) { // Telescope
@@ -2059,9 +2057,7 @@ void Saturn::SetView(double offset, bool update_direction)
 				FovSave = oapiCameraAperture();
 				FovFixed = true;
 			}
-			DWORD w, h;
-			oapiGetViewportSize(&w, &h);
-			oapiCameraSetAperture(atan(0.0010811*((double)h))); //60deg FOV for 534px; tan(30*PI/180)/534 = 1.0811e-3
+			oapiCameraSetAperture(atan(0.0010811*PanelPixelHeight)); //60deg FOV for 534px; tan(30*PI/180)/534 = 1.0811e-3
 
 		}
 		else {


### PR DESCRIPTION
- corrected the bad scaling of the reticles
- trunnion angle range is extended to (-59°,59°)
- Telescope angle counter displays are changed to be similar to the real one. The real counter is the same for both shaft and trunnion, and has the display range of 0.00° to 359.98°. The two most significant digits are blanked, when the 0°<=angle<10°, I guess due to avoid mechanical issues when the counter wraps and these digits should "jump" to zero from 3 and 5, respectively.