### PR TITLE
Fix a locking bug in the AGC code that caused EMEM corruption

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj
@@ -124,6 +124,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp14</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
@@ -29,6 +29,8 @@
 #include "inttypes.h"
 #include <stdio.h>
 #include <math.h>
+#include <thread>
+#include <mutex>
 #include "soundlib.h"
 
 #include "yaAGC/agc_engine.h"
@@ -44,7 +46,7 @@
 
 #include "tracer.h"
 
-ApolloGuidance::ApolloGuidance(SoundLib &s, DSKY &display, IMU &im, CDU &sc, CDU &tc, PanelSDK &p) : soundlib(s), dsky(display), imu(im), DCPower(0, p), scdu(sc), tcdu(tc)
+ApolloGuidance::ApolloGuidance(SoundLib &s, DSKY &display, IMU &im, CDU &sc, CDU &tc, PanelSDK &p) : soundlib(s), dsky(display), imu(im), DCPower(0, p), scdu(sc), tcdu(tc), agcCycleMutex()
 
 {
 	Reset = false;
@@ -288,7 +290,7 @@ void ApolloGuidance::PulsePIPA(int RegPIPA, int pulses)
 	if (pulses == 0 ) 
 		return;
 
-	Lock lock(agcCycleMutex);
+	std::lock_guard<std::mutex> guard(agcCycleMutex);
 
 
 	if (pulses >= 0) {

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
@@ -40,6 +40,8 @@ class PanelSDK;
 #include "control.h"
 #include "yaAGC/agc_engine.h"
 #include "thread.h"
+#include <thread>
+#include <mutex>
 
 
 typedef std::bitset<16> ChannelValue;
@@ -442,7 +444,7 @@ protected:
 	/// \brief Virtual AGC state.
 	///
 	agc_t vagc;
-	Mutex agcCycleMutex;
+	std::mutex agcCycleMutex;
 	Event timeStepEvent;
 	double thread_simt;
 	double thread_simdt;


### PR DESCRIPTION
When using time acceleration with multi-threading turned on the AGC timesteps are run from a separate thread and guarded by a mutex. When quickly switching between a high time acceleration factor and no time acceleration the thread sometimes hasn't finished before a new timestep is run. Because the no acceleration timesteps run from the main thread and do not check the mutex, undefined behavior occurs eventually causing the computer to trigger a restart from various conditions.

This commit always locks the mutex so that timesteps never execute at the same time. The language level is also set to C++14 so feel encouraged to use anything from that from now on.