### PR TITLE
Change previous main and hover thruster groups to THGROUP_USER

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnmesh.cpp
@@ -642,9 +642,7 @@ void Saturn::SetCSMStage ()
 	// *********************** thruster definitions ********************************
 
 	th_sps[0] = CreateThruster(_V(0.0, 0.0, -3.37472), _V(0, 0, 1), SPS_THRUST, ph_sps, SPS_ISP);
-
-	DelThrusterGroup(THGROUP_MAIN, true);
-	thg_sps = CreateThrusterGroup(th_sps, 1, THGROUP_MAIN);
+	thg_sps = CreateThrusterGroup(th_sps, 1, THGROUP_USER);
 
 	VECTOR3 spspos0 = _V(0.0, 0.0, -5);
 	EXHAUSTSPEC es_sps[1] = {

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -1917,7 +1917,7 @@ void RTCC::AP7BlockData(AP7BLKOpt *opt, AP7BLK &pad)
 
 	char weather[] = "GOOD";
 
-	v_e = calcParams.src->GetThrusterIsp0(calcParams.src->GetGroupThruster(THGROUP_MAIN, 0));
+	v_e = SystemParameters.MCTST1 / SystemParameters.MCTSW1;
 
 	entopt.vessel = calcParams.src;
 	entopt.GETbase = CalcGETBase();
@@ -5031,16 +5031,6 @@ MATRIX3 RTCC::REFSMMATCalc(REFSMMATOpt *opt)
 	VECTOR3 DV_P, DV_C, V_G, X_SM, Y_SM, Z_SM;
 	double theta_T;
 	SV sv0, sv2;
-	THGROUP_TYPE th_main;
-
-	if (opt->vessel->GetGroupThruster(THGROUP_MAIN, 0) == NULL)
-	{
-		th_main = THGROUP_HOVER;
-	}
-	else
-	{
-		th_main = THGROUP_MAIN;
-	}
 
 	if (opt->useSV)
 	{
@@ -6146,8 +6136,8 @@ void RTCC::TLI_PAD(TLIPADOpt* opt, TLIPAD &pad)
 		UZ = unit(-sv1.R);
 		UX = crossp(UY, UZ);
 
-		v_e = opt->vessel->GetThrusterIsp0(opt->vessel->GetGroupThruster(THGROUP_MAIN, 0));
-		F = opt->vessel->GetThrusterMax0(opt->vessel->GetGroupThruster(THGROUP_MAIN, 0));
+		F = SystemParameters.MCTJT5;
+		v_e = F / SystemParameters.MCTJW5;
 
 		DV_P = UX*opt->dV_LVLH.x + UZ*opt->dV_LVLH.z;
 		if (length(DV_P) != 0.0)

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
@@ -169,9 +169,7 @@ void LEM::SetLmVesselDockStage()
 	//RCS plane is at 254 inches in LM coordinates. DPS gimbal plane is at 154 inches in LM coordinates
 	//Therefore: 3.9116 m - (6.4516 m - 0.99 m) = -1.55 m for the DPS reference position
 	th_hover[0] = CreateThruster(_V(0.0, -1.55, 0.0), _V(0, 1, 0), 46706.3, ph_Dsc, 3107);
-
-	DelThrusterGroup(THGROUP_HOVER,true);
-	thg_hover = CreateThrusterGroup(th_hover, 1, THGROUP_HOVER);
+	thg_hover = CreateThrusterGroup(th_hover, 1, THGROUP_USER);
 	
 	EXHAUSTSPEC es_hover[1] = {
 		{ th_hover[0], NULL, NULL, NULL, 10.0, 1.5, 1.16, 0.1, exhaustTex, EXHAUST_CONSTANTPOS }
@@ -182,7 +180,6 @@ void LEM::SetLmVesselDockStage()
 	AddDust();
 
 	SetCameraOffset(_V(-0.58, 1.60, 1.40) - currentCoG); // Has to be the same as LPD view
-	SetEngineLevel(ENGINE_HOVER,0);
 
 	AddRCS_LMH(-5.4616); //254 inches minus the 0.99m offset from mesh_asc = 5.4616 m
 	status = 0;
@@ -238,9 +235,7 @@ void LEM::SetLmVesselHoverStage()
 	//RCS plane is at 254 inches in LM coordinates. DPS gimbal plane is at 154 inches in LM coordinates
 	//Therefore: 3.9116 m - (6.4516 m - 0.99 m) = -1.55 m for the DPS reference position
 	th_hover[0] = CreateThruster(_V(0.0, -1.55, 0.0), _V(0, 1, 0), 46706.3, ph_Dsc, 3107);
-
-	DelThrusterGroup(THGROUP_HOVER, true);
-	thg_hover = CreateThrusterGroup(th_hover, 1, THGROUP_HOVER);
+	thg_hover = CreateThrusterGroup(th_hover, 1, THGROUP_USER);
 
 	EXHAUSTSPEC es_hover[1] = {
 		{ th_hover[0], NULL, NULL, NULL, 10.0, 1.5, 1.16, 0.1, exhaustTex, EXHAUST_CONSTANTPOS }
@@ -253,7 +248,6 @@ void LEM::SetLmVesselHoverStage()
 	SetCameraOffset(_V(-0.58, 1.60, 1.40) - currentCoG); // Has to be the same as LPD view
 	status = 1;
 	stage = 1;
-	SetEngineLevel(ENGINE_HOVER,0);
 	AddRCS_LMH(-5.4616); //254 inches minus the 0.99m offset from mesh_asc = 5.4616 m
 
 	InitNavRadios (4);
@@ -319,9 +313,7 @@ void LEM::SetLmAscentHoverStage()
 	//Point of thrust application is also shifted 3.75 in (0.09525 m) in the z-axis.
 	//And it's canted at 1.5° to point through the CG which is located forward of the centerline
     th_hover[0] = CreateThruster (_V( 0.0,  -1.294416, 0.09525), _V( 0,cos(1.5*RAD),sin(1.5*RAD)), APS_THRUST, ph_Asc, APS_ISP);
-
-    DelThrusterGroup(THGROUP_HOVER,true);
-	thg_hover = CreateThrusterGroup (th_hover, 1, THGROUP_HOVER);
+	thg_hover = CreateThrusterGroup (th_hover, 1, THGROUP_USER);
 	
 	EXHAUSTSPEC es_hover[1] = {
 		{ th_hover[0], NULL, NULL, NULL, 6.0, 0.8, 0.5, 0.1, exhaustTex, EXHAUST_CONSTANTPOS }
@@ -332,7 +324,6 @@ void LEM::SetLmAscentHoverStage()
 	SetCameraOffset(_V(-0.58, -0.15, 1.40)); // Has to be the same as LPD view
 	status = 2;
 	stage = 2;
-	SetEngineLevel(ENGINE_HOVER,0);
 	AddRCS_LMH(-7.2116);  //254 inches minus the 0.99m offset from mesh_asc and plus 1.75 m from the ShiftCG = 7.2116 m
 
 	if(ph_Dsc){

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/sat1bmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/sat1bmesh.cpp
@@ -277,7 +277,7 @@ void Saturn1b::SetFirstStageEngines()
 	th_1st[7] = CreateThruster (m_exhaust_pos8, _V( 0,0,1), THRUST_FIRST_VAC , ph_1st, ISP_FIRST_VAC, ISP_FIRST_SL);
 
 	SURFHANDLE tex = oapiRegisterExhaustTexture ("ProjectApollo/Exhaust2");
-	thg_1st = CreateThrusterGroup (th_1st, 8, THGROUP_MAIN);
+	thg_1st = CreateThrusterGroup (th_1st, 8, THGROUP_USER);
 	
 	EXHAUSTSPEC es_1st[8] = {
 		{ th_1st[0], NULL, NULL, NULL, 30.0, 0.80, 0, 0.1, tex },
@@ -555,7 +555,7 @@ void Saturn1b::SetSecondStageEngines ()
 	//
 
 	th_3rd[0] = CreateThruster (m_exhaust_pos1, _V( 0,0,1), THRUST_SECOND_VAC, ph_3rd, ISP_SECOND_VAC, ISP_SECOND_SL);
-	thg_3rd = CreateThrusterGroup (th_3rd, 1, THGROUP_MAIN);
+	thg_3rd = CreateThrusterGroup (th_3rd, 1, THGROUP_USER);
 	
 	EXHAUSTSPEC es_3rd[1] = {
 		{ th_3rd[0], NULL, NULL, NULL, 30.0, 2.9, 0, 0.1, J2Tex }

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/sat5mesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/sat5mesh.cpp
@@ -545,7 +545,7 @@ void SaturnV::SetFirstStageEngines ()
 	th_1st[3] = CreateThruster (MAIN3a_Vector, _V( 0,0,1), THRUST_FIRST_VAC , ph_1st, ISP_FIRST_VAC, ISP_FIRST_SL);
 	th_1st[4] = CreateThruster (MAIN5a_Vector, _V( 0,0,1), THRUST_FIRST_VAC , ph_1st, ISP_FIRST_VAC, ISP_FIRST_SL);
 
-	thg_1st = CreateThrusterGroup (th_1st, SI_EngineNum, THGROUP_MAIN);
+	thg_1st = CreateThrusterGroup (th_1st, SI_EngineNum, THGROUP_USER);
 	
 	EXHAUSTSPEC es_1st[5] = {
 		{ th_1st[0], NULL, NULL, NULL, 120.0, 3.5, 0, 0.1, exhaust_tex },
@@ -725,7 +725,7 @@ void SaturnV::SetSecondStageEngines(double offset)
 	th_2nd[3] = CreateThruster (m_exhaust_pos4, _V( 0,0,1), THRUST_SECOND_VAC , ph_2nd, ISP_SECOND_VAC, ISP_SECOND_SL);
 	th_2nd[4] = CreateThruster (m_exhaust_pos5, _V( 0,0,1), THRUST_SECOND_VAC , ph_2nd, ISP_SECOND_VAC, ISP_SECOND_SL);
 
-	thg_2nd = CreateThrusterGroup (th_2nd, SII_EngineNum, THGROUP_MAIN);
+	thg_2nd = CreateThrusterGroup (th_2nd, SII_EngineNum, THGROUP_USER);
 
 	EXHAUSTSPEC es_2nd[5] = {
 	    { th_2nd[0], NULL, NULL, NULL, 30.0, 2.9, 0, 0.1, J2Tex },
@@ -893,7 +893,6 @@ void SaturnV::SetThirdStageMesh (double offset)
 
 void SaturnV::SetThirdStageEngines (double offset)
 {
-	DelThrusterGroup(THGROUP_MAIN, true);
 	ClearThrusterDefinitions();
 	ClearExhaustRefs();
 	ClearAttExhaustRefs();
@@ -988,7 +987,7 @@ void SaturnV::SetThirdStageEngines (double offset)
 	//
 
 	th_3rd[0] = CreateThruster (m_exhaust_pos1, _V( 0,0,1), THRUST_THIRD_VAC, ph_3rd, ISP_THIRD_VAC);
-	thg_3rd = CreateThrusterGroup (th_3rd, 1, THGROUP_MAIN);
+	thg_3rd = CreateThrusterGroup (th_3rd, 1, THGROUP_USER);
 
 	EXHAUSTSPEC es_3rd[1] = {
 		{ th_3rd[0], NULL, NULL, NULL, 30.0, 2.9, 0, 0.1, J2Tex }


### PR DESCRIPTION
This update will disable the standard Orbiter controls for the main and hover engines, specifically the SPS, DPS, APS and all Saturn engines in the Saturn class. Previously it was possible to change the thruster level manually or a noisy joystick throttle lever could cause an early cutoff of the J-2 engine during TLI.