### PR TITLE
Prevent initial state of AEA engine on discrete, before AEA power up, to be interpreted as a valid engine on signal

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_ags.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_ags.cpp
@@ -457,6 +457,7 @@ LEM_AEA::LEM_AEA(PanelSDK &p, LEM_DEDA &display) : DCPower(0, p), deda(display) 
 	AGSLateralVelocity = 0.0;
 	Altitude = 0.0;
 	AltitudeRate = 0.0;
+	powered = false;
 
 	//
 	// Virtual AGS.
@@ -931,6 +932,24 @@ bool LEM_AEA::GetTestModeFailure()
 	AGSChannelValue40 agsval40;
 	agsval40 = OutputPorts[IO_ODISCRETES];
 	return ~agsval40[AGSTestModeFailure];
+}
+
+bool LEM_AEA::GetEngineOnSignal()
+{
+	if (!IsPowered())
+		return false;
+	AGSChannelValue40 agsval40;
+	agsval40 = OutputPorts[IO_ODISCRETES];
+	return ~agsval40[AGSEngineOn];
+}
+
+bool LEM_AEA::GetEngineOffSignal()
+{
+	if (!IsPowered())
+		return false;
+	AGSChannelValue40 agsval40;
+	agsval40 = OutputPorts[IO_ODISCRETES];
+	return ~agsval40[AGSEngineOff];
 }
 
 void LEM_AEA::InitVirtualAGS(char *binfile)

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_ags.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_ags.h
@@ -157,6 +157,8 @@ public:
 	bool IsPowered();
 	bool IsACPowered();
 	bool GetTestModeFailure();
+	bool GetEngineOnSignal();
+	bool GetEngineOffSignal();
 	LEM *lem;					// Pointer at LEM
 	h_HeatLoad *aeaHeat;
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lmscs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lmscs.cpp
@@ -2508,14 +2508,12 @@ void SCCA2::Timestep(double simdt)
 	}
 
 	ChannelValue val11;
-	AGSChannelValue40 agsval40;
 
 	val11 = lem->agc.GetOutputChannel(011);
-	agsval40 = lem->aea.GetOutputChannel(IO_ODISCRETES);
 
 	if (K8)
 	{
-		AutoEngOn = ~agsval40[AGSEngineOn];
+		AutoEngOn = lem->aea.GetEngineOnSignal();
 	}
 	else
 	{
@@ -2526,7 +2524,7 @@ void SCCA2::Timestep(double simdt)
 	{
 		if (lem->ModeControlAGSSwitch.IsUp())
 		{
-			AutoEngOff = ~agsval40[AGSEngineOff];
+			AutoEngOff = lem->aea.GetEngineOffSignal();
 		}
 		else
 		{


### PR DESCRIPTION
The check on the bits in the output register could be accomplished with less code.