### PR TITLE
Set higher surface friction coefficients so the LM doesn't "creep" on…

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -556,6 +556,8 @@ void LEM::Init()
 	VcInfoActive = false;
 	VcInfoEnabled = false;
 
+	FrictionCounter = 0;
+
 	Crewed = true;
 	AutoSlow = false;
 
@@ -1260,6 +1262,18 @@ void LEM::clbkPreStep (double simt, double simdt, double mjd) {
 			sprintf(oapiDebugString(), "");
 			VcInfoActive = false;
 		}
+	}
+
+	// Sets low surface friction for 10 timesteps to avoid instability at session start, then set once to high friction
+	if (FrictionCounter == 10)
+	{
+		SetSurfaceFrictionCoeff(20, 20);
+		FrictionCounter++;
+	}
+	else if (FrictionCounter < 10)
+	{
+		SetSurfaceFrictionCoeff(1, 1);
+		FrictionCounter++;
 	}
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -1721,6 +1721,7 @@ protected:
 	bool RefreshPanelIdInTimestep;
 	bool VcInfoActive;
 	bool VcInfoEnabled;
+	int FrictionCounter;
 
 	//
 	// Random motion.

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
@@ -715,8 +715,8 @@ void LEM::ConfigTouchdownPoints(double mass, double ro1, double ro2, double tdph
 			tdv[i].damping = damping / 200;
 			tdv[i].stiffness = stiffness / 200;
 		}
-		tdv[i].mu = 3;
-		tdv[i].mu_lng = 3;
+		tdv[i].mu = 20;
+		tdv[i].mu_lng = 20;
 	}
 
 	tdv[0].pos.x = 0;


### PR DESCRIPTION
… the moon at session start

or when RCS is fired. Friction coefficients are set low for 10 timesteps at session start to avoid instabiilities.