### PR TITLE
Set damping/stiffness factor to default value -0.5 for all LM stages. …

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
@@ -680,22 +680,22 @@ void LEM::DefineTouchdownPoints(int s)
 	//Touchdown Points
 	if (s == 0)
 	{
-		ConfigTouchdownPoints(7137.75, 3.5, 0.5, -3.60, 0, 3.86, -0.25); // landing gear retracted
+		ConfigTouchdownPoints(7137.75, 3.5, 0.5, -3.60, 0, 3.86); // landing gear retracted
 	}
 	else if (s == 1)
 	{
 		if (pMission->LMHasLegs())
 		{
-			ConfigTouchdownPoints(7137.75, 3.5, 4.25, -3.60, -5.31, 3.86, -0.25); // landing gear extended
+			ConfigTouchdownPoints(7137.75, 3.5, 4.25, -3.60, -5.31, 3.86); // landing gear extended
 		}
 		else
 		{
-			ConfigTouchdownPoints(7137.75, 3.5, 0.5, -3.60, 0, 3.86, -0.25); // landing gear retracted
+			ConfigTouchdownPoints(7137.75, 3.5, 0.5, -3.60, 0, 3.86); // landing gear retracted
 		}
 	}
 	else
 	{
-		ConfigTouchdownPoints(4495.0, 3, 3, -5.42, 0, 2.8, -0.5);
+		ConfigTouchdownPoints(4495.0, 3, 3, -5.42, 0, 2.8);
 	}
 }
 


### PR DESCRIPTION
…Certain systems seem to have a jerk/jump with the previous -0.25 value, now with the more stable -0.5, the behavior of the LM at loading should be much improved. NOTE: This is not related to the previous PR #687 which was for the surface friction...the behavior that this PR fixes was present before PR #687 and only noticeable on certain systems.