### PR TITLE
Consume Ctrl-D undock key to prevent invalid probe state

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3371,6 +3371,12 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 		return 0;
 	}
 	if (KEYMOD_CONTROL(kstate)) {
+		switch (key) {
+			case OAPI_KEY_D:
+				// Orbiter undocking messes with our undocking system. We consume the keybind here to block it.
+				// This won't work if the user has changed this keybind. Unfortunately Orbiter does not export the keymap through the API (yet). :(
+				return 1;
+		}
 		return 0;
 	}
 	if (KEYMOD_ALT(kstate))

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -915,6 +915,10 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 			case OAPI_KEY_NUMPAD0:
 				deda.NumberPressed(0);
 				break;
+			case OAPI_KEY_D:
+				// Orbiter undocking messes with our undocking system. We consume the keybind here to block it.
+				// This won't work if the user has changed this keybind. Unfortunately Orbiter does not export the keymap through the API (yet). :(
+				return 1;
 			}
 		}
 		else {


### PR DESCRIPTION
It would be nicer if Orbiter exported the current keymap through the API so the Undock key itself can be consumed instead of the default keybind for it.