### PR TITLE
RTCC: Add option to CSM and LM DAP PAD to calculate trim gimbal angles with or without docked vehicles

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_D.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_D.cpp
@@ -126,14 +126,14 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 	{
 		AP10DAPDATA * form = (AP10DAPDATA *)pad;
 
-		CSMDAPUpdate(calcParams.src, *form);
+		CSMDAPUpdate(calcParams.src, *form, false);
 	}
 	break;
 	case 6: //LM DAP DATA
 	{
 		AP10DAPDATA * form = (AP10DAPDATA *)pad;
 
-		LMDAPUpdate(calcParams.tgt, *form);
+		LMDAPUpdate(calcParams.tgt, *form, false);
 	}
 	break;
 	case 7: //MISSION INITIALIZATION
@@ -603,7 +603,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 		manopt.vessel = calcParams.tgt;
 
 		AP11LMManeuverPAD(&manopt, *form);
-		LMDAPUpdate(calcParams.tgt, dappad);
+		LMDAPUpdate(calcParams.tgt, dappad, true);
 
 		sprintf(form->remarks, "LM weight is %.0f, CSM weight is %.0f", dappad.ThisVehicleWeight, dappad.OtherVehicleWeight);
 
@@ -694,7 +694,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 		AP7ManeuverPAD(&manopt, *form);
 		sprintf(form->purpose, "SPS-5");
 
-		CSMDAPUpdate(calcParams.src, dappad);
+		CSMDAPUpdate(calcParams.src, dappad, false);
 		sprintf(form->remarks, "LM weight is %.0f", dappad.OtherVehicleWeight);
 
 		AGCStateVectorUpdate(buffer1, sv, true, GETbase, true);
@@ -1227,7 +1227,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 
 		AP11LMManeuverPAD(&opt, *form);
 
-		LMDAPUpdate(calcParams.tgt, dappad);
+		LMDAPUpdate(calcParams.tgt, dappad, false);
 		sprintf(form->purpose, "APS Depletion");
 		sprintf(form->remarks, "LM weight is %.0f", dappad.ThisVehicleWeight);
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
@@ -1493,14 +1493,14 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 	{
 		AP10DAPDATA * form = (AP10DAPDATA *)pad;
 
-		CSMDAPUpdate(calcParams.src, *form);
+		CSMDAPUpdate(calcParams.src, *form, false);
 	}
 	break;
 	case 62: //LM DAP DATA
 	{
 		AP10DAPDATA * form = (AP10DAPDATA *)pad;
 
-		LMDAPUpdate(calcParams.tgt, *form);
+		LMDAPUpdate(calcParams.tgt, *form, false);
 	}
 	break;
 	case 63: //GYRO TORQUING ANGLES

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
@@ -1208,7 +1208,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 	{
 		AP10DAPDATA * form = (AP10DAPDATA *)pad;
 
-		CSMDAPUpdate(calcParams.src, *form);
+		CSMDAPUpdate(calcParams.src, *form, false);
 	}
 	break;
 	case 34: //LM DAP DATA
@@ -1217,7 +1217,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 
 		AP10DAPDATA dap;
 
-		LMDAPUpdate(calcParams.tgt, dap);
+		LMDAPUpdate(calcParams.tgt, dap, false);
 		
 		LEM *lem = (LEM *)calcParams.tgt;
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -4308,7 +4308,7 @@ void RTCC::AP9LMCDHPAD(AP9LMCDHPADOpt *opt, AP9LMCDH &pad)
 	pad.Vg = opt->dV_LVLH / 0.3048;
 }
 
-void RTCC::CSMDAPUpdate(VESSEL *v, AP10DAPDATA &pad)
+void RTCC::CSMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool docked)
 {
 	double CSMmass, LMmass, p_T, y_T;
 
@@ -4317,13 +4317,13 @@ void RTCC::CSMDAPUpdate(VESSEL *v, AP10DAPDATA &pad)
 
 	double T, WDOT;
 	unsigned IC;
-	if (LMmass > 0)
+	if (docked)
 	{
-		IC = 13;
+		IC = 13; //CSM + LM
 	}
 	else
 	{
-		IC = 1;
+		IC = 1; //CSM
 	}
 	GIMGBL(CSMmass, LMmass, p_T, y_T, T, WDOT, RTCC_ENGINETYPE_CSMSPS, IC, 1, 0, 0.0);
 
@@ -4339,7 +4339,7 @@ void ConvertDPSGimbalAnglesToTrim(double P_G, double R_G, double &P_G_trim, doub
 	R_G_trim = 6.0*RAD + R_G;
 }
 
-void RTCC::LMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool asc)
+void RTCC::LMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool docked, bool asc)
 {
 	double CSMmass, LMmass;
 
@@ -4371,13 +4371,13 @@ void RTCC::LMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool asc)
 	{
 		double T, WDOT, p_T, r_T;
 		unsigned IC;
-		if (CSMmass > 0)
+		if (docked)
 		{
-			IC = 13;
+			IC = 13; //CSM + LM
 		}
 		else
 		{
-			IC = 12;
+			IC = 12; //LM
 		}
 		GIMGBL(CSMmass, LMmass, p_T, r_T, T, WDOT, RTCC_ENGINETYPE_LMDPS, IC, 1, 0, 0.0);
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -2485,8 +2485,8 @@ public:
 	void AP11LMManeuverPAD(AP11LMManPADOpt *opt, AP11LMMNV &pad);
 	void AP11ManeuverPAD(AP11ManPADOpt *opt, AP11MNV &pad);
 	void AP10CSIPAD(AP10CSIPADOpt *opt, AP10CSI &pad);
-	void CSMDAPUpdate(VESSEL *v, AP10DAPDATA &pad);
-	void LMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool asc = false);
+	void CSMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool docked);
+	void LMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool docked, bool asc = false);
 	void RTEMoonTargeting(RTEMoonOpt *opt, EntryResults *res);
 	void LunarOrbitMapUpdate(SV sv0, double GETbase, AP10MAPUPDATE &pad, double pm = -150.0*RAD);
 	void LandmarkTrackingPAD(LMARKTRKPADOpt *opt, AP11LMARKTRKPAD &pad);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -1182,11 +1182,11 @@ void ARCore::DAPPADCalc()
 	if (vesseltype == 4) return;
 	if (vesseltype < 2)
 	{
-		GC->rtcc->CSMDAPUpdate(vessel, DAP_PAD);
+		GC->rtcc->CSMDAPUpdate(vessel, DAP_PAD, vesseltype == 1);
 	}
 	else
 	{
-		GC->rtcc->LMDAPUpdate(vessel, DAP_PAD, lemdescentstage == false);
+		GC->rtcc->LMDAPUpdate(vessel, DAP_PAD, vesseltype == 3, lemdescentstage == false);
 	}
 }
 


### PR DESCRIPTION
Fixes the currently existing bug that the Apollo 10 and 11 LM DAP PAD gives gimbal angles for the LM that are based on LM+CSM docked instead of LM alone.