### PR TITLE
RTCC MFD: Fix bug in Angle_Display function by changing variable name  time to angle

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -414,7 +414,7 @@ void ApolloRTCCMFD::menuTLANDUpload()
 void ApolloRTCCMFD::Angle_Display(char *Buff, double angle, bool DispPlus)
 {
 	double angle2 = abs(round(angle));
-	if (time >= 0)
+	if (angle >= 0)
 	{
 		if (DispPlus)
 		{


### PR DESCRIPTION
This caused a Linux only build error, see here: https://www.orbiter-forum.com/threads/linux-playground.40476/post-595561