### PR TITLE
Solution for VC head movement bug

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn1b.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn1b.vcxproj
@@ -289,6 +289,7 @@
     <ClCompile Include="..\..\src_mfd\MFDconnector.cpp">
       <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ProgramDatabase</DebugInformationFormat>
     </ClCompile>
+    <ClCompile Include="..\..\src_sys\inertial.cpp" />
     <ClCompile Include="..\..\src_sys\MechanicalAccelerometer.cpp" />
     <ClCompile Include="..\..\src_sys\missiontimer.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -489,6 +490,7 @@
     <ClInclude Include="..\..\src_sys\dsky.h" />
     <ClInclude Include="..\..\src_sys\FDAI.h" />
     <ClInclude Include="..\..\src_sys\IMU.h" />
+    <ClInclude Include="..\..\src_sys\inertial.h" />
     <ClInclude Include="..\..\src_sys\ioChannels.h" />
     <ClInclude Include="..\..\src_saturn\iu.h" />
     <ClInclude Include="..\..\src_mfd\MFDconnector.h" />

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn1b.vcxproj.filters
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn1b.vcxproj.filters
@@ -237,7 +237,10 @@
     <ClCompile Include="..\..\src_aux\vesim.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-	<ClCompile Include="..\..\src_aux\animations.cpp">
+    <ClCompile Include="..\..\src_aux\animations.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src_sys\inertial.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -446,7 +449,10 @@
     <ClInclude Include="..\..\src_aux\vesim.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-	<ClInclude Include="..\..\src_aux\animations.h">
+    <ClInclude Include="..\..\src_aux\animations.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src_sys\inertial.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj
@@ -262,6 +262,7 @@
     </ClCompile>
     <ClCompile Include="..\..\src_saturn\lvimu.cpp" />
     <ClCompile Include="..\..\src_mfd\MFDconnector.cpp" />
+    <ClCompile Include="..\..\src_sys\inertial.cpp" />
     <ClCompile Include="..\..\src_sys\MechanicalAccelerometer.cpp" />
     <ClCompile Include="..\..\src_sys\missiontimer.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -426,6 +427,7 @@
     <ClInclude Include="..\..\src_saturn\s1csystems.h" />
     <ClInclude Include="..\..\src_saturn\siisystems.h" />
     <ClInclude Include="..\..\src_saturn\sivbsystems.h" />
+    <ClInclude Include="..\..\src_sys\intertial.h" />
     <ClInclude Include="..\..\src_sys\apolloguidance.h" />
     <ClInclude Include="..\..\src_aux\BasicExcelVC6.hpp" />
     <ClInclude Include="..\..\src_sys\cautionwarning.h" />

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj.filters
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj.filters
@@ -237,7 +237,10 @@
     <ClCompile Include="..\..\src_aux\vesim.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-	<ClCompile Include="..\..\src_aux\animations.cpp">
+    <ClCompile Include="..\..\src_aux\animations.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src_sys\inertial.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -464,7 +467,10 @@
     <ClInclude Include="..\..\src_aux\vesim.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-	<ClInclude Include="..\..\src_aux\animations.h">
+    <ClInclude Include="..\..\src_aux\animations.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src_sys\intertial.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -362,6 +362,7 @@ Saturn::Saturn(OBJHANDLE hObj, int fmodel) : ProjectApolloConnectorVessel (hObj,
 	imu(agc, Panelsdk),
 	scdu(agc, RegOPTX, 0140, 2),
 	tcdu(agc, RegOPTY, 0141, 2),
+	intertialData(this),
 	cws(SMasterAlarm, Bclick, Panelsdk),
 	dockingprobe(0, SDockingCapture, SDockingLatch, SDockingExtend, SUndock, CrashBumpS, Panelsdk),
 	MissionTimerDisplay(Panelsdk),
@@ -2890,6 +2891,8 @@ void Saturn::GenericTimestep(double simt, double simdt, double mjd)
 		SetView();
 	}
 
+	intertialData.timestep(simdt);
+
 	//
 	// Update mission time.
 	//
@@ -2936,13 +2939,10 @@ void Saturn::GenericTimestep(double simt, double simdt, double mjd)
 	//
 	//  This model of vibration is visual only and has no effect on other parts of the simulation.
 	double dynpress = GetDynPressure();
-	VECTOR3 vAccel, vWeight;
-	GetForceVector(vAccel);
-	GetWeightVector(vWeight);
-	
-	vAccel -= vWeight;
-	vAccel /= GetMass();
-	
+	VECTOR3 vAccel;
+
+	intertialData.getIntertialAccel(vAccel);
+	vAccel = -vAccel;
 	THRUSTER_HANDLE *tharr;
 	VECTOR3 seatacc = vAccel;
 	double thsum = 0.0;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -65,6 +65,7 @@
 #include "sce.h"
 #include "csmsensors.h"
 #include "rhc.h"
+#include "inertial.h"
 
 #define DIRECTINPUT_VERSION 0x0800
 #include "dinput.h"
@@ -3593,6 +3594,8 @@ protected:
 	///////////////////////////////////////////////////////
 	// Internal systems devices.						 //
 	///////////////////////////////////////////////////////
+
+	IntertialData intertialData;
 
 	// SCS components
 	BMAG bmag1;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/inertial.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/inertial.cpp
@@ -1,0 +1,148 @@
+/***************************************************************************
+This file is part of Project Apollo - NASSP
+Copyright 2004-2022
+
+Generic Apollo Guidance computer class which is hooked
+up to the DSKY to allow easy support for the CSM and LEM
+computers. This defines the interfaces that the DSKY will
+use to either computer, so only parts specific to the CSM
+or LEM will need to be written specially.
+
+Project Apollo is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+Project Apollo is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Project Apollo; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+See http://nassp.sourceforge.net/license/ for more details.
+
+**************************************************************************/
+
+#include "inertial.h"
+
+IntertialData::IntertialData(VESSEL *vessel) {
+	this->vessel = vessel;
+	accel = _V(0.0, 0.0, 0.0);
+}
+
+VECTOR3 IntertialData::GetGravityVector() {
+	OBJHANDLE gravref = vessel->GetGravityRef();
+	OBJHANDLE hSun = oapiGetObjectByName("Sun");
+	VECTOR3 R, U_R;
+	vessel->GetRelativePos(gravref, R);
+	U_R = unit(R);
+	double r = length(R);
+	VECTOR3 R_S, U_R_S;
+	vessel->GetRelativePos(hSun, R_S);
+	U_R_S = unit(R_S);
+	double r_S = length(R_S);
+	double mu = GGRAV * oapiGetMass(gravref);
+	double mu_S = GGRAV * oapiGetMass(hSun);
+	int jcount = oapiGetPlanetJCoeffCount(gravref);
+	double JCoeff[5];
+	for (int i = 0; i < jcount; i++)
+	{
+		JCoeff[i] = oapiGetPlanetJCoeff(gravref, i);
+	}
+	double R_E = oapiGetSize(gravref);
+
+	VECTOR3 a_dP;
+
+	a_dP = -U_R;
+
+	if (jcount > 0)
+	{
+		MATRIX3 mat;
+		VECTOR3 U_Z;
+		double costheta, P2, P3;
+
+		oapiGetPlanetObliquityMatrix(gravref, &mat);
+		U_Z = mul(mat, _V(0, 1, 0));
+
+		costheta = dotp(U_R, U_Z);
+
+		P2 = 3.0 * costheta;
+		P3 = 0.5*(15.0*costheta*costheta - 3.0);
+		a_dP += (U_R*P3 - U_Z * P2)*JCoeff[0] * pow(R_E / r, 2.0);
+		if (jcount > 1)
+		{
+			double P4;
+			P4 = 1.0 / 3.0*(7.0*costheta*P3 - 4.0*P2);
+			a_dP += (U_R*P4 - U_Z * P3)*JCoeff[1] * pow(R_E / r, 3.0);
+			if (jcount > 2)
+			{
+				double P5;
+				P5 = 0.25*(9.0*costheta*P4 - 5.0 * P3);
+				a_dP += (U_R*P5 - U_Z * P4)*JCoeff[2] * pow(R_E / r, 4.0);
+			}
+		}
+	}
+	a_dP *= mu / pow(r, 2.0);
+	a_dP -= U_R_S * mu_S / pow(r_S, 2.0);
+
+	if (gravref == oapiGetObjectByName("Moon"))
+	{
+		OBJHANDLE hEarth = oapiGetObjectByName("Earth");
+
+		VECTOR3 R_Ea, U_R_E;
+		vessel->GetRelativePos(hEarth, R_Ea);
+		U_R_E = unit(R_Ea);
+		double r_E = length(R_Ea);
+		double mu_E = GGRAV * oapiGetMass(hEarth);
+
+		a_dP -= U_R_E * mu_E / pow(r_E, 2.0);
+	}
+
+	return a_dP;
+}
+
+
+void IntertialData::timestep(double simdt) {
+	VECTOR3 w, vel;
+
+	vessel->GetWeightVector(w);
+	vessel->GetGlobalVel(vel);
+	vessel->GetRotationMatrix(rotmat);
+
+	w = mul(rotmat, w) / vessel->GetMass();
+
+	//Orbiter 2016 hack
+	if (length(w) == 0.0)
+	{
+		w = GetGravityVector();
+	}
+
+	if (!dVInitialized) {
+		lastWeight = w;
+		lastGlobalVel = vel;
+		lastSimDT = simdt;
+		dVInitialized = true;
+	}
+	else {
+		// Acceleration calculation, see IMU
+		VECTOR3 dvel = (vel - lastGlobalVel) / lastSimDT;
+		VECTOR3 dw1 = w - dvel;
+		VECTOR3 dw2 = lastWeight - dvel;
+		lastWeight = w;
+		lastGlobalVel = vel;
+		lastSimDT = simdt;
+
+		// Transform to vessel coordinates
+		VECTOR3 avg = (dw1 + dw2) / 2.0;
+		accel = tmul(rotmat, avg);
+	}
+}
+
+void IntertialData::getIntertialAccel(VECTOR3 &acc) {
+	acc.x = accel.x;
+	acc.y = accel.y;
+	acc.z = accel.z;
+}

--- a/Orbitersdk/samples/ProjectApollo/src_sys/inertial.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/inertial.h
@@ -1,0 +1,46 @@
+/***************************************************************************
+This file is part of Project Apollo - NASSP
+Copyright 2004-2022
+
+Generic Apollo Guidance computer class which is hooked
+up to the DSKY to allow easy support for the CSM and LEM
+computers. This defines the interfaces that the DSKY will
+use to either computer, so only parts specific to the CSM
+or LEM will need to be written specially.
+
+Project Apollo is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+Project Apollo is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Project Apollo; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+See http://nassp.sourceforge.net/license/ for more details.
+
+**************************************************************************/
+
+#pragma once
+#include "Orbitersdk.h"
+
+class IntertialData {
+	VECTOR3 accel;
+	MATRIX3 rotmat;
+	VESSEL *vessel;
+	bool dVInitialized;
+	VECTOR3 lastWeight;
+	VECTOR3 lastGlobalVel;
+	double lastSimDT;
+
+public:
+	IntertialData(VESSEL *vessel);
+	VECTOR3 IntertialData::GetGravityVector();
+	void timestep(double simdt);
+	void getIntertialAccel(VECTOR3 &acc);
+};


### PR DESCRIPTION
This bug: https://github.com/orbiternassp/NASSP/issues/767 was caused because GetForceVector does not take into account all the forces when the vessel is docked. A new class InertialData is created to correctly calculate inertial acceleration. The head movement in VC is now based on this instead of GetForceVector function.
This - or a very similar - calculation is done many times for multiple instruments (IMU, EMS, mechanical G-meter on CSM, LV IMU, LM IMU, LM T/W, LM AGS Accelerometer). It would be more effective to make all these to query the InertialData object of the vessel for inertial acceleration instead of doing the calculation on their own.