### PR TITLE
RTCC bug fixes

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -2812,9 +2812,9 @@ public:
 	//CMC External Delta-V Update Display
 	void CMDAXTDV();
 	//CMC External Delta-V Update Generator
-	void CMMAXTDV(double GETIG, VECTOR3 DV_EXDV, unsigned man = 0);
+	void CMMAXTDV(double GETIG, VECTOR3 DV_EXDV, int mpt = 0, unsigned man = 0);
 	//LGC External Delta-V Update Generator
-	void CMMLXTDV(double GETIG, VECTOR3 DV_EXDV, unsigned man = 0);
+	void CMMLXTDV(double GETIG, VECTOR3 DV_EXDV, int mpt = 0, unsigned man = 0);
 	//CMC and LGC REFSMMAT Update Generator
 	void CMMRFMAT(int L, int id, int addr);
 	//SLV Navigation Update

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
@@ -506,6 +506,14 @@ int RTCC::ELVCNV(EphemerisData &sv, int out, EphemerisData &sv_out)
 	sv_out.R = sv_out2.R;
 	sv_out.V = sv_out2.V;
 	sv_out.GMT = sv_out2.GMT;
+	if (out < 2) //Set to Earth for ECI and ECT, to Moon for MCI, MCT, EMP
+	{
+		sv_out.RBI = 0;
+	}
+	else
+	{
+		sv_out.RBI = 2;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
-SPS thrust was hardcoded in P30 REFSMMAT calculation. Now can also use DPS
-More error messages for Return to Earth Digitals
-P30 uplink with MPT active can uplink CSM MPT maneuver to LGC and vice versa
-General purpose maneuver to change apo/peri adjusts apo or peri if radius before maneuver is out of range
-Vector conversion routine outputs reference body indicator