### PR TITLE
Run systems simulation on the first timestep in CSM and LM

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -508,7 +508,6 @@ Saturn::Saturn(OBJHANDLE hObj, int fmodel) : ProjectApolloConnectorVessel (hObj,
 {	
 	//_CrtSetDbgFlag ( _CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF|_CRTDBG_CHECK_ALWAYS_DF );
 	InitSaturnCalled = false;
-	LastTimestep = 0;
 
 	//Mission File
 	InitMissionManagementMemory();

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -4432,11 +4432,6 @@ protected:
 
 	double CurrentViewOffset;
 
-	///
-	/// Time of last timestep call.
-	///
-	double LastTimestep;
-
 	//
 	// Panel flash.
 	//

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -1175,7 +1175,6 @@ void LEM::clbkPreStep (double simt, double simdt, double mjd) {
 	{
 		DoFirstTimestep();
 		FirstTimestep = false;
-		return;
 	}
 
 	// Prevent Orbiter navmodes from doing stuff

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/Saturn1b.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/Saturn1b.cpp
@@ -257,18 +257,9 @@ void Saturn1b::DoFirstTimestep(double simt)
 void Saturn1b::Timestep (double simt, double simdt, double mjd)
 
 {
-	//
-	// On the first timestep we just do basic setup
-	// stuff and return. We seem to get called in at
-	// least some cases before Orbiter is properly set
-	// up, so the last thing we want to do is point the
-	// engines in a wacky direction and then not be
-	// called again for several seconds.
-	//
 	if (FirstTimestep){
 		DoFirstTimestep(simt);
 		FirstTimestep = false;
-		return;
 	}
 
 	GenericTimestep(simt, simdt, mjd);
@@ -310,8 +301,6 @@ void Saturn1b::Timestep (double simt, double simdt, double mjd)
 		SeparateStage(CM_STAGE);
 		SetStage(CM_STAGE);
 	}
-
-	LastTimestep = simt;
 }
 
 void Saturn1b::clbkPostStep (double simt, double simdt, double mjd) {

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/Saturn5.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/Saturn5.cpp
@@ -460,20 +460,9 @@ void SaturnV::DoFirstTimestep(double simt)
 void SaturnV::Timestep(double simt, double simdt, double mjd)
 
 {
-	//
-	// On the first timestep we just do basic setup
-	// stuff and return. We seem to get called in at
-	// least some cases before Orbiter is properly set
-	// up, so the last thing we want to do is point the
-	// engines in a wacky direction and then not be
-	// called again for several seconds.
-	//
-
 	if (FirstTimestep) {
 		DoFirstTimestep(simt);
-		LastTimestep = simt;
 		FirstTimestep = false;
-		return;
 	}
 
 	GenericTimestep(simt, simdt, mjd);
@@ -550,8 +539,6 @@ void SaturnV::Timestep(double simt, double simdt, double mjd)
 		SeparateStage(CM_STAGE);
 		SetStage(CM_STAGE);
 	}
-
-	LastTimestep = simt;
 }
 
 void SaturnV::clbkPostStep (double simt, double simdt, double mjd) {


### PR DESCRIPTION
Previously very little code was run in the CSM and LM on the first timestep after loading into an Orbiter session. This first timestep always has a duration of 0.01 seconds. This time was not accounted for in the simulation of any time keeping code, which includes the MissionTimer variable (used to show mission time in the PAMFD among many other things) but also the AGC. No AGC cycles are done during this initial 0.01 seconds. That means every time you are loading an Orbiter session while flying a mission you give the AGC an additional clock error of 0.01 seconds. Do this very often during a mission and you could get a significant clock drift.

The reason for not calling the main timestep functions in CSM and LM was given in a code comment:

> On the first timestep we just do basic setup stuff and return. We seem to get called in at least some cases before Orbiter is properly set up, so the last thing we want to do is point the engines in a wacky direction and then not be called again for several seconds.

It is quite possible that this issue is long gone and doesn't apply to the current Orbiter anymore. It could very well be that it was already fixed in Orbiter 2010! This PR has no problem loading scenarios, but I think it's still a significant change that could lead to new bugs. So it can use a bunch of testing!

LastTimestep was just an unused variable related to the first timestep code.