### PR TITLE
Use different logic for ascent engine arm telemetry, using relay K206…

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_scea.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_scea.cpp
@@ -317,7 +317,7 @@ void SCERA1::Timestep()
 	//Deadband select (wide) (GH1603)
 	SA3.SetOutput(1, lem->DeadBandSwitch.IsUp() && !lem->scca1.GetK15() && !lem->scca1.GetK203() && !lem->scca1.GetK204());
 	//Ascent engine arm (GH1230)
-	SA3.SetOutput(2, lem->EngineArmSwitch.IsUp() && lem->SCS_ENG_ARM_CB.IsPowered());
+	SA3.SetOutput(2, lem->scca1.GetK206());
 	//RCS thrust chamber pressure A2A (GR5041)
 	SA3.SetOutput(3, lem->GetRCSThrusterLevel(LMRCS_A2A) > 0.1);
 	//RCS thrust chamber pressure B2L (GR5042)

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lmscs.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lmscs.h
@@ -289,6 +289,7 @@ public:
 	bool GetK20() { return K20; }
 	bool GetK203() { return K203; }
 	bool GetK204() { return K204; }
+	bool GetK206() { return K206; }
 	bool GetThrustOn() { return thrustOn; }
 
 	void SaveState(FILEHANDLE scn, char *start_str, char *end_str);


### PR DESCRIPTION
… will take the Apollo 9+10 only electronics into account