### PR TITLE
TLI on MPT bugs

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -7750,7 +7750,7 @@ RTCC_PMMSPT_20_1:
 			goto RTCC_PMMSPT_20_3;
 		}
 	}
-	in.CurMan->GMTMAN = T_RP;
+	in.mpt->TimeToBeginManeuver[0] = in.CurMan->GMTMAN = T_RP;
 	if (in.QUEID != 33)
 	{
 		//Trajectory Update
@@ -18448,6 +18448,7 @@ RTCC_PMSVCT_8:
 						intab2.V = sv1.V;
 						intab2.CurMan = &mpt->mantable[i];
 						intab2.Table = L;
+						intab2.mpt = mpt;
 
 						int err;
 						if (err = PMMSPT(intab2))

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/TLIGuidanceSim.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/TLIGuidanceSim.cpp
@@ -42,6 +42,7 @@ TLIGuidanceSim::TLIGuidanceSim(RTCC *r, RTCCNIInputTable tablin, int &iretn, Eph
 	DTPREV = 0.0;
 	DVMAG = 0.0;
 	DVTO = 0.0;
+	DVULL = 0.0;
 	DVX = 0.0;
 	DVXTO = 0.0;
 	for (int i = 0;i < 7;i++)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
@@ -861,7 +861,7 @@ void RTCC::ELVCTR(const ELVCTRInputTable &in, ELVCTROutputTable2 &out, Ephemeris
 		TS_stored = EPH.Header.TL;
 		TE_stored = EPH.Header.TR;
 		unsigned NV = 1;
-		while (TE != EPH.table[NV - 1].GMT)
+		while (abs (TE - EPH.table[NV - 1].GMT) > 0.000001) //To avoid floating point issues
 		{
 			if (TE < EPH.table[NV - 1].GMT)
 			{


### PR DESCRIPTION
-During trajectory update, the new TLI ignition time is stored correctly
-Initialize TLI ullage DV counter to zero (could be NaN otherwise)
-Implement a small tolerance on double comparison in interpolation routine