### PR TITLE
Fix PCM telemetry scaling

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
@@ -2208,9 +2208,9 @@ unsigned char PCM::scale_data(double data, double low, double high)
 	if(data <= low){  return 0; }
 	
 	// Now figure step value
-	double step = ( ( high - low ) / 256.0);
+	double step = ( ( high - low ) / 253.0);
 	// and return result
-	return static_cast<unsigned char>( ( ( data - low ) / step ) + 0.5 );
+	return static_cast<unsigned char>( ( ( data - low ) / step ) + 1.5 );
 }
 
 // Fetch a telemetry data item from its channel code

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
@@ -522,9 +522,9 @@ unsigned char LM_PCM::scale_data(double data, double low, double high)
 	if(data <= low){  return 0; }
 	
 	// Now figure step value
-	double step = ( ( high - low ) / 256.0);
+	double step = ( ( high - low ) / 253.0);
 	// and return result
-	return static_cast<unsigned char>( ( ( data - low ) / step ) + 0.5 );
+	return static_cast<unsigned char>( ( ( data - low ) / step ) + 1.5 );
 }
 
 unsigned char LM_PCM::scale_scea(double data)


### PR DESCRIPTION
The way our scaling function in the PCM classes scales the byte-sized telemetry words is wrong. Not the full 0 to 255 data range of one byte is used. Instead 0 and 255 indicate full scale low and high. Data in the expected range then only goes from 1 to 254. That is illustrated in this example telemetry conversion sheet:

https://i.imgur.com/lqCoC2K.png

At the same time when this get merged our CSM and LM telemetry clients need to be updated to reflect the same scaling.
