### PR TITLE
Prevent PCM from sending out a huge amount of telemetry on the first timestep, if the AGC is unpowered

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -195,7 +195,11 @@ void CSMcomputer::Timestep(double simt, double simdt)
 			// Reset last cycling time
 			LastCycled = 0;
 
-			// We should issue telemetry though.
+			// We should issue telemetry though. Careful with the first timestep
+			if (sat->pcm.last_update == 0)
+			{
+				sat->pcm.last_update = simt - simdt;
+			}
 			sat->pcm.TimeStep(simt);
 			return;
 		}

--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -87,7 +87,6 @@ void CSMcomputer::SetMissionInfo(std::string AGCVersion, char *OtherVessel)
 void CSMcomputer::agcTimestep(double simt, double simdt)
 {
 	// Do single timesteps to maintain sync with telemetry engine
-	SingleTimestepPrep(simt, simdt);        // Setup
 	if (LastCycled == 0) {					// Use simdt as difference if new run
 		LastCycled = (simt - simdt); 
 		sat->pcm.last_update = LastCycled;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
@@ -173,7 +173,11 @@ void LEMcomputer::Timestep(double simt, double simdt)
 		dsky.ClearStby();
 		// Reset last cycling time
 		LastCycled = 0;
-		// We should issue telemetry though.
+		// We should issue telemetry though. Careful with the first timestep
+		if (lem->PCM.last_update == 0)
+		{
+			lem->PCM.last_update = simt - simdt;
+		}
 		lem->PCM.Timestep(simt);
 
 		// and do nothing more.

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
@@ -83,7 +83,6 @@ void LEMcomputer::SetMissionInfo(std::string ProgramName, char *OtherVessel)
 void LEMcomputer::agcTimestep(double simt, double simdt)
 {
 	// Do single timesteps to maintain sync with telemetry engine
-	SingleTimestepPrep(simt, simdt);        // Setup
 	if (LastCycled == 0) {					// Use simdt as difference if new run
 		LastCycled = (simt - simdt);
 		lem->PCM.last_update = LastCycled;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
@@ -51,8 +51,6 @@ ApolloGuidance::ApolloGuidance(SoundLib &s, DSKY &display, IMU &im, CDU &sc, CDU
 
 {
 	Reset = false;
-	CurrentTimestep = 0;
-	LastTimestep = 0;
 	LastCycled = 0;
 	AGCHeat = NULL;
 
@@ -177,14 +175,6 @@ bool ApolloGuidance::OutOfReset()
 	return true;
 }
 
-
-// Do a single timestep - Used by CM to maintain sync between telemetry and vAGC.
-bool ApolloGuidance::SingleTimestepPrep(double simt, double simdt){
-	LastTimestep = CurrentTimestep;
-	CurrentTimestep = simt;
-	return TRUE;
-}
-
 bool ApolloGuidance::SingleTimestep() {
 
 	agc_engine(&vagc);
@@ -194,25 +184,6 @@ bool ApolloGuidance::SingleTimestep() {
 void ApolloGuidance::VirtualAGCCoreDump(char *fileName) {
 
 	MakeCoreDump(&vagc, fileName); 
-}
-
-bool ApolloGuidance::GenericTimestep(double simt, double simdt)
-{
-//	TRACESETUP("COMPUTER TIMESTEP");
-	int i;
-
-	LastTimestep = CurrentTimestep;
-	CurrentTimestep = simt;
-
-	// Physical AGC timing was generated from a master 1024 KHz clock, divided by 12.
-	// This resulted in a machine cycle of just over 11.7 microseconds.
-	int cycles = (long) ((simdt) * 1024000 / 12);
-
-	for (i = 0; i < cycles; i++) {
-		agc_engine(&vagc);
-	}
-
-	return true;
 }
 
 void ApolloGuidance::SystemTimestep(double simdt) 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
@@ -362,9 +362,8 @@ public:
 	// Odds and ends.
 	//
 
-	bool SingleTimestepPrep(double simt, double simdt);
 	bool SingleTimestep();
-	bool GenericTimestep(double simt, double simdt);
+	virtual void agcTimestep(double simt, double simdt) = 0;
 	bool GenericReadMemory(unsigned int loc, int &val);
 	void GenericWriteMemory(unsigned int loc, int val);
 
@@ -394,9 +393,7 @@ public:
 	///
 	std::string ProgramName;
 
-	double LastTimestep;
 	double LastCycled;
-	double CurrentTimestep;
 
 	bool isFirstTimestep;
 


### PR DESCRIPTION
Many timestep functions in NASSP don't use the Orbiter simulation time (counting up from simulation start) but the NASSP mission elapsed time. In most cases this is probably unnecessary, but changing this is a more substantial project. Using the mission time causes a bug for PCM telemetry if the AGC is unpowered, like the LM during translunar coast.

The last_update variable in the PCM class is zero on the first timestep. In the case of high bitrate the following equation is used to determine the number of telemetry cycles:

`tx_size = (int)((simt - last_update) / 0.00015625);`

simt is the mission time, and last_update is zero on the first timestep, so if the AGC has no power then on the first timestep a very large number of telemetry cycles are done. If the mission time is large enough (about 93 hours) this can even lead to an integer overflow. To prevent this, the unpowered AGC code now does a check, which is nearly identical to the one in agcTimestep:

`if (sat->pcm.last_update == 0)
{
  sat->pcm.last_update = simt - simdt;
}`

causing the PCM code to do the right number of cycles for simdt. Probably not the cleanest solution, but I did not want to add any check to the PCM timestep itself, as it can be called many times per timestep with the AGC powered.

Thanks to @TheGondos for finding this bug!

Also included is a bit of cleanup of the apolloguidance class, deleting unused code which I found in this process.