### PR TITLE
Apollo 9 MCC: SPS-1 calculation causesd a CTD if no scenario reload w…

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
@@ -1257,12 +1257,7 @@ int MCC::subThread(){
 		subThreadMacro(subThreadType, subThreadMode);
 		Result = 0;
 	}
-	else if (MissionType == MTP_D)
-	{
-		subThreadMacro(subThreadType, subThreadMode);
-		Result = 0;
-	}
-	else if (MissionType == MTP_F || MissionType == MTP_G || MissionType == MTP_H1)
+	else if (MissionType == MTP_D || MissionType == MTP_F || MissionType == MTP_G || MissionType == MTP_H1)
 	{
 		//Try to find LEM
 		if (rtcc->calcParams.tgt == NULL)


### PR DESCRIPTION
…as done since before CSM separation, as pointer to LM was still null. Make use of code to prevent this issue that was already there, but only used for Apollo 10-12