### PR TITLE
Migration to sketchpad API

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/satswitches.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satswitches.cpp
@@ -588,7 +588,7 @@ void SaturnPartPressCO2Meter::DoDrawSwitch(double v, SURFHANDLE drawSurface)
 		oapiBlt(drawSurface, NeedleSurface, 215, (20 - (int)((v - 20.0) / 10.0 * 14.0)), 10, 0, 10, 10, SURF_PREDEF_CK);
 }
 
-void SaturnRoundMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s)
+void SaturnRoundMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s)
 {
 	RoundMeter::Init(p0, p1, row);
 	Sat = s;
@@ -644,7 +644,7 @@ void SaturnRightO2FlowMeter::DoDrawSwitch(double v, SURFHANDLE drawSurface)
 }
 
 
-void SaturnEcsRadTempInletMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch)
+void SaturnEcsRadTempInletMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch)
 {
 	SaturnRoundMeter::Init(p0, p1, row, s);
 	ECSIndicatorsSwitch = ecsindicatorsswitch;
@@ -690,7 +690,7 @@ void SaturnEcsRadTempSecOutletMeter::DoDrawSwitch(double v, SURFHANDLE drawSurfa
 }
 
 
-void SaturnGlyEvapTempOutletMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch)
+void SaturnGlyEvapTempOutletMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch)
 {
 	SaturnRoundMeter::Init(p0, p1, row, s);
 	ECSIndicatorsSwitch = ecsindicatorsswitch;
@@ -712,7 +712,7 @@ void SaturnGlyEvapTempOutletMeter::DoDrawSwitch(double v, SURFHANDLE drawSurface
 }
 
 
-void SaturnGlyEvapSteamPressMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch)
+void SaturnGlyEvapSteamPressMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch)
 {
 	SaturnRoundMeter::Init(p0, p1, row, s);
 	ECSIndicatorsSwitch = ecsindicatorsswitch;
@@ -734,7 +734,7 @@ void SaturnGlyEvapSteamPressMeter::DoDrawSwitch(double v, SURFHANDLE drawSurface
 }
 
 
-void SaturnGlycolDischPressMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch)
+void SaturnGlycolDischPressMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch)
 {
 	SaturnRoundMeter::Init(p0, p1, row, s);
 	ECSIndicatorsSwitch = ecsindicatorsswitch;
@@ -756,7 +756,7 @@ void SaturnGlycolDischPressMeter::DoDrawSwitch(double v, SURFHANDLE drawSurface)
 }
 
 
-void SaturnAccumQuantityMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch)
+void SaturnAccumQuantityMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch)
 {
 	SaturnRoundMeter::Init(p0, p1, row, s);
 	ECSIndicatorsSwitch = ecsindicatorsswitch;
@@ -778,7 +778,7 @@ void SaturnAccumQuantityMeter::DoDrawSwitch(double v, SURFHANDLE drawSurface)
 }
 
 
-void SaturnH2oQuantityMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, ToggleSwitch *h2oqtyindswitch, PowerSource *pwr)
+void SaturnH2oQuantityMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, ToggleSwitch *h2oqtyindswitch, PowerSource *pwr)
 {
 	SaturnRoundMeter::Init(p0, p1, row, s);
 	H2oQtyIndSwitch = h2oqtyindswitch;
@@ -985,7 +985,7 @@ SaturnDCAmpMeter::SaturnDCAmpMeter(double minVal, double maxVal, double vMin, do
 {
 }
 
-void SaturnDCAmpMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, PowerStateRotationalSwitch *dcindicatorswitch)
+void SaturnDCAmpMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, PowerStateRotationalSwitch *dcindicatorswitch)
 {
 	ElectricMeter::Init(p0, p1, row, dcindicatorswitch);
 	DCIndicatorSwitch = dcindicatorswitch;
@@ -1201,7 +1201,7 @@ void SaturnSPSHeliumNitrogenPressMeter::DoDrawSwitch(double v, SURFHANDLE drawSu
 }
 
 
-void SaturnLVSPSPcMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, ToggleSwitch *lvspspcindicatorswitch, SURFHANDLE frameSurface)
+void SaturnLVSPSPcMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, ToggleSwitch *lvspspcindicatorswitch, SURFHANDLE frameSurface)
 {
 	SaturnRoundMeter::Init(p0, p1, row, s);
 	LVSPSPcIndicatorSwitch = lvspspcindicatorswitch;
@@ -2367,14 +2367,12 @@ void SaturnLMDPGauge::DrawNeedle (SURFHANDLE surf, int x, int y, double rad, dou
 	// This one needs a longer and offset needle
 
 	double dx = rad * cos(angle), dy = rad * sin(angle);
-	HGDIOBJ oldObj;
 
-	HDC hDC = oapiGetDC (surf);
-	oldObj = SelectObject (hDC, Pen1);
-	MoveToEx (hDC, x + (int)(2*dx+0.5), y - (int)(2*dy+0.5), 0); 
-	LineTo (hDC, x + (int)(3*dx+0.5), y - (int)(3*dy+0.5));
-	SelectObject (hDC, oldObj);
-	oapiReleaseDC (surf, hDC);
+	oapi::Sketchpad *skp = oapiGetSketchpad (surf);
+	skp->SetPen(Pen1);
+	skp->MoveTo (x + (int)(2*dx+0.5), y - (int)(2*dy+0.5));
+	skp->LineTo (x + (int)(3*dx+0.5), y - (int)(3*dy+0.5));
+	oapiReleaseSketchpad (skp);
 }
 
 // Right Docking Target Switch
@@ -2504,20 +2502,18 @@ void SaturnAltimeter::Init(SURFHANDLE surf1, SURFHANDLE surf2, Saturn *s) {
 	Sat = s;
 };
 
-void SaturnAltimeter::DrawNeedle(HDC hDC, int x, int y, double rad, double angle, HPEN pen0, HPEN pen1)
+void SaturnAltimeter::DrawNeedle(oapi::Sketchpad* skp, int x, int y, double rad, double angle, oapi::Pen* pen0, oapi::Pen* pen1)
 {
 	//
     //Needle function by Rob Conley from Mercury code
     //
 	double dx = rad * cos(angle), dy = rad * sin(angle);
-	HGDIOBJ oldObj;
 
-	oldObj = SelectObject(hDC, pen1);
-	MoveToEx(hDC, x, y, 0); LineTo(hDC, x + (int)(0.85*dx + 0.5), y - (int)(0.85*dy + 0.5));
-	SelectObject(hDC, oldObj);
-	oldObj = SelectObject(hDC, pen0);
-	MoveToEx(hDC, x, y, 0); LineTo(hDC, x + (int)(dx + 0.5), y - (int)(dy + 0.5));
-	SelectObject(hDC, oldObj);
+	oapi::Pen* oldObj = skp->SetPen(pen1);
+	skp->MoveTo(x, y); skp->LineTo(x + (int)(0.85 * dx + 0.5), y - (int)(0.85 * dy + 0.5));
+	skp->SetPen(pen0);
+	skp->MoveTo(x, y); skp->LineTo(x + (int)(dx + 0.5), y - (int)(dy + 0.5));
+	skp->SetPen(oldObj);
 }
 
 //
@@ -2545,57 +2541,57 @@ void SaturnAltimeter::RedrawPanel_Alt(SURFHANDLE surf)
 		range = 120 * RAD;
 		range = range / 4000;
 		alpha = 4000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha*range) + 150 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha * range) + 150 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else if (alpha > 4001 && alpha < 6001) {
 		range = 35 * RAD;
 		range = range / 2000;
 		alpha = 2000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha*range) + 185 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha * range) + 185 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else if (alpha > 6001 && alpha < 8001) {
 		range = 25 * RAD;
 		range = range / 2000;
 		alpha = 2000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha*range) + 165 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha * range) + 165 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else if (alpha > 8001 && alpha < 10001) {
 		range = 30 * RAD;
 		range = range / 2000;
 		alpha = 2000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha*range) + 180 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha * range) + 180 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else if (alpha > 10001 && alpha < 20001) {
 		range = 45 * RAD;
 		range = range / 10000;
 		alpha = 10000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha*range) + 60 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha * range) + 60 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else if (alpha > 20001 && alpha < 40001) {
 		range = 65 * RAD;
 		range = range / 20000;
 		alpha = 20000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha*range) + 15 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha * range) + 15 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else {
 		range = 20 * RAD;
 		range = range / 10000;
 		alpha = 10000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha*range) + 10 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER_X_CENTER, ALTIMETER_Y_CENTER, ALTIMETER_RADIUS, (alpha * range) + 10 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	oapiBlt(surf, surface1, 0, 0, 0, 0, 137, 137, SURF_PREDEF_CK);
 }
@@ -2619,57 +2615,57 @@ void SaturnAltimeter::RedrawPanel_Alt2(SURFHANDLE surf)
 		range = 120 * RAD;
 		range = range / 4000;
 		alpha = 4000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha*range) + 150 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha * range) + 150 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else if (alpha > 4001 && alpha < 6001) {
 		range = 35 * RAD;
 		range = range / 2000;
 		alpha = 2000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha*range) + 185 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha * range) + 185 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else if (alpha > 6001 && alpha < 8001) {
 		range = 25 * RAD;
 		range = range / 2000;
 		alpha = 2000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha*range) + 165 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha * range) + 165 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else if (alpha > 8001 && alpha < 10001) {
 		range = 20 * RAD;
 		range = range / 2000;
 		alpha = 2000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha*range) + 150 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha * range) + 150 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else if (alpha > 10001 && alpha < 20001) {
 		range = 55 * RAD;
 		range = range / 10000;
 		alpha = 10000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha*range) + 70 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha * range) + 70 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else if (alpha > 20001 && alpha < 40001) {
 		range = 65 * RAD;
 		range = range / 20000;
 		alpha = 20000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha*range) + 15 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha * range) + 15 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	else {
 		range = 20 * RAD;
 		range = range / 10000;
 		alpha = 10000 - alpha;
-		HDC hDC = oapiGetDC(surf);
-		DrawNeedle(hDC, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha*range) + 10 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
-		oapiReleaseDC(surf, hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+		DrawNeedle(skp, ALTIMETER2_X_CENTER, ALTIMETER2_Y_CENTER, ALTIMETER2_RADIUS, (alpha * range) + 10 * RAD, g_Param.pen[1], g_Param.pen[4]);//(alpha * range)
+		oapiReleaseSketchpad(skp);
 	}
 	oapiBlt(surf, surface2, 0, 0, 0, 0, 161, 161, SURF_PREDEF_CK);
 }

--- a/Orbitersdk/samples/ProjectApollo/src_csm/satswitches.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satswitches.h
@@ -262,7 +262,7 @@ public:
 
 class SaturnRoundMeter : public RoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s);
 
 protected:
 	Saturn *Sat;
@@ -298,7 +298,7 @@ public:
 
 class SaturnEcsRadTempInletMeter: public SaturnRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 
@@ -320,7 +320,7 @@ public:
 
 class SaturnGlyEvapTempOutletMeter: public SaturnRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 
@@ -330,7 +330,7 @@ protected:
 
 class SaturnGlyEvapSteamPressMeter: public SaturnRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 
@@ -340,7 +340,7 @@ protected:
 
 class SaturnGlycolDischPressMeter: public SaturnRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 
@@ -350,7 +350,7 @@ protected:
 
 class SaturnAccumQuantityMeter: public SaturnRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, RotationalSwitch *ecsindicatorsswitch);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 
@@ -360,7 +360,7 @@ protected:
 
 class SaturnH2oQuantityMeter: public SaturnRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, ToggleSwitch *h2oqtyindswitch, PowerSource *src);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, ToggleSwitch *h2oqtyindswitch, PowerSource *src);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 
@@ -462,7 +462,7 @@ public:
 	///
 	SaturnDCAmpMeter(double minVal, double maxVal, double vMin = 202.5, double vMax = (-22.5));
 
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, PowerStateRotationalSwitch *dcindicatorswitch);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, PowerStateRotationalSwitch *dcindicatorswitch);
 
 	///
 	/// \brief Query the voltage.
@@ -592,7 +592,7 @@ protected:
 
 class SaturnLVSPSPcMeter : public SaturnRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, Saturn *s, ToggleSwitch *lvspspcindicatorswitch, SURFHANDLE frameSurface);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, Saturn *s, ToggleSwitch *lvspspcindicatorswitch, SURFHANDLE frameSurface);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 
@@ -987,7 +987,7 @@ public:
 	void RedrawPanel_Alt(SURFHANDLE surf);
 	void RedrawPanel_Alt2(SURFHANDLE surf);
 	void DrawSwitchVC(int id, int event, SURFHANDLE surf);
-	void DrawNeedle(HDC hDC, int x, int y, double rad, double angle, HPEN pen0, HPEN pen1);
+	void DrawNeedle(oapi::Sketchpad *skp, int x, int y, double rad, double angle, oapi::Pen *pen0, oapi::Pen *pen1);
 	void DefineVCAnimations(UINT vc_idx);
 
 protected:

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -3999,7 +3999,7 @@ protected:
 	int ReticleLineCnt[2], ReticleLineMaxLen;
 	int *ReticleLineLen[2]; //[SCT=0 | SXT=1]
 	double *ReticleLine[2][2]; //[SCT=0 | SXT=1][X=0 | Y=1]
-	POINT *ReticlePoint;
+	oapi::IVECTOR2 *ReticlePoint;
 
 	double PanelPixelHeight;
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
@@ -4969,7 +4969,7 @@ bool Saturn::clbkPanelRedrawEvent(int id, int event, SURFHANDLE surf)
 		oapi::Brush* whiteBrush = oapiCreateBrush(0xffffff);
 		skp->SetPen(g_Param.pen[6]);
 		skp->SetBrush(whiteBrush);
-		skp->Ellipse(14, 14, 71, 68);
+		skp->Ellipse(14, 14, 71, 69);
 		skp->SetBrush(g_Param.brush[3]);
 		skp->SetPen(g_Param.pen[2]);
 		skp->Polygon(ems.RSITriangle, 3);

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
@@ -215,16 +215,15 @@ void Saturn::InitReticle() {
 		ReticleLine[1][1][i] = std::get<1>(line[i]);
 	}
 
-	ReticlePoint = new POINT[ReticleLineMaxLen];
+	ReticlePoint = new oapi::IVECTOR2[ReticleLineMaxLen];
 	//printf("RetMaxlen:%d\n", ReticleLineMaxLen);
 }
 
-void drawReticle(SURFHANDLE surf, double shaft, double panelPixelHeight, int reticleLineCnt, int reticleLineLen[], double **reticleLine, POINT ptbuf[]) {
-	HGDIOBJ oldObj;
-	HDC hDC = oapiGetDC(surf);
-	HPEN pen = CreatePen(PS_SOLID, 1, RGB(211, 171, 23));
-	oldObj = SelectObject(hDC, pen);
-	double reticleMul = 0.5*panelPixelHeight / tan(oapiCameraAperture());
+void drawReticle(SURFHANDLE surf, double shaft, double panelPixelHeight, int reticleLineCnt, int reticleLineLen[], double **reticleLine, oapi::IVECTOR2 ptbuf[]) {
+	oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+	oapi::Pen* pen = oapiCreatePen(1, 1, RGB(211, 171, 23));
+	skp->SetPen(pen);
+	double reticleMul = 0.5 * panelPixelHeight / tan(oapiCameraAperture());
 	double cosShaft = cos(shaft), sinShaft = sin(shaft);
 	int idx = 0;
 	for (int i = 0; i < reticleLineCnt; i++) {
@@ -234,11 +233,10 @@ void drawReticle(SURFHANDLE surf, double shaft, double panelPixelHeight, int ret
 			ptbuf[k].y = 268L - (LONG (reticleMul*(-sinShaft*xorig + cosShaft*yorig)));
 			idx++;
 		}
-		Polyline(hDC, ptbuf, reticleLineLen[i]);
+		skp->Polyline(ptbuf, reticleLineLen[i]);
 	}
-	SelectObject(hDC, oldObj);
-	DeleteObject(pen);
-	oapiReleaseDC(surf, hDC);
+	oapiReleasePen(pen);
+	oapiReleaseSketchpad(skp);
 }
 
 void setCameraLOS(double shaft, double trunnion) {
@@ -254,18 +252,18 @@ void setCameraLOS(double shaft, double trunnion) {
 
 void Saturn::RedrawPanel_MFDButton(SURFHANDLE surf, int mfd, int side, int xoffset, int yoffset, int ydist) {
 
-	HDC hDC = oapiGetDC (surf);
-	SelectObject (hDC, g_Param.font[2]);
-	SetTextColor (hDC, RGB(196, 196, 196));
-	SetTextAlign (hDC, TA_CENTER);
-	SetBkMode (hDC, TRANSPARENT);
+	oapi::Sketchpad *skp = oapiGetSketchpad(surf);
+	skp->SetFont(g_Param.font[2]);
+	skp->SetTextColor (RGB(196, 196, 196));
+	skp->SetTextAlign(oapi::Sketchpad::CENTER);
+	skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
 	const char *label;
 	for (int bt = 0; bt < 6; bt++) {
 		if (label = oapiMFDButtonLabel (mfd, bt+side*6))
-			TextOut (hDC, 10 + xoffset, 3 + ydist * bt + yoffset, label, strlen(label));
+			skp->Text (10 + xoffset, 3 + ydist * bt + yoffset, label, strlen(label));
 		else break;
 	}
-	oapiReleaseDC (surf, hDC);
+	oapiReleaseSketchpad (skp);
 }
 
 
@@ -3570,20 +3568,20 @@ void SetupgParam(HINSTANCE hModule) {
 	// allocate GDI resources
 	//
 
-	g_Param.font[0]  = CreateFont (-13, 0, 0, 0, 700, 0, 0, 0, 0, 0, 0, 0, 0, "Arial");
-	g_Param.font[1]  = CreateFont (-10, 0, 0, 0, 400, 0, 0, 0, 0, 0, 0, 0, 0, "Arial");
-	g_Param.font[2]  = CreateFont (-8, 0, 0, 0, 400, 0, 0, 0, 0, 0, 0, 0, 0, "Arial");
-	g_Param.brush[0] = CreateSolidBrush (RGB(0,255,0));    // green
-	g_Param.brush[1] = CreateSolidBrush (RGB(255,0,0));    // red
-	g_Param.brush[2] = CreateSolidBrush (RGB(154,154,154));  // Grey
-	g_Param.brush[3] = CreateSolidBrush (RGB(3,3,3));  // Black
-	g_Param.pen[0] = CreatePen (PS_SOLID, 3, RGB(224, 224, 224));
-	g_Param.pen[1] = CreatePen (PS_SOLID, 4, RGB(  0,   0,   0));
-	g_Param.pen[2] = CreatePen (PS_SOLID, 1, RGB(  0,   0,   0));
-	g_Param.pen[3] = CreatePen (PS_SOLID, 3, RGB( 77,  77,  77));
-	g_Param.pen[4] = CreatePen (PS_SOLID, 3, RGB(  0,   0,   0));
-	g_Param.pen[5] = CreatePen (PS_SOLID, 1, RGB(255,   0,   0));
-	g_Param.pen[6] = CreatePen (PS_SOLID, 3, RGB(255, 255, 255));
+	g_Param.font[0] = oapiCreateFont(-13, true, "Arial", FONT_BOLD);
+	g_Param.font[1] = oapiCreateFont(-10, true, "Arial");
+	g_Param.font[2] = oapiCreateFont(-8, true, "Arial");
+	g_Param.brush[0] = oapiCreateBrush (RGB(0,255,0));    // green
+	g_Param.brush[1] = oapiCreateBrush (RGB(255,0,0));    // red
+	g_Param.brush[2] = oapiCreateBrush (RGB(154,154,154));  // Grey
+	g_Param.brush[3] = oapiCreateBrush (RGB(3,3,3));  // Black
+	g_Param.pen[0] = oapiCreatePen (1, 3, RGB(224, 224, 224));
+	g_Param.pen[1] = oapiCreatePen (1, 4, RGB(  0,   0,   0));
+	g_Param.pen[2] = oapiCreatePen (1, 1, RGB(  0,   0,   0));
+	g_Param.pen[3] = oapiCreatePen (1, 3, RGB( 77,  77,  77));
+	g_Param.pen[4] = oapiCreatePen (1, 3, RGB(  0,   0,   0));
+	g_Param.pen[5] = oapiCreatePen (1, 1, RGB(255,   0,   0));
+	g_Param.pen[6] = oapiCreatePen (1, 3, RGB(255, 255, 255));
 }
 
 void DeletegParam() {
@@ -3591,12 +3589,12 @@ void DeletegParam() {
 	int i;
 
 	//
-	// deallocate GDI resources
+	// deallocate sketchpad resources
 	//
 
-	for (i = 0; i < 3; i++) DeleteObject (g_Param.font[i]);
-	for (i = 0; i < 4; i++) DeleteObject (g_Param.brush[i]);
-	for (i = 0; i < 6; i++) DeleteObject (g_Param.pen[i]);
+	for (i = 0; i < 3; i++) oapiReleaseFont(g_Param.font[i]);
+	for (i = 0; i < 4; i++) oapiReleaseBrush(g_Param.brush[i]);
+	for (i = 0; i < 6; i++) oapiReleasePen(g_Param.pen[i]);
 }
 
 bool Saturn::clbkPanelMouseEvent (int id, int event, int mx, int my)
@@ -4936,18 +4934,14 @@ bool Saturn::clbkPanelRedrawEvent(int id, int event, SURFHANDLE surf)
 
 	case AID_EMS_SCROLL_LEO:
 	{
+		oapi::Sketchpad* skp = oapiGetSketchpad(srf[SRF_EMS_SCROLL_LEO]);
 
-		HDC hDC;
+		skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
+		skp->SetPen(g_Param.pen[2]);
 
-		hDC = oapiGetDC(srf[SRF_EMS_SCROLL_LEO]);
+		skp->Polyline(ems.ScribePntArray, ems.ScribePntCnt);
 
-		SetBkMode(hDC, TRANSPARENT);
-		HGDIOBJ oldObj = SelectObject(hDC, g_Param.pen[2]);
-
-		Polyline(hDC, ems.ScribePntArray, ems.ScribePntCnt);
-	
-		SelectObject(hDC, oldObj);
-		oapiReleaseDC(srf[SRF_EMS_SCROLL_LEO], hDC);
+		oapiReleaseSketchpad(skp);
 
 		oapiBlt(surf, srf[SRF_EMS_SCROLL_LEO], 5, 4, ems.GetScrollOffset(), 0, 132, 143);
 		oapiBlt(surf, srf[SRF_EMS_SCROLL_BUG], 42, ems.GetGScribe() + 2, 0, 0, 5, 5, SURF_PREDEF_CK);
@@ -4956,10 +4950,6 @@ bool Saturn::clbkPanelRedrawEvent(int id, int event, SURFHANDLE surf)
 	}
 	case AID_EMS_RSI_BKGRND:
 	{
-		HDC hDC;
-		HGDIOBJ brush = NULL;
-		HGDIOBJ pen = NULL;
-
 		oapiBlt(surf, srf[SRF_EMS_RSI_BKGRND], 0, 0, 0, 0, 86, 84);
 		switch (ems.LiftVectLight()) {
 		case 1:
@@ -4974,15 +4964,16 @@ bool Saturn::clbkPanelRedrawEvent(int id, int event, SURFHANDLE surf)
 			break;
 		}
 
-		hDC = oapiGetDC(srf[SRF_EMS_RSI_BKGRND]);
-		SetBkMode(hDC, TRANSPARENT);
-		pen = SelectObject(hDC, GetStockObject(WHITE_PEN));
-		Ellipse(hDC, 14, 14, 71, 68);
-		brush = SelectObject(hDC, GetStockObject(BLACK_BRUSH));
-		Polygon(hDC, ems.RSITriangle, 3);
-		SelectObject(hDC, pen);
-		SelectObject(hDC, brush);
-		oapiReleaseDC(srf[SRF_EMS_RSI_BKGRND], hDC);
+		oapi::Sketchpad* skp = oapiGetSketchpad(srf[SRF_EMS_RSI_BKGRND]);
+		skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
+		oapi::Brush* whiteBrush = oapiCreateBrush(0xffffff);
+		skp->SetPen(g_Param.pen[6]);
+		skp->SetBrush(whiteBrush);
+		skp->Ellipse(14, 14, 71, 68);
+		skp->SetBrush(g_Param.brush[3]);
+		skp->Polygon(ems.RSITriangle, 3);
+		oapiReleaseBrush(whiteBrush);
+		oapiReleaseSketchpad(skp);
 		return true;
 	}
 	case AID_EMSDVSETSWITCH:		

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
@@ -4971,6 +4971,7 @@ bool Saturn::clbkPanelRedrawEvent(int id, int event, SURFHANDLE surf)
 		skp->SetBrush(whiteBrush);
 		skp->Ellipse(14, 14, 71, 68);
 		skp->SetBrush(g_Param.brush[3]);
+		skp->SetPen(g_Param.pen[2]);
 		skp->Polygon(ems.RSITriangle, 3);
 		oapiReleaseBrush(whiteBrush);
 		oapiReleaseSketchpad(skp);

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -546,7 +546,17 @@ void Saturn::InitVC()
 	srf[SRF_VC_CW_LIGHTS] = oapiLoadTexture("ProjectApollo/VC/cw_lights.dds");
 	srf[SRF_VC_LVENGLIGHTS] = oapiLoadTexture("ProjectApollo/VC/lv_eng.dds");
 	srf[SRF_VC_EVENT_TIMER_DIGITS] = oapiLoadTexture("ProjectApollo/VC/event_timer.dds");
-	srf[SRF_VC_EMS_SCROLL_LEO] = oapiLoadTexture("ProjectApollo/VC/EMSscroll_LEO.dds");
+#if 0
+	srf[SRF_VC_EMS_SCROLL_LEO] = oapiLoadTexture("ProjectApollo/VC/EMSscroll_LEO.dds", true);
+#else
+	// As a workaround for the dynamic flag of oapiLoadTexture being lost on the way,
+	// we create a texture with oapiCreateTextureSurface which will have the correct flags
+	// and then blit the original texture onto it
+	SURFHANDLE tmp = oapiLoadTexture("ProjectApollo/VC/EMSscroll_LEO.dds");
+	srf[SRF_VC_EMS_SCROLL_LEO] = oapiCreateTextureSurface(4096, 256);
+	oapiBlt(srf[SRF_VC_EMS_SCROLL_LEO], tmp, 0, 0, 0, 0, 4096, 256);
+	oapiReleaseTexture(tmp);
+#endif
 	srf[SRF_VC_EMS_SCROLL_BORDER] = oapiLoadTexture("ProjectApollo/VC/EMSscroll_border.dds");
 	srf[SRF_VC_EMS_SCROLL_BUG] = oapiLoadTexture("ProjectApollo/VC/EMSscroll_bug.dds");
 	srf[SRF_VC_EMS_LIGHTS] = oapiLoadTexture("ProjectApollo/VC/ems_lights.dds");

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -1687,18 +1687,14 @@ bool Saturn::clbkVCRedrawEvent (int id, int event, SURFHANDLE surf)
 
 	case AID_VC_EMS_SCROLL_LEO:
 	{
+		oapi::Sketchpad* skp = oapiGetSketchpad(srf[SRF_VC_EMS_SCROLL_LEO]);
 
-		HDC hDC;
+		skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
+		skp->SetPen(g_Param.pen[2]);
 
-		hDC = oapiGetDC(srf[SRF_VC_EMS_SCROLL_LEO]);
+		skp->Polyline(ems.ScribePntArray, ems.ScribePntCnt);
 
-		SetBkMode(hDC, TRANSPARENT);
-		HGDIOBJ oldObj = SelectObject(hDC, g_Param.pen[2]);
-
-		Polyline(hDC, ems.ScribePntArray, ems.ScribePntCnt);
-
-		SelectObject(hDC, oldObj);
-		oapiReleaseDC(srf[SRF_VC_EMS_SCROLL_LEO], hDC);
+		oapiReleaseSketchpad(skp);
 
 		oapiBlt(surf, srf[SRF_VC_EMS_SCROLL_LEO], 5, 4, ems.GetScrollOffset(), 0, 132, 143);
 		oapiBlt(surf, srf[SRF_VC_EMS_SCROLL_BUG], 42, ems.GetGScribe() + 2, 0, 0, 5, 5, SURF_PREDEF_CK);

--- a/Orbitersdk/samples/ProjectApollo/src_csm/scs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/scs.cpp
@@ -5459,7 +5459,8 @@ bool EMS::WriteScrollToFile() {
 
 	// Draw Commands
 	SetBkMode(hMemDC, TRANSPARENT);
-	HGDIOBJ oldObj = SelectObject(hMemDC, g_Param.pen[5]);
+	HPEN redPen = CreatePen(PS_SOLID, 1, RGB(255, 0, 0));
+	HGDIOBJ oldObj = SelectObject(hMemDC, redPen);
 	POINT *points = new POINT[ScribePntCnt];
 	for (int i = 0; i < ScribePntCnt; i++) {
 		points[i].x = ScribePntArray[i].x;
@@ -5472,6 +5473,7 @@ bool EMS::WriteScrollToFile() {
 
 	SelectObject(hMemDC, oldObj);
 	SelectObject(hMemDC, hOld);
+	DeleteObject(redPen);
 
 	PBITMAPINFO bitmapInfo = CreateBitmapInfoStruct(hBitmap);
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/scs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/scs.cpp
@@ -5452,7 +5452,7 @@ bool EMS::WriteScrollToFile() {
 	/////////////////////////////////////////////////////////
     // Get the drawing surface, apply the scribe line and create a corresponding 
     // bitmap with the same dimensions
-
+	
 	HDC hMemDC = CreateCompatibleDC(0);
 	HBITMAP hBitmap = LoadBitmap(g_Param.hDLL, MAKEINTRESOURCE (IDB_EMS_SCROLL_LEO));
 	HGDIOBJ hOld = SelectObject(hMemDC, hBitmap);
@@ -5460,7 +5460,15 @@ bool EMS::WriteScrollToFile() {
 	// Draw Commands
 	SetBkMode(hMemDC, TRANSPARENT);
 	HGDIOBJ oldObj = SelectObject(hMemDC, g_Param.pen[5]);
-	Polyline(hMemDC, ScribePntArray, ScribePntCnt);
+	POINT *points = new POINT[ScribePntCnt];
+	for (int i = 0; i < ScribePntCnt; i++) {
+		points[i].x = ScribePntArray[i].x;
+		points[i].y = ScribePntArray[i].y;
+	}
+
+	Polyline(hMemDC, points, ScribePntCnt);
+
+	delete[] points;
 
 	SelectObject(hMemDC, oldObj);
 	SelectObject(hMemDC, hOld);

--- a/Orbitersdk/samples/ProjectApollo/src_csm/scs.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/scs.h
@@ -834,8 +834,8 @@ public:
 	void LoadState(FILEHANDLE scn);                                // LoadState callback
 
 	double GetdVRangeCounter() { return dVRangeCounter; };
-	POINT ScribePntArray[EMS_SCROLL_LENGTH_PX*3]; //Thrice the number of pixels in the scrolling direction.
-	POINT RSITriangle[3];
+	oapi::IVECTOR2 ScribePntArray[EMS_SCROLL_LENGTH_PX*3]; //Thrice the number of pixels in the scrolling direction.
+	oapi::IVECTOR2 RSITriangle[3];
 	void SetRSIDeltaRotation(double dangle);
 	int ScribePntCnt;
 	int GetScrollOffset() { return ScribePntArray[ScribePntCnt-1].x-40; };

--- a/Orbitersdk/samples/ProjectApollo/src_launch/mccvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/mccvc.cpp
@@ -318,18 +318,18 @@ bool MCCVessel::clbkVCMouseEvent(int id, int event, VECTOR3 &p)
 
 void MCCVessel::RedrawPanel_MFDButton(SURFHANDLE surf, int mfd, int side, int xoffset, int yoffset, int xdist) {
 
-	HDC hDC = oapiGetDC(surf);
-	SelectObject(hDC, g_Param.font[2]);
-	SetTextColor(hDC, RGB(196, 196, 196));
-	SetTextAlign(hDC, TA_CENTER);
-	SetBkMode(hDC, TRANSPARENT);
-	const char *label;
+	oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+	skp->SetFont(g_Param.font[2]);
+	skp->SetTextColor(RGB(196, 196, 196));
+	skp->SetTextAlign(oapi::Sketchpad::CENTER);
+	skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
+	const char* label;
 	for (int bt = 0; bt < 6; bt++) {
 		if (label = oapiMFDButtonLabel(mfd, bt + side * 6))
-			TextOut(hDC, 16 + (xdist * bt) + xoffset, 7 + yoffset, label, strlen(label));
+			skp->Text(16 + (xdist * bt) + xoffset, 7 + yoffset, label, strlen(label));
 		else break;
 	}
-	oapiReleaseDC(surf, hDC);
+	oapiReleaseSketchpad(skp);
 }
 
 void MCCVessel::clbkMFDMode(int mfd, int mode)

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lempanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lempanel.cpp
@@ -52,19 +52,19 @@ void InitGParam(HINSTANCE hModule)
 	g_Param.hDLL = hModule;
 
 	// allocate GDI resources
-	g_Param.font[0]  = CreateFont (-13, 0, 0, 0, 700, 0, 0, 0, 0, 0, 0, 0, 0, "Arial");
-	g_Param.font[1]  = CreateFont (-10, 0, 0, 0, 400, 0, 0, 0, 0, 0, 0, 0, 0, "Arial");
+	g_Param.font[0]  = oapiCreateFont(-13, true, "Arial");
+	g_Param.font[1]  = oapiCreateFont(-10, true, "Arial");
 
-	g_Param.brush[0] = CreateSolidBrush (RGB(0,255,0));    // green
-	g_Param.brush[1] = CreateSolidBrush (RGB(255,0,0));    // red
-	g_Param.brush[2] = CreateSolidBrush (RGB(154,154,154));  // Grey
-	g_Param.brush[3] = CreateSolidBrush (RGB(3,3,3));  // Black
+	g_Param.brush[0] = oapiCreateBrush(RGB(0,255,0));    // green
+	g_Param.brush[1] = oapiCreateBrush(RGB(255,0,0));    // red
+	g_Param.brush[2] = oapiCreateBrush(RGB(154,154,154));  // Grey
+	g_Param.brush[3] = oapiCreateBrush(RGB(3,3,3));  // Black
 
-	g_Param.pen[0] = CreatePen (PS_SOLID, 1, RGB(224,224,224));
-	g_Param.pen[1] = CreatePen (PS_SOLID, 3, RGB(164,164,164));
-	g_Param.pen[2] = CreatePen (PS_SOLID, 1, RGB(255,0,0));
-	g_Param.pen[3] = CreatePen (PS_SOLID, 3, RGB(255,0,0));
-	g_Param.pen[4] = CreatePen (PS_SOLID, 3, RGB(0,0,0));
+	g_Param.pen[0] = oapiCreatePen(1, 1, RGB(224,224,224));
+	g_Param.pen[1] = oapiCreatePen(1, 3, RGB(164,164,164));
+	g_Param.pen[2] = oapiCreatePen(1, 1, RGB(255,0,0));
+	g_Param.pen[3] = oapiCreatePen(1, 3, RGB(255,0,0));
+	g_Param.pen[4] = oapiCreatePen(1, 3, RGB(0,0,0));
 
 	g_Param.col[2] = oapiGetColour(154,154,154);
 	g_Param.col[3] = oapiGetColour(3,3,3);
@@ -75,10 +75,10 @@ void FreeGParam()
 
 {
 	int i;
-	// deallocate GDI resources
-	for (i = 0; i < 2; i++) DeleteObject (g_Param.font[i]);
-	for (i = 0; i < 4; i++) DeleteObject (g_Param.brush[i]);
-	for (i = 0; i < 4; i++) DeleteObject (g_Param.pen[i]);
+	// deallocate sketchpad resources
+	for (i = 0; i < 2; i++) oapiReleaseFont(g_Param.font[i]);
+	for (i = 0; i < 4; i++) oapiReleaseBrush(g_Param.brush[i]);
+	for (i = 0; i < 4; i++) oapiReleasePen(g_Param.pen[i]);
 }
 
 #define RETICLE_X_CENTER 525
@@ -87,66 +87,64 @@ void FreeGParam()
 #define RETICLE_SPLIT_ANGLE 0.05 // about 2.25 degrees
 #define RETICLE_SCREW_NPTS 360
 
-void DrawReticle (HDC hDC, double angle, int dimmer)
+void DrawReticle(oapi::Sketchpad * skp, double angle, int dimmer)
 {
-	HGDIOBJ oldObj;
-	int xend,yend;
+	int xend, yend;
 	// Set up Dimmer Pen
-	HPEN pen = CreatePen(PS_SOLID,1,RGB(dimmer,64,64));
-	oldObj = SelectObject (hDC, pen);
+	oapi::Pen* pen = oapiCreatePen(1, 1, RGB(dimmer, 64, 64));
+	oapi::Pen* oldObj = skp->SetPen(pen);
 	// Draw crosshair vertical member
 	xend = RETICLE_X_CENTER - (int)(RETICLE_RADIUS * sin(angle));
 	yend = RETICLE_Y_CENTER - (int)(RETICLE_RADIUS * cos(angle));
-	MoveToEx (hDC, RETICLE_X_CENTER, RETICLE_Y_CENTER, 0); LineTo(hDC, xend, yend);
-	xend = RETICLE_X_CENTER - (int)(RETICLE_RADIUS * sin(angle+PI));
-	yend = RETICLE_Y_CENTER - (int)(RETICLE_RADIUS * cos(angle+PI));
-	MoveToEx (hDC, RETICLE_X_CENTER, RETICLE_Y_CENTER, 0); LineTo(hDC, xend, yend);
+	skp->MoveTo(RETICLE_X_CENTER, RETICLE_Y_CENTER); skp->LineTo(xend, yend);
+	xend = RETICLE_X_CENTER - (int)(RETICLE_RADIUS * sin(angle + PI));
+	yend = RETICLE_Y_CENTER - (int)(RETICLE_RADIUS * cos(angle + PI));
+	skp->MoveTo(RETICLE_X_CENTER, RETICLE_Y_CENTER); skp->LineTo(xend, yend);
 	// Draw crosshair horizontal member
 	xend = RETICLE_X_CENTER - (int)(RETICLE_RADIUS * cos(angle));
 	yend = RETICLE_Y_CENTER + (int)(RETICLE_RADIUS * sin(angle));
-	MoveToEx (hDC, RETICLE_X_CENTER, RETICLE_Y_CENTER, 0); LineTo(hDC, xend, yend);
-	xend = RETICLE_X_CENTER - (int)(RETICLE_RADIUS * cos(angle+PI));
-	yend = RETICLE_Y_CENTER + (int)(RETICLE_RADIUS * sin(angle+PI));
-	MoveToEx (hDC, RETICLE_X_CENTER, RETICLE_Y_CENTER, 0); LineTo(hDC, xend, yend);
+	skp->MoveTo(RETICLE_X_CENTER, RETICLE_Y_CENTER); skp->LineTo(xend, yend);
+	xend = RETICLE_X_CENTER - (int)(RETICLE_RADIUS * cos(angle + PI));
+	yend = RETICLE_Y_CENTER + (int)(RETICLE_RADIUS * sin(angle + PI));
+	skp->MoveTo(RETICLE_X_CENTER, RETICLE_Y_CENTER); skp->LineTo(xend, yend);
 	// Draw radial line #1
 	xend = RETICLE_X_CENTER - (int)(RETICLE_RADIUS * sin(angle + RETICLE_SPLIT_ANGLE));
 	yend = RETICLE_Y_CENTER - (int)(RETICLE_RADIUS * cos(angle + RETICLE_SPLIT_ANGLE));
-	MoveToEx (hDC, RETICLE_X_CENTER, RETICLE_Y_CENTER, 0); LineTo(hDC, xend, yend);
+	skp->MoveTo(RETICLE_X_CENTER, RETICLE_Y_CENTER); skp->LineTo(xend, yend);
 	// Draw radial line #2
 	xend = RETICLE_X_CENTER - (int)(RETICLE_RADIUS * sin(angle - RETICLE_SPLIT_ANGLE));
 	yend = RETICLE_Y_CENTER - (int)(RETICLE_RADIUS * cos(angle - RETICLE_SPLIT_ANGLE));
-	MoveToEx (hDC, RETICLE_X_CENTER, RETICLE_Y_CENTER, 0); LineTo(hDC, xend, yend);
+	skp->MoveTo(RETICLE_X_CENTER, RETICLE_Y_CENTER); skp->LineTo(xend, yend);
 	int i;
-	double theta,b, r;
-	b = -RETICLE_RADIUS / tan(PI2*30.0 / 360.0);
-	POINT ScrewPt[RETICLE_SCREW_NPTS];
+	double theta, b, r;
+	b = -RETICLE_RADIUS / tan(PI2 * 30.0 / 360.0);
+	oapi::IVECTOR2 ScrewPt[RETICLE_SCREW_NPTS];
 	// Draw Archemedes screw #1
-	for (i = 0; i < RETICLE_SCREW_NPTS; i++){
-		theta = 2*PI / RETICLE_SCREW_NPTS * i;
-		r = b * tan(theta*30.0 / 360.0);
-		ScrewPt[i].x = RETICLE_X_CENTER - (int)(r*sin(theta+angle+RETICLE_SPLIT_ANGLE+PI));
-		ScrewPt[i].y = RETICLE_Y_CENTER - (int)(r*cos(theta+angle+RETICLE_SPLIT_ANGLE+PI));
+	for (i = 0; i < RETICLE_SCREW_NPTS; i++) {
+		theta = 2 * PI / RETICLE_SCREW_NPTS * i;
+		r = b * tan(theta * 30.0 / 360.0);
+		ScrewPt[i].x = RETICLE_X_CENTER - (int)(r * sin(theta + angle + RETICLE_SPLIT_ANGLE + PI));
+		ScrewPt[i].y = RETICLE_Y_CENTER - (int)(r * cos(theta + angle + RETICLE_SPLIT_ANGLE + PI));
 	}
-	Polyline (hDC, ScrewPt, RETICLE_SCREW_NPTS);
+	skp->Polyline(ScrewPt, RETICLE_SCREW_NPTS);
 	// Draw Archemedes screw #2
-	for (i = 0; i < RETICLE_SCREW_NPTS; i++){
-		theta = 2*PI / RETICLE_SCREW_NPTS * i;
-		r = b * tan(theta*30.0 / 360.0);
-		ScrewPt[i].x = RETICLE_X_CENTER - (int)(r*sin(theta+angle-RETICLE_SPLIT_ANGLE+PI));
-		ScrewPt[i].y = RETICLE_Y_CENTER - (int)(r*cos(theta+angle-RETICLE_SPLIT_ANGLE+PI));
+	for (i = 0; i < RETICLE_SCREW_NPTS; i++) {
+		theta = 2 * PI / RETICLE_SCREW_NPTS * i;
+		r = b * tan(theta * 30.0 / 360.0);
+		ScrewPt[i].x = RETICLE_X_CENTER - (int)(r * sin(theta + angle - RETICLE_SPLIT_ANGLE + PI));
+		ScrewPt[i].y = RETICLE_Y_CENTER - (int)(r * cos(theta + angle - RETICLE_SPLIT_ANGLE + PI));
 	}
-	Polyline (hDC, ScrewPt, RETICLE_SCREW_NPTS);
+	skp->Polyline(ScrewPt, RETICLE_SCREW_NPTS);
 
-	SelectObject(hDC, oldObj);
-	DeleteObject(pen);
+	skp->SetPen(oldObj);
+	oapiReleasePen(pen);
 }
 
 void LEM::RedrawPanel_AOTReticle(SURFHANDLE surf)
 {
-	HDC hDC = oapiGetDC (surf);
-	DrawReticle (hDC, optics.OpticsReticle, optics.RetDimmer);
-	oapiReleaseDC (surf,hDC);
-
+	oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+	DrawReticle(skp, optics.OpticsReticle, optics.RetDimmer);
+	oapiReleaseSketchpad(skp);
 }
 
 
@@ -1006,7 +1004,7 @@ void LEM::InitSwitches() {
 
 void LEM::RedrawPanel_Horizon (SURFHANDLE surf)
 {
-POINT pt[4];
+	oapi::IVECTOR2 pt[4];
 	static double prange = RAD*30.0;
 	static int size = 48, size2 = size*2;
 	static int extent = (int)(size*prange);
@@ -1092,24 +1090,24 @@ POINT pt[4];
 	}
 	if (!n) bblue = (pitch < 0.0);
 	oapiClearSurface (surf, bblue ? g_Param.col[3]:g_Param.col[2]);
-	HDC hDC = oapiGetDC (surf);
-	SelectObject (hDC, GetStockObject (BLACK_PEN));
+	oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+	skp->SetPen(g_Param.pen[4]); //pen 4 is black
 	if (n >= 3) {
-		SelectObject (hDC, g_Param.brush[bblue ? 2:3]);
-		Polygon (hDC, pt, n);
-		SelectObject (hDC, g_Param.pen[0]);
-		MoveToEx (hDC, pt[0].x, pt[0].y, NULL); LineTo (hDC, pt[1].x, pt[1].y);
+		skp->SetBrush(g_Param.brush[bblue ? 2 : 3]);
+		skp->Polygon(pt, n);
+		skp->SetPen(g_Param.pen[0]);
+		skp->MoveTo(pt[0].x, pt[0].y); skp->LineTo(pt[1].x, pt[1].y);
 	}
 	// bank indicator
-	SelectObject (hDC, g_Param.pen[0]);
-	SelectObject (hDC, GetStockObject (NULL_BRUSH));
+	skp->SetPen(g_Param.pen[0]);
+	//SelectObject (hDC, GetStockObject (NULL_BRUSH)); //FIXME
 	static double r1 = 40, r2 = 35;
-	double sinb1 = sin(bank-0.1), cosb1 = cos(bank-0.1);
-	double sinb2 = sin(bank+0.1), cosb2 = cos(bank+0.1);
-	pt[0].x = (int)(r2*sinb1+0.5)+size; pt[0].y = -(int)(r2*cosb1+0.5)+size;
-	pt[1].x = (int)(r1*sinb+0.5)+size;  pt[1].y = -(int)(r1*cosb+0.5)+size;
-	pt[2].x = (int)(r2*sinb2+0.5)+size; pt[2].y = -(int)(r2*cosb2+0.5)+size;
-	Polygon (hDC, pt, 3);
+	double sinb1 = sin(bank - 0.1), cosb1 = cos(bank - 0.1);
+	double sinb2 = sin(bank + 0.1), cosb2 = cos(bank + 0.1);
+	pt[0].x = (int)(r2 * sinb1 + 0.5) + size; pt[0].y = -(int)(r2 * cosb1 + 0.5) + size;
+	pt[1].x = (int)(r1 * sinb + 0.5) + size;  pt[1].y = -(int)(r1 * cosb + 0.5) + size;
+	pt[2].x = (int)(r2 * sinb2 + 0.5) + size; pt[2].y = -(int)(r2 * cosb2 + 0.5) + size;
+	skp->Polygon(pt, 3);
 
 	// pitch ladder
 	static double d = size*(10.0*RAD)/prange;
@@ -1123,13 +1121,13 @@ POINT pt[4];
 	ylr = lwsina+d1*cosb, yll = -lwsina+d1*cosb;
 	for (iphi = (int)phi0+4, i = 0; i < 8; i++, iphi--) {
 		if (iphi) {
-			MoveToEx (hDC, size+(int)xll, size+(int)yll, NULL);
-			LineTo   (hDC, size+(int)xlr, size+(int)ylr);
+			skp->MoveTo(size + (int)xll, size + (int)yll);
+			skp->LineTo(size + (int)xlr, size + (int)ylr);
 		}
 		xlr -= dsinb, ylr += dcosb;
 		xll -= dsinb, yll += dcosb;
 	}
-	oapiReleaseDC (surf, hDC);
+	oapiReleaseSketchpad(skp);
 	// labels
 	lwcosa *= 1.6, lwsina *= 1.6;
 	xlr = lwcosa-d1*sinb, xll = -lwcosa-d1*sinb;
@@ -1149,59 +1147,54 @@ POINT pt[4];
 	// oapiBlt (surf, srf[5], 0, 0, 0, 0, 96, 96, SURF_PREDEF_CK);
 }
 
-void DrawNeedle (HDC hDC, int x, int y, double rad, double angle, HPEN pen0, HPEN pen1)
+void DrawNeedle(oapi::Sketchpad* skp, int x, int y, double rad, double angle, oapi::Pen* pen0, oapi::Pen* pen1)
 
 {
 	double dx = rad * cos(angle), dy = rad * sin(angle);
-	HGDIOBJ oldObj;
-	oldObj = SelectObject (hDC, pen1);
-	MoveToEx (hDC, x, y, 0); LineTo (hDC, x + (int)(0.85*dx+0.5), y - (int)(0.85*dy+0.5));
-	SelectObject (hDC, oldObj);
-	oldObj = SelectObject (hDC, pen0);
-	MoveToEx (hDC, x, y, 0); LineTo (hDC, x + (int)(dx+0.5), y - (int)(dy+0.5));
-	SelectObject (hDC, oldObj);
+	oapi::Pen* oldPen = skp->SetPen(pen1);
+	skp->MoveTo(x, y); skp->LineTo(x + (int)(0.85 * dx + 0.5), y - (int)(0.85 * dy + 0.5));
+	skp->SetPen(pen0);
+	skp->MoveTo(x, y); skp->LineTo(x + (int)(dx + 0.5), y - (int)(dy + 0.5));
+	skp->SetPen(oldPen);
 }
 
-void LEM::RedrawPanel_XPointer (CrossPointer *cp, SURFHANDLE surf) {
+void LEM::RedrawPanel_XPointer(CrossPointer* cp, SURFHANDLE surf) {
 
 	int ix, iy;
 	double vx, vy;
-	HDC hDC;
 
 	//draw the crosspointers
 	cp->GetVelocities(vx, vy);
 
 	ix = (int)(-3.0 * vx);
-	if(ix < -60) ix = -60;
-	if(ix > 60) ix = 60;
+	if (ix < -60) ix = -60;
+	if (ix > 60) ix = 60;
 	iy = (int)(3.0 * vy);
-	if(iy < -60) iy = -60;
-	if(iy > 60 ) iy = 60;
-	hDC = oapiGetDC(surf);
-	HPEN pen = CreatePen(PS_SOLID, 3, RGB(0, 0, 0));
-	SelectObject(hDC, pen);
-	MoveToEx(hDC, 0, 65 + ix, NULL);
-	LineTo(hDC, 134, 65 + ix);
-	MoveToEx(hDC, 67 + iy, 0, NULL);
-	LineTo(hDC, 67 + iy, 131);
-	DeleteObject(pen);
-	oapiReleaseDC(surf, hDC);
+	if (iy < -60) iy = -60;
+	if (iy > 60) iy = 60;
+	oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+	skp->SetPen(g_Param.pen[4]);
+	skp->MoveTo(0, 65 + ix);
+	skp->LineTo(134, 65 + ix);
+	skp->MoveTo(67 + iy, 0);
+	skp->LineTo(67 + iy, 131);
+	oapiReleaseSketchpad(skp);
 }
 
 void LEM::RedrawPanel_MFDButton(SURFHANDLE surf, int mfd, int side, int xoffset, int yoffset) {
 
-	HDC hDC = oapiGetDC (surf);
-	SelectObject (hDC, g_Param.font[1]);
-	SetTextColor (hDC, RGB(255, 255, 255));
-	SetTextAlign (hDC, TA_CENTER);
-	SetBkMode (hDC, TRANSPARENT);
-	const char *label;
+	oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+	skp->SetFont(g_Param.font[1]);
+	skp->SetTextColor(oapiGetColour(255, 255, 255));
+	skp->SetTextAlign(oapi::Sketchpad::CENTER);
+	skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
+	const char* label;
 	for (int bt = 0; bt < 6; bt++) {
-		if (label = oapiMFDButtonLabel (mfd, bt+side*6))
-			TextOut (hDC, xoffset, 44 * bt + yoffset, label, strlen(label));
+		if (label = oapiMFDButtonLabel(mfd, bt + side * 6))
+			skp->Text(xoffset, 44 * bt + yoffset, label, strlen(label));
 		else break;
 	}
-	oapiReleaseDC (surf, hDC);
+	oapiReleaseSketchpad(skp);
 }
 
 void LEM::clbkMFDMode (int mfd, int mode) {

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemswitches.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemswitches.cpp
@@ -1149,7 +1149,7 @@ bool LGCThrusterPairSwitch::SwitchTo(int newState, bool dontspring)
 }
 
 // Meters
-void LEMRoundMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s)
+void LEMRoundMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s)
 
 {
 	RoundMeter::Init(p0, p1, row);
@@ -1158,7 +1158,7 @@ void LEMRoundMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s)
 
 // DC Voltmeter
 
-void LEMDCVoltMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface)
+void LEMDCVoltMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface)
 {
 	LEMRoundMeter::Init(p0, p1, row, s);
 	FrameSurface = frameSurface;
@@ -1222,7 +1222,7 @@ void LEMDCVoltMeter::DoDrawSwitchVC(UINT anim) {
 
 // DC Ammeter
 
-void LEMDCAmMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface)
+void LEMDCAmMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface)
 {
 	LEMRoundMeter::Init(p0, p1, row, s);
 	FrameSurface = frameSurface;
@@ -1693,7 +1693,7 @@ double RadarSignalStrengthAttenuator::GetValue()
 	return val;
 }
 
-void LEMSteerableAntennaPitchMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface)
+void LEMSteerableAntennaPitchMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface)
 {
 	LEMRoundMeter::Init(p0, p1, row, s);
 	FrameSurface = frameSurface;
@@ -1714,7 +1714,7 @@ void LEMSteerableAntennaPitchMeter::DoDrawSwitchVC(UINT anim) {
 	lem->SetAnimation(anim, v);
 }
 
-void LEMSteerableAntennaYawMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface)
+void LEMSteerableAntennaYawMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface)
 {
 	LEMRoundMeter::Init(p0, p1, row, s);
 	FrameSurface = frameSurface;
@@ -1735,7 +1735,7 @@ void LEMSteerableAntennaYawMeter::DoDrawSwitchVC(UINT anim) {
 	lem->SetAnimation(anim, (v + 0.56) * 0.47);
 }
 
-void LEMSBandAntennaStrengthMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface)
+void LEMSBandAntennaStrengthMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface)
 {
 	LEMRoundMeter::Init(p0, p1, row, s);
 	FrameSurface = frameSurface;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemswitches.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemswitches.h
@@ -78,7 +78,7 @@ class LEMVoltCB: public CircuitBrakerSwitch {
 // Meters
 class LEMRoundMeter : public RoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s);
 
 protected:
 	LEM *lem;
@@ -86,7 +86,7 @@ protected:
 
 class LEMDCVoltMeter: public LEMRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 	void DoDrawSwitchVC(UINT anim);
@@ -99,7 +99,7 @@ protected:
 
 class LEMDCAmMeter: public LEMRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 	void DoDrawSwitchVC(UINT anim);
@@ -484,7 +484,7 @@ protected:
 
 class LEMSteerableAntennaPitchMeter : public LEMRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 	void DoDrawSwitchVC(UINT anim);
@@ -494,7 +494,7 @@ protected:
 
 class LEMSteerableAntennaYawMeter : public LEMRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 	void DoDrawSwitchVC(UINT anim);
@@ -504,7 +504,7 @@ protected:
 
 class LEMSBandAntennaStrengthMeter : public LEMRoundMeter {
 public:
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, LEM *s, SURFHANDLE frameSurface);
 	double QueryValue();
 	void DoDrawSwitch(double v, SURFHANDLE drawSurface);
 	void DoDrawSwitchVC(UINT anim);

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
@@ -787,8 +787,8 @@ bool ProjectApolloChecklistMFD::Update (oapi::Sketchpad* skp)
 	oapi::Brush *hBr;
 
 	SURFHANDLE s = skp->GetSurface();
-	RECT src{0, 0, 256, 256};
-	RECT dst{1, 1, width - 2, height - 2 };
+	RECT src{ 0, 0, 256, 256 };
+	RECT dst{ 1, 1, (LONG)width - 2, (LONG)height - 2 };
 	oapiBlt(s, hLogo, &dst, &src);
 
 	// Retrieve Checklists

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
@@ -787,7 +787,7 @@ bool ProjectApolloChecklistMFD::Update (oapi::Sketchpad* skp)
 	oapi::Brush *hBr;
 
 	SURFHANDLE s = skp->GetSurface();
-	RECT src{ 0, 0, 256, 256 };
+	RECT src{ 0, 0, 255, 255 };
 	RECT dst{ 1, 1, (LONG)width - 2, (LONG)height - 2 };
 	oapiBlt(s, hLogo, &dst, &src);
 
@@ -815,7 +815,7 @@ bool ProjectApolloChecklistMFD::Update (oapi::Sketchpad* skp)
 		}
 
 		skp->SetTextAlign(oapi::Sketchpad::LEFT);
-		skp->SetPen(GetDefaultPen(1));
+		skp->SetPen(GetDefaultPen(0));
 		skp->MoveTo((int)(width * 0.02), (int)(height * 0.94));
 		skp->LineTo((int)(width * 0.98), (int)(height * 0.94));
 
@@ -983,7 +983,7 @@ bool ProjectApolloChecklistMFD::Update (oapi::Sketchpad* skp)
 			skp->Text((int)(width * .5), (int)(height * 0.05), line.c_str(), line.size());
 		}
 
-		skp->SetPen(GetDefaultPen(1));
+		skp->SetPen(GetDefaultPen(0));
 		skp->MoveTo((int)(width * 0.02), (int)(height * 0.94));
 		skp->LineTo((int)(width * 0.98), (int)(height * 0.94));
 
@@ -1188,7 +1188,7 @@ bool ProjectApolloChecklistMFD::Update (oapi::Sketchpad* skp)
 			skp->SetBrush(oldBrush);
 			skp->SetPen(oldPen);
 			oapiReleaseBrush(hBr);
-			skp->SetPen(GetDefaultPen(1));
+			skp->SetPen(GetDefaultPen(0));
 			skp->MoveTo((int)(width * 0.02), (int)(height * 0.94));
 			skp->LineTo((int)(width * 0.98), (int)(height * 0.94));
 			skp->SetFont(GetDefaultFont(0));

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
@@ -95,7 +95,7 @@ void ProjectApolloChecklistMFDopcDLLExit (HINSTANCE hDLL)
 void ProjectApolloChecklistMFDopcTimestep (double simt, double simdt, double mjd)
 {
 }
-ProjectApolloChecklistMFD::ProjectApolloChecklistMFD (DWORD w, DWORD h, VESSEL *vessel) : MFD (w,h,vessel)
+ProjectApolloChecklistMFD::ProjectApolloChecklistMFD (DWORD w, DWORD h, VESSEL *vessel) : MFD2 (w,h,vessel)
 {
 	saturn = NULL;
 	crawler = NULL;
@@ -129,7 +129,8 @@ ProjectApolloChecklistMFD::ProjectApolloChecklistMFD (DWORD w, DWORD h, VESSEL *
 			lem = (LEM *)vessel;
 	}
 
-	hBmpLogo = LoadBitmap(g_hDLL, MAKEINTRESOURCE (IDB_LOGO));
+	HBITMAP hBmpLogo = LoadBitmap(g_hDLL, MAKEINTRESOURCE (IDB_LOGO));
+	hLogo = oapiCreateSurface(hBmpLogo);
 }
 
 ProjectApolloChecklistMFD::~ProjectApolloChecklistMFD ()
@@ -780,17 +781,15 @@ void ProjectApolloChecklistMFD::substituteVariables(char *buffer,int buflen) {
 	}
 }
 
-void ProjectApolloChecklistMFD::Update (HDC hDC)
+bool ProjectApolloChecklistMFD::Update (oapi::Sketchpad* skp)
 {
-	static RECT ShadedBox;
 	ChecklistItem *item;
-	HBRUSH hBr;
+	oapi::Brush *hBr;
 
-	HDC hDCTemp = CreateCompatibleDC(hDC);
-	HBITMAP hBmpTemp = (HBITMAP) SelectObject(hDCTemp, hBmpLogo);
-	StretchBlt(hDC, 1, 1, width - 2, height - 2, hDCTemp, 0, 0, 256, 256, SRCCOPY);
-	DeleteObject(hBmpTemp);
-	DeleteDC(hDCTemp);
+	SURFHANDLE s = skp->GetSurface();
+	RECT src{0, 0, 256, 256};
+	RECT dst{1, 1, width - 2, height - 2 };
+	oapiBlt(s, hLogo, &dst, &src);
 
 	// Retrieve Checklists
 	vector<ChecklistGroup> *temp = conn.GetChecklistList();
@@ -801,36 +800,36 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 
 	if (screen == PROG_CHKLST)
 	{
-		SelectDefaultFont(hDC, 0);
+		skp->SetFont(GetDefaultFont(0));
 		char *cn = conn.checklistName();
 		if (cn)
-			Title(hDC, cn);
+			Title(skp, cn);
 		
 		// Display the MET after the header
 		if (bDisplayMET)
 		{
-			SetTextColor (hDC, RGB(225, 225, 255)); // blue 
-			SetTextAlign (hDC, TA_CENTER);
+			skp->SetTextColor(RGB(225, 225, 255)); // blue 
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
 			line = DisplayMissionElapsedTime();
-			TextOut(hDC, (int) (width * .5), (int) (height * 0.05), line.c_str(), line.size());
+			skp->Text((int)(width * .5), (int)(height * 0.05), line.c_str(), line.size());
 		}
 
-		SetTextAlign (hDC, TA_LEFT);
-		SelectDefaultPen(hDC, 1);
-		MoveToEx (hDC, (int) (width * 0.02), (int) (height * 0.94), 0);
-		LineTo (hDC, (int) (width * 0.98), (int) (height * 0.94));
+		skp->SetTextAlign(oapi::Sketchpad::LEFT);
+		skp->SetPen(GetDefaultPen(1));
+		skp->MoveTo((int)(width * 0.02), (int)(height * 0.94));
+		skp->LineTo((int)(width * 0.98), (int)(height * 0.94));
 
 		// Display bottom flag row
 		bool autocomplete = conn.ChecklistAutocomplete();
 		bool autoexec = conn.GetAutoExecute();
 		bool flash = conn.GetChecklistFlashing();
-		SetTextColor(hDC, RGB(0, 255, 0));
-		SetTextAlign(hDC, TA_LEFT);
-		TextOut(hDC, (int)(width * 0.05), (int)(height * .95), autocomplete ? "AUTO: ON " : "AUTO: OFF", strlen("AUTO: OFF"));
-		SetTextAlign(hDC, TA_CENTER);
-		TextOut(hDC, width / 2, (int)(height * .95), autoexec ? "EXEC: ON " : "EXEC: OFF", strlen("EXEC: OFF"));
-		SetTextAlign(hDC, TA_RIGHT);
-		TextOut(hDC, width - (int)(width * 0.05), (int)(height * .95), flash ? "FLASH: ON " : "FLASH: OFF", strlen("FLASH: OFF"));
+		skp->SetTextColor(RGB(0, 255, 0));
+		skp->SetTextAlign(oapi::Sketchpad::LEFT);
+		skp->Text((int)(width * 0.05), (int)(height * .95), autocomplete ? "AUTO: ON " : "AUTO: OFF", strlen("AUTO: OFF"));
+		skp->SetTextAlign(oapi::Sketchpad::CENTER);
+		skp->Text(width / 2, (int)(height * .95), autoexec ? "EXEC: ON " : "EXEC: OFF", strlen("EXEC: OFF"));
+		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
+		skp->Text(width - (int)(width * 0.05), (int)(height * .95), flash ? "FLASH: ON " : "FLASH: OFF", strlen("FLASH: OFF"));
 
 		//Retrieve 15 visible checklist steps  (all are displayed on two lines)
 		//Lines 1,2,3,4,5,6,7,8,9 (index 0/1,2/3,4/5,6/7,8/9,10/11,12/13,14/15,16/17)
@@ -846,9 +845,9 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 					if (StepCnt != 0)
 						cnt++; //go to next line
 					if (cnt >= 20) break;
-					SetTextColor(hDC,RGB(225, 225, 255)); 
-					SetTextAlign (hDC, TA_CENTER);
-					TextOut(hDC, (int) (width * .5), (int) (height * (LINE0+cnt*HLINE)), item->heading1, strlen(item->heading1));
+					skp->SetTextColor(RGB(225, 225, 255));
+					skp->SetTextAlign(oapi::Sketchpad::CENTER);
+					skp->Text((int)(width * .5), (int)(height * (LINE0 + cnt * HLINE)), item->heading1, strlen(item->heading1));
 					cnt++;
 					cnt++; //go to next line to write information
 				}
@@ -859,11 +858,11 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 					if (strlen(item->heading1) == 0 && StepCnt != 0 && !linebreakpanel)
 						cnt++; //go to next line
 					if (cnt >= 20) break;
-					SetTextColor(hDC,RGB(225, 225, 255)); 
-					SetTextAlign (hDC, TA_LEFT);
+					skp->SetTextColor(RGB(225, 225, 255));
+					skp->SetTextAlign(oapi::Sketchpad::LEFT);
 					//display Current Checklist Mission Time
 					line = DisplayChecklistMissionTime(item);
-					TextOut(hDC, (int) (width * .01), (int) (height * (LINE0+cnt*HLINE)), line.c_str(), line.size());
+					skp->Text((int)(width * .01), (int)(height * (LINE0 + cnt * HLINE)), line.c_str(), line.size());
 					cnt++; //go to next line to write information
 				}
 				if (cnt >= 20) break;
@@ -873,9 +872,9 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 					if (strlen(item->heading1) == 0 && (item->relativeEvent == NO_TIME_DEF || item->relativeEvent == HIDDEN_DELAY) && StepCnt != 0 && !linebreakpanel)
 						cnt++; //go to next line
 					if (cnt >= 20) break;
-					SetTextColor(hDC,RGB(225, 225, 255)); 
-					SetTextAlign (hDC, TA_LEFT);
-					TextOut(hDC, (int) (width * .03), (int) (height * (LINE0+cnt*HLINE)), item->heading2, strlen(item->heading2));
+					skp->SetTextColor(RGB(225, 225, 255));
+					skp->SetTextAlign(oapi::Sketchpad::LEFT);
+					skp->Text((int)(width * .03), (int)(height * (LINE0 + cnt * HLINE)), item->heading2, strlen(item->heading2));
 					cnt++; //go to next line to write information
 				}
 				if (cnt >= 20) break;
@@ -888,26 +887,29 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 				//Display Highlighted box
 				if (StepCnt == 0 || StepCnt == -CurrentStep) {
 					if (StepCnt == -CurrentStep) {
-						hBr = CreateSolidBrush( RGB(0, 100, 0));
+						hBr = oapiCreateBrush(RGB(0, 100, 0));
 					} else {
-						hBr = CreateSolidBrush( RGB(0, 50, 0));
+						hBr = oapiCreateBrush(RGB(0, 50, 0));
 					}
-					SetRect(&ShadedBox,(int) (width * .01),(int) (height * (LINE0+cnt*HLINE+.008)),(int) (width * .99), (int) (height * (LINE1+cnt*HLINE+.01)));
-					FillRect(hDC, &ShadedBox, hBr);
-					DeleteObject(hBr);
+					oapi::Brush *oldBrush = skp->SetBrush(hBr);
+					oapi::Pen* oldPen = skp->SetPen(nullptr);
+					skp->Rectangle((int)(width * .01), (int)(height * (LINE0 + cnt * HLINE + .008)), (int)(width * .99), (int)(height * (LINE1 + cnt * HLINE + .01)));
+					skp->SetBrush(oldBrush);
+					skp->SetPen(oldPen);
+					oapiReleaseBrush(hBr);
 				}
 
 				//Print Step
 				if (item->callGroup == -1) {
 					if (item->automatic) {
-						SetTextColor (hDC, RGB(0, 255, 0));
+						skp->SetTextColor(RGB(0, 255, 0));
 					} else {
-						SetTextColor (hDC, RGB(255, 255, 0));
+						skp->SetTextColor(RGB(255, 255, 0));
 					}
 				} else {
-					SetTextColor (hDC, RGB(0, 255, 255));
+					skp->SetTextColor(RGB(0, 255, 255));
 				}
-				SetTextAlign (hDC, TA_LEFT);
+				skp->SetTextAlign(oapi::Sketchpad::LEFT);
 
 				// Line break
 				char buffer[1000];
@@ -924,7 +926,7 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 						}
 						if (breakpos == 0) breakpos = 30;
 
-						TextOut(hDC, (int) (width * .05), (int) (height * (LINE0+cnt*HLINE)), buffer, breakpos);
+						skp->Text((int)(width * .05), (int)(height * (LINE0 + cnt * HLINE)), buffer, breakpos);
 						cnt++; //go to next line
 						if (cnt >= 20) break;
 
@@ -935,10 +937,10 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 						strcpy(buffer, tmp);
 					}
 					if (cnt >= 20) break;
-					TextOut(hDC, (int) (width * .05), (int) (height * (LINE0+cnt*HLINE)), buffer, strlen(buffer));
+					skp->Text((int)(width * .05), (int)(height * (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
 
 				} else {
-					TextOut(hDC, (int) (width * .05), (int) (height * (LINE0+cnt*HLINE)), buffer, strlen(buffer));
+					skp->Text((int)(width * .05), (int)(height * (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
 				}
 
 				//Print panel
@@ -949,8 +951,8 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 						if (cnt >= 20) break;
 						linebreakpanel = true;
 					}
-					SetTextAlign (hDC, TA_RIGHT);
-					TextOut(hDC, (int) (width * .98), (int) (height * (LINE0+cnt*HLINE)), item->panel, strlen(item->panel));
+					skp->SetTextAlign(oapi::Sketchpad::RIGHT);
+					skp->Text((int)(width * .98), (int)(height* (LINE0 + cnt * HLINE)), item->panel, strlen(item->panel));
 				}
 			} else {
 				if (StepCnt == 0 && CurrentStep != 0) {
@@ -962,53 +964,59 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 			StepCnt++;
 		}
 		if (noChecklist) {
-			SetTextColor (hDC, RGB(0, 255, 0));
-			SetTextAlign (hDC, TA_CENTER);
-			TextOut(hDC, (int) (width * .5), (int) (height * .4), "(No active checklist)", 21);
+			skp->SetTextColor(RGB(0, 255, 0));
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text((int)(width * .5), (int)(height * .4), "(No active checklist)", 21);
 		}
 	}
 	else if (screen == PROG_CHKLSTNAV)
 	{
-		SelectDefaultFont(hDC, 0);				
-		Title(hDC, "Checklist Navigation");
-		
+		skp->SetFont(GetDefaultFont(0));
+		Title(skp, "Checklist Navigation");
+
 		// Display the MET after the header
 		if (bDisplayMET)
 		{
-			SetTextColor (hDC, RGB(225, 225, 255)); // blue 
-			SetTextAlign (hDC, TA_CENTER);
+			skp->SetTextColor(RGB(225, 225, 255)); // blue 
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
 			line = DisplayMissionElapsedTime();
-			TextOut(hDC, (int) (width * .5), (int) (height * 0.05), line.c_str(), line.size());
+			skp->Text((int)(width * .5), (int)(height * 0.05), line.c_str(), line.size());
 		}
 
-		SelectDefaultPen(hDC, 1);
-		MoveToEx (hDC, (int) (width * 0.02), (int) (height * 0.94), 0);
-		LineTo (hDC, (int) (width * 0.98), (int) (height * 0.94));
+		skp->SetPen(GetDefaultPen(1));
+		skp->MoveTo((int)(width * 0.02), (int)(height * 0.94));
+		skp->LineTo((int)(width * 0.98), (int)(height * 0.94));
 
 		//display AutoToggle selection box.
-		hBr = CreateSolidBrush( RGB(0, 150, 0));
+		hBr = oapiCreateBrush(RGB(0, 150, 0));
+		oapi::Brush* oldBrush = skp->SetBrush(hBr);
+		oapi::Pen* oldPen = skp->SetPen(nullptr);
 		if (!conn.ChecklistAutocomplete()) {
-			SetRect(&ShadedBox,(int) (width * 0.34),(int) (height * 0.955),(int) (width * 0.47), (int) (height - .999));
+			skp->Rectangle((int)(width * 0.34), (int)(height * 0.955), (int)(width * 0.47), (int)(height - .999));
 		} else {
-			SetRect(&ShadedBox,(int) (width * 0.24),(int) (height * 0.955),(int) (width * 0.34), (int) (height - .999));
+			skp->Rectangle((int)(width * 0.24), (int)(height * 0.955), (int)(width * 0.34), (int)(height - .999));
 		}
-		FillRect(hDC, &ShadedBox, hBr);
-		SetTextColor (hDC, RGB(0, 255, 0));
-		SetTextAlign (hDC, TA_LEFT);
-		TextOut(hDC, (int) (width * .05), (int) (height * .95), " AUTO:  ON  OFF", 15);
+		skp->SetBrush(oldBrush);
+		skp->SetPen(oldPen);
+		skp->SetTextColor(RGB(0, 255, 0));
+		skp->SetTextAlign(oapi::Sketchpad::LEFT);
+		skp->Text((int)(width * .05), (int)(height * .95), " AUTO:  ON  OFF", 15);
 
 		//display flashing selection box.
+		oldBrush = skp->SetBrush(hBr);
+		oldPen = skp->SetPen(nullptr);
 		if (!conn.GetChecklistFlashing()) {
-			SetRect(&ShadedBox,(int) (width * 0.82),(int) (height * 0.955),(int) (width * 0.95), (int) (height - .999));
+			skp->Rectangle((int) (width * 0.82),(int) (height * 0.955),(int) (width * 0.95), (int) (height - .999));
 		} else {
-			SetRect(&ShadedBox,(int) (width * 0.72),(int) (height * 0.955),(int) (width * 0.82), (int) (height - .999));
+			skp->Rectangle((int) (width * 0.72),(int) (height * 0.955),(int) (width * 0.82), (int) (height - .999));
 		}
-		FillRect(hDC, &ShadedBox, hBr);
-		DeleteObject(hBr);
-		SetTextColor (hDC, RGB(0, 255, 0));
-		SetTextAlign (hDC, TA_LEFT);
-		TextOut(hDC, (int) (width * .5), (int) (height * .95), " FLASH:  ON  OFF", 16);
-		
+		skp->SetBrush(oldBrush);
+		skp->SetPen(oldPen);
+		oapiReleaseBrush(hBr);
+		skp->SetTextColor(RGB(0, 255, 0));
+		skp->SetTextAlign(oapi::Sketchpad::LEFT);
+		skp->Text((int)(width * .5), (int)(height * .95), " FLASH:  ON  OFF", 16);
+
 		//TODO: Handle Writing Text
 		/*
 		sprintf(buffer, "%d", groups.size());
@@ -1020,7 +1028,7 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 		//sprintf(oapiDebugString(), "TopStep: %d  CurrentStep: %d  HighLightedStep: %d", TopStep,CurrentStep,HiLghtdLine);
 
 		//Set up Type for checklist display
-		SetTextAlign (hDC, TA_LEFT);
+		skp->SetTextAlign(oapi::Sketchpad::LEFT);
 		int cnt, grpcnt = 0;
 
 		// Make sure that the HiLghtdLine is shown actually
@@ -1069,9 +1077,9 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 				if (grpcnt != 0)
 					cnt++; //go to next line
 				if (cnt >= NLINES) break;
-				SetTextColor(hDC, RGB(225, 225, 255)); 
-				SetTextAlign(hDC, TA_CENTER);
-				TextOut(hDC, (int) (width * .5), (int) (height * (LINE0 + cnt * HLINE)), grp->heading, strlen(grp->heading));
+				skp->SetTextColor(RGB(225, 225, 255));
+				skp->SetTextAlign(oapi::Sketchpad::CENTER);
+				skp->Text((int)(width * .5), (int)(height * (LINE0 + cnt * HLINE)), grp->heading, strlen(grp->heading));
 				cnt++;
 				cnt++; //go to next line to write information
 			}
@@ -1079,18 +1087,21 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 
 			//display Highlighted box
 			if (grpcnt == HiLghtdLine) {
-				hBr = CreateSolidBrush( RGB(0, 100, 0));
-				SetRect(&ShadedBox,(int) (width * .01),(int) (height * (LINE0 + cnt * HLINE + .01)),(int) (width * .99), (int) (height * (LINE1 + cnt * HLINE + .01)));
-				FillRect(hDC, &ShadedBox, hBr);
-				DeleteObject(hBr);
+				hBr = oapiCreateBrush(RGB(0, 100, 0));
+				oapi::Brush* oldBrush = skp->SetBrush(hBr);
+				oapi::Pen* oldPen = skp->SetPen(nullptr);
+				skp->Rectangle((int)(width * .01), (int)(height * (LINE0 + cnt * HLINE + .01)), (int)(width * .99), (int)(height * (LINE1 + cnt * HLINE + .01)));
+				skp->SetBrush(oldBrush);
+				skp->SetPen(oldPen);
+				oapiReleaseBrush(hBr);
 				HiLghtdLineDown = true;
 			} else {
 				HiLghtdLineDown = false;
 			}
 
-			SetTextColor (hDC, RGB(0, 255, 0));
-			SetTextAlign (hDC, TA_LEFT);
-			TextOut(hDC, (int) (width * .05), (int) (height * (LINE0 + (cnt * HLINE))), grp->name, strlen(grp->name));
+			skp->SetTextColor(RGB(0, 255, 0));
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
+			skp->Text((int)(width * .05), (int)(height* (LINE0 + (cnt * HLINE))), grp->name, strlen(grp->name));
 
 			grpcnt++;
 		}
@@ -1151,35 +1162,38 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 	{
 		item = conn.GetChecklistItem(-1, CurrentStep);
 		if (item) {
-			SelectDefaultFont(hDC, 0);
-			Title(hDC, "Checklist Information");
+			skp->SetFont(GetDefaultFont(0));
+			Title(skp, "Checklist Information");
 			// Display the MET after the header
 			if (bDisplayMET) {
-				SetTextColor(hDC, RGB(225, 225, 255)); // blue 
-				SetTextAlign(hDC, TA_CENTER);
+				skp->SetTextColor(RGB(225, 225, 255)); // blue 
+				skp->SetTextAlign(oapi::Sketchpad::CENTER);
 				line = DisplayMissionElapsedTime();
-				TextOut(hDC, (int)(width * .5), (int)(height * 0.05), line.c_str(), line.size());
+				skp->Text((int)(width * .5), (int)(height * 0.05), line.c_str(), line.size());
 			}
 			cnt = 1;
-			SetTextColor(hDC, RGB(225, 225, 255));
-			SetTextAlign(hDC, TA_LEFT);
+			skp->SetTextColor(RGB(225, 225, 255));
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
 			//display Current Checklist Mission Time
 			if (item->relativeEvent != NO_TIME_DEF && item->relativeEvent != HIDDEN_DELAY) {
 				line = DisplayChecklistMissionTime(item);
-				TextOut(hDC, (int)(width * .02), (int)(height * (LINE0 + cnt * HLINE)), line.c_str(), line.size());
+				skp->Text((int)(width * .02), (int)(height* (LINE0 + cnt * HLINE)), line.c_str(), line.size());
 				cnt = cnt + 2;
 			}
 			//display Highlighted box
-			hBr = CreateSolidBrush(RGB(0, 100, 0));
-			SetRect(&ShadedBox, (int)(width * .01), (int)(height * (LINE0 + cnt * HLINE + .01)), (int)(width * .99), (int)(height * (LINE0 + (cnt + 1) * HLINE + .01)));
-			FillRect(hDC, &ShadedBox, hBr);
-			DeleteObject(hBr);
-			SelectDefaultPen(hDC, 1);
-			MoveToEx(hDC, (int)(width * 0.02), (int)(height * 0.94), 0);
-			LineTo(hDC, (int)(width * 0.98), (int)(height * 0.94));
-			SelectDefaultFont(hDC, 0);
-			SetTextColor(hDC, RGB(0, 255, 0));
-			SetTextAlign(hDC, TA_LEFT);
+			hBr = oapiCreateBrush(RGB(0, 100, 0));
+			oapi::Brush* oldBrush = skp->SetBrush(hBr);
+			oapi::Pen* oldPen = skp->SetPen(nullptr);
+			skp->Rectangle((int)(width * .01), (int)(height* (LINE0 + cnt * HLINE + .01)), (int)(width * .99), (int)(height* (LINE0 + (cnt + 1) * HLINE + .01)));
+			skp->SetBrush(oldBrush);
+			skp->SetPen(oldPen);
+			oapiReleaseBrush(hBr);
+			skp->SetPen(GetDefaultPen(1));
+			skp->MoveTo((int)(width * 0.02), (int)(height * 0.94));
+			skp->LineTo((int)(width * 0.98), (int)(height * 0.94));
+			skp->SetFont(GetDefaultFont(0));
+			skp->SetTextColor(RGB(0, 255, 0));
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
 
 			// Item
 			char buffer[1000];
@@ -1196,7 +1210,7 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 					}
 					if (breakpos == 0) breakpos = 30;
 
-					TextOut(hDC, (int)(width * .05), (int)(height * (LINE0 + cnt * HLINE)), buffer, breakpos);
+					skp->Text((int)(width * .05), (int)(height* (LINE0 + cnt * HLINE)), buffer, breakpos);
 					cnt++; //go to next line
 
 					char tmp[1000];
@@ -1205,16 +1219,16 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 					strcat(tmp, buffer + breakpos + 1);
 					strcpy(buffer, tmp);
 				}
-				TextOut(hDC, (int)(width * .05), (int)(height * (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
+				skp->Text((int)(width * .05), (int)(height* (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
 			} else {
-				TextOut(hDC, (int)(width * .05), (int)(height * (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
+				skp->Text((int)(width * .05), (int)(height* (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
 			}
 			// Line break
 			cnt = cnt + 2;
 
 			// Info
-			SetTextColor(hDC, RGB(0, 225, 0));
-			SetTextAlign(hDC, TA_LEFT);
+			skp->SetTextColor(RGB(0, 225, 0));
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
 			strcpy(buffer, item->info);
 			// Variable substitution comes first, so we can include the variable expansion in line length calculations
 			this->substituteVariables(buffer,1000);
@@ -1239,7 +1253,7 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 					}
 					if (breakpos == 0) breakpos = 30;
 
-					TextOut(hDC, (int) (width * .05), (int) (height * (LINE0 + cnt * HLINE)), buffer, breakpos);
+					skp->Text((int)(width * .05), (int)(height* (LINE0 + cnt * HLINE)), buffer, breakpos);
 					cnt++; //go to next line
 
 					char tmp[1000];
@@ -1247,10 +1261,10 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 					strcpy(buffer, tmp);
 					nlp = strchr(buffer, '\n');
 				}
-				TextOut(hDC, (int) (width * .05), (int) (height * (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
+				skp->Text((int)(width * .05), (int)(height * (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
 
 			} else {
-				TextOut(hDC, (int) (width * .05), (int) (height * (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
+				skp->Text((int)(width * .05), (int)(height * (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
 			}
 
 			// Line break
@@ -1260,13 +1274,14 @@ void ProjectApolloChecklistMFD::Update (HDC hDC)
 			if (strlen(item->panel) > 0) {
 				sprintf(buffer, "Panel: %s", item->panel);
 
-				SetTextColor(hDC, RGB(0, 225, 0)); 
-				SetTextAlign (hDC, TA_RIGHT);
-				TextOut(hDC, (int) (width * .98), (int) (height * (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
+				skp->SetTextColor(RGB(0, 225, 0));
+				skp->SetTextAlign(oapi::Sketchpad::RIGHT);
+				skp->Text((int)(width * .98), (int)(height * (LINE0 + cnt * HLINE)), buffer, strlen(buffer));
 				cnt = cnt + 2;
 			}
 		}
 	}
+	return true;
 }
 std::string ProjectApolloChecklistMFD::DisplayChecklistMissionTime(ChecklistItem *item)
 {

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.h
@@ -25,7 +25,7 @@
 #include "connector.h"
 #include "MFDconnector.h"
 
-class ProjectApolloChecklistMFD: public MFD {
+class ProjectApolloChecklistMFD: public MFD2 {
 public:
 	ProjectApolloChecklistMFD (DWORD w, DWORD h, VESSEL *vessel);
 	~ProjectApolloChecklistMFD ();
@@ -33,7 +33,7 @@ public:
 	int ButtonMenu (const MFDBUTTONMENU **menu) const;
 	bool ConsumeButton (int bt, int event);
 	bool ConsumeKeyBuffered (DWORD key);
-	void Update (HDC hDC);
+	bool Update (oapi::Sketchpad* skp);
 	void WriteStatus (FILEHANDLE scn) const;
 	void ReadStatus (FILEHANDLE scn);
 	void StoreStatus (void) const;
@@ -67,7 +67,7 @@ protected:
 	int CurrentStep;
 	int HiLghtdLine;
 	bool HiLghtdLineDown;
-	HBITMAP hBmpLogo;
+	SURFHANDLE hLogo;
 
 	std::string DisplayChecklistMissionTime (ChecklistItem *item);
 	bool bDisplayMET; // Coussini 

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.cpp
@@ -734,7 +734,7 @@ bool ProjectApolloMFD::Update (oapi::Sketchpad* skp)
 	char buffer[100];
 
 	SURFHANDLE s = skp->GetSurface();
-	RECT src{ 0, 0, 256, 256 };
+	RECT src{ 0, 0, 255, 255 };
 	RECT dst{ 1, 1, (LONG)width - 2, (LONG)height - 2 };
 	oapiBlt(s, hLogo, &dst, &src);
 
@@ -775,7 +775,7 @@ bool ProjectApolloMFD::Update (oapi::Sketchpad* skp)
 	if (!saturn && !lem)
 		return true;
 
-	skp->SetPen(GetDefaultPen(1));
+	skp->SetPen(GetDefaultPen(0));
 	skp->MoveTo((int)(width * 0.05), (int)(height * 0.25));
 	skp->LineTo((int)(width * 0.95), (int)(height * 0.25));
 

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.cpp
@@ -629,7 +629,7 @@ void ProjectApolloMFDopcTimestep (double simt, double simdt, double mjd)
 // MFD class implementation
 
 // Constructor
-ProjectApolloMFD::ProjectApolloMFD (DWORD w, DWORD h, VESSEL *vessel) : MFD (w, h, vessel)
+ProjectApolloMFD::ProjectApolloMFD (DWORD w, DWORD h, VESSEL *vessel) : MFD2 (w, h, vessel)
 
 {
 	saturn = NULL;
@@ -639,7 +639,8 @@ ProjectApolloMFD::ProjectApolloMFD (DWORD w, DWORD h, VESSEL *vessel) : MFD (w, 
 	lem = NULL;
 	width = w;
 	height = h;
-	hBmpLogo = LoadBitmap(g_hDLL, MAKEINTRESOURCE (IDB_LOGO));
+	HBITMAP hBmpLogo = LoadBitmap(g_hDLL, MAKEINTRESOURCE (IDB_LOGO));
+	hLogo = oapiCreateSurface(hBmpLogo);
 	screen = 0;
 	debug_frozen = false;
 	char buffer[8];
@@ -728,33 +729,32 @@ bool ProjectApolloMFD::ConsumeButton (int bt, int event)
 }
 
 // Repaint the MFD
-void ProjectApolloMFD::Update (HDC hDC)
+bool ProjectApolloMFD::Update (oapi::Sketchpad* skp)
 {
 	char buffer[100];
 
-	HDC hDCTemp = CreateCompatibleDC(hDC);
-	HBITMAP hBmpTemp = (HBITMAP) SelectObject(hDCTemp, hBmpLogo);
-	StretchBlt(hDC, 1, 1, width - 2, height - 2, hDCTemp, 0, 0, 256, 256, SRCCOPY);
-	DeleteObject(hBmpTemp);
-	DeleteDC(hDCTemp);
+	SURFHANDLE s = skp->GetSurface();
+	RECT src{ 0, 0, 256, 256 };
+	RECT dst{ 1, 1, (LONG)width - 2, (LONG)height - 2 };
+	oapiBlt(s, hLogo, &dst, &src);
 
 	// Draws the MFD title
-	Title (hDC, "Project Apollo");
+	Title(skp, "Project Apollo");
 
-	SelectDefaultFont(hDC, 0);
-	SetBkMode (hDC, TRANSPARENT);
-	SetTextAlign (hDC, TA_CENTER);
+	skp->SetFont(GetDefaultFont(0));
+	skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
+	skp->SetTextAlign(oapi::Sketchpad::CENTER);
 
 	if (!saturn && !lem) {
-		SetTextColor (hDC, RGB(255, 0, 0));
-		TextOut(hDC, width / 2, (int) (height * 0.5), "Unsupported vessel", 18); 
+		skp->SetTextColor(RGB(255, 0, 0));
+		skp->Text(width / 2, (int)(height * 0.5), "Unsupported vessel", 18);
 		if (!crawler)
-			return;
+			return true;
 	}
 
 	// Draw mission time
-	SetTextColor (hDC, RGB(0, 255, 0));
-	TextOut(hDC, width / 2, (int) (height * 0.1), "Ground Elapsed Time", 19);
+	skp->SetTextColor (RGB(0, 255, 0));
+	skp->Text(width / 2, (int) (height * 0.1), "Ground Elapsed Time", 19);
 
 	double mt = 0;
 	if (saturn){ mt = saturn->GetMissionTime(); }
@@ -770,27 +770,27 @@ void ProjectApolloMFD::Update (HDC hDC)
 		sprintf(buffer, "-%d:%02d:%02d", hours, minutes, secs);
 	else
 		sprintf(buffer, "%d:%02d:%02d", hours, minutes, secs);
-	TextOut(hDC, width / 2, (int) (height * 0.15), buffer, strlen(buffer));
+	skp->Text(width / 2, (int)(height * 0.15), buffer, strlen(buffer));
 	//If this is the crawler and not the actual Saturn, do NOTHING else!
 	if (!saturn && !lem)
-		return;
+		return true;
 
-	SelectDefaultPen(hDC, 1);
-	MoveToEx (hDC, (int) (width * 0.05), (int) (height * 0.25), 0);
-	LineTo (hDC, (int) (width * 0.95), (int) (height * 0.25));
+	skp->SetPen(GetDefaultPen(1));
+	skp->MoveTo((int)(width * 0.05), (int)(height * 0.25));
+	skp->LineTo((int)(width * 0.95), (int)(height * 0.25));
 
 	// Draw GNC
 	if (screen == m_buttonPages.page.GNC) {
-		TextOut(hDC, width / 2, (int) (height * 0.3), "Guidance, Navigation & Control", 30);
-		SetTextAlign (hDC, TA_LEFT);
-		TextOut(hDC, (int) (width * 0.1), (int) (height * 0.4), "Velocity:", 9);
-		TextOut(hDC, (int) (width * 0.1), (int) (height * 0.45), "Vert. Velocity:", 15);
-		TextOut(hDC, (int) (width * 0.1), (int) (height * 0.5), "Altitude:", 9);
-		TextOut(hDC, (int) (width * 0.1), (int) (height * 0.6), "Apoapsis Alt.:", 14);
-		TextOut(hDC, (int) (width * 0.1), (int) (height * 0.65), "Periapsis Alt.:", 15);
-		TextOut(hDC, (int) (width * 0.1), (int) (height * 0.7), "Inclination:", 12);
-		TextOut(hDC, (int) (width * 0.1), (int) (height * 0.8), "Latitude:", 9);
-		TextOut(hDC, (int) (width * 0.1), (int) (height * 0.85), "Longitude:", 10);
+		skp->Text(width / 2, (int)(height * 0.3), "Guidance, Navigation & Control", 30);
+		skp->SetTextAlign(oapi::Sketchpad::LEFT);
+		skp->Text((int)(width * 0.1), (int)(height * 0.4), "Velocity:", 9);
+		skp->Text((int)(width * 0.1), (int)(height * 0.45), "Vert. Velocity:", 15);
+		skp->Text((int)(width * 0.1), (int)(height * 0.5), "Altitude:", 9);
+		skp->Text((int)(width * 0.1), (int)(height * 0.6), "Apoapsis Alt.:", 14);
+		skp->Text((int)(width * 0.1), (int)(height * 0.65), "Periapsis Alt.:", 15);
+		skp->Text((int)(width * 0.1), (int)(height * 0.7), "Inclination:", 12);
+		skp->Text((int)(width * 0.1), (int)(height * 0.8), "Latitude:", 9);
+		skp->Text((int)(width * 0.1), (int)(height * 0.85), "Longitude:", 10);
 
 		OBJHANDLE planet;
 		ELEMENTS elem;
@@ -800,7 +800,7 @@ void ProjectApolloMFD::Update (HDC hDC)
 
 		if (saturn) {
 			planet = saturn->GetGravityRef();
-			saturn->GetRelativeVel(planet, vel); 
+			saturn->GetRelativeVel(planet, vel);
 			if (saturn->GetAirspeedVector(FRAME_HORIZON, hvel)) {
 				vvel = hvel.y * 3.2808399;
 			}
@@ -808,9 +808,10 @@ void ProjectApolloMFD::Update (HDC hDC)
 			saturn->GetPeDist(peDist);
 			saturn->GetEquPos(lon, lat, radius);
 			saturn->GetElements(planet, elem, 0, 0, FRAME_EQU);
-		} else if (lem) {
+		}
+		else if (lem) {
 			planet = lem->GetGravityRef();
-			lem->GetRelativeVel(planet, vel); 
+			lem->GetRelativeVel(planet, vel);
 			if (lem->GetAirspeedVector(FRAME_HORIZON, hvel)) {
 				vvel = hvel.y * 3.2808399;
 			}
@@ -824,301 +825,302 @@ void ProjectApolloMFD::Update (HDC hDC)
 		if (strcmp(planetName, "Earth") == 0) {
 			apDist -= 6.373338e6;
 			peDist -= 6.373338e6;
-		} else {
+		}
+		else {
 			apDist -= 1.73809e6;
 			peDist -= 1.73809e6;
 		}
 
-		SetTextAlign (hDC, TA_RIGHT);
+		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
 		sprintf(buffer, "%.0lf ft/s", length(vel) * 3.2808399);
-		TextOut(hDC, (int) (width * 0.9), (int) (height * 0.4), buffer, strlen(buffer));
+		skp->Text((int)(width * 0.9), (int)(height * 0.4), buffer, strlen(buffer));
 		sprintf(buffer, "%.0lf ft/s", vvel);
-		TextOut(hDC, (int) (width * 0.9), (int) (height * 0.45), buffer, strlen(buffer));
-		if(saturn){ sprintf(buffer, "%.1lf nm  ", saturn->GetAltitude() * 0.000539957); }
-		if(lem){    sprintf(buffer, "%.1lf nm  ", lem->GetAltitude() * 0.000539957); }
-		TextOut(hDC, (int) (width * 0.9), (int) (height * 0.5), buffer, strlen(buffer));
+		skp->Text((int)(width * 0.9), (int)(height * 0.45), buffer, strlen(buffer));
+		if (saturn) { sprintf(buffer, "%.1lf nm  ", saturn->GetAltitude() * 0.000539957); }
+		if (lem) { sprintf(buffer, "%.1lf nm  ", lem->GetAltitude() * 0.000539957); }
+		skp->Text((int)(width * 0.9), (int)(height * 0.5), buffer, strlen(buffer));
 		sprintf(buffer, "%.1lf nm  ", apDist * 0.000539957);
-		TextOut(hDC, (int) (width * 0.9), (int) (height * 0.6), buffer, strlen(buffer));
+		skp->Text((int)(width * 0.9), (int)(height * 0.6), buffer, strlen(buffer));
 		sprintf(buffer, "%.1lf nm  ", peDist * 0.000539957);
-		TextOut(hDC, (int) (width * 0.9), (int) (height * 0.65), buffer, strlen(buffer));
+		skp->Text((int)(width * 0.9), (int)(height * 0.65), buffer, strlen(buffer));
 		sprintf(buffer, "%.2lf°   ", elem.i * DEG);
-		TextOut(hDC, (int) (width * 0.9), (int) (height * 0.7), buffer, strlen(buffer));
+		skp->Text((int)(width * 0.9), (int)(height * 0.7), buffer, strlen(buffer));
 		sprintf(buffer, "%.2lf°   ", lat * DEG);
-		TextOut(hDC, (int) (width * 0.9), (int) (height * 0.8), buffer, strlen(buffer));
+		skp->Text((int)(width * 0.9), (int)(height * 0.8), buffer, strlen(buffer));
 		sprintf(buffer, "%.2lf°   ", lon * DEG);
-		TextOut(hDC, (int) (width * 0.9), (int) (height * 0.85), buffer, strlen(buffer));
+		skp->Text((int)(width * 0.9), (int)(height * 0.85), buffer, strlen(buffer));
 
 		if (g_Data.killrot) {
-			SetTextColor (hDC, RGB(255, 0, 0));
-			SetTextAlign (hDC, TA_CENTER);
-			TextOut(hDC, width / 2, (int) (height * 0.9), "*** KILL ROTATION ACTIVE ***", 28);
+			skp->SetTextColor(RGB(255, 0, 0));
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text(width / 2, (int)(height * 0.9), "*** KILL ROTATION ACTIVE ***", 28);
 		}
 	}
 
 	// Draw ECS
 	else if (screen == m_buttonPages.page.ECS) {
-		TextOut(hDC, width / 2, (int) (height * 0.3), "Environmental Control System", 28);
+		skp->Text(width / 2, (int)(height * 0.3), "Environmental Control System", 28);
 
 		if (saturn)
 		{
 
-			SetTextAlign(hDC, TA_LEFT);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.4), "Crew status:", 12);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.45), "Crew number:", 12);
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
+			skp->Text((int)(width * 0.1), (int)(height * 0.4), "Crew status:", 12);
+			skp->Text((int)(width * 0.1), (int)(height * 0.45), "Crew number:", 12);
 
 			ECSStatus ecs;
 			saturn->GetECSStatus(ecs);
 
-			SetTextAlign(hDC, TA_CENTER);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
 			if (ecs.crewStatus == ECS_CREWSTATUS_OK) {
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.4), "OK", 2);
+				skp->Text((int)(width * 0.7), (int)(height * 0.4), "OK", 2);
 			}
 			else if (ecs.crewStatus == ECS_CREWSTATUS_CRITICAL) {
-				SetTextColor(hDC, RGB(255, 255, 0));
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.4), "CRITICAL", 8);
-				SetTextColor(hDC, RGB(0, 255, 0));
+				skp->SetTextColor(RGB(255, 255, 0));
+				skp->Text((int)(width * 0.7), (int)(height * 0.4), "CRITICAL", 8);
+				skp->SetTextColor(RGB(0, 255, 0));
 			}
 			else {
-				SetTextColor(hDC, RGB(255, 0, 0));
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.4), "DEAD", 4);
-				SetTextColor(hDC, RGB(0, 255, 0));
+				skp->SetTextColor(RGB(255, 0, 0));
+				skp->Text((int)(width * 0.7), (int)(height * 0.4), "DEAD", 4);
+				skp->SetTextColor(RGB(0, 255, 0));
 			}
 
 			sprintf(buffer, "%d", ecs.crewNumber);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.45), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.7), (int)(height * 0.45), buffer, strlen(buffer));
 
-			TextOut(hDC, (int)(width * 0.5), (int)(height * 0.525), "Glycol Coolant Loops", 20);
-			TextOut(hDC, (int)(width * 0.6), (int)(height * 0.6), "Prim.", 5);
-			TextOut(hDC, (int)(width * 0.8), (int)(height * 0.6), "Sec.", 4);
+			skp->Text((int)(width * 0.5), (int)(height * 0.525), "Glycol Coolant Loops", 20);
+			skp->Text((int)(width * 0.6), (int)(height * 0.6), "Prim.", 5);
+			skp->Text((int)(width * 0.8), (int)(height * 0.6), "Sec.", 4);
 
-			SetTextAlign(hDC, TA_LEFT);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.6), "Heating:", 8);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.65), "Actual:", 7);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.7), "Test:", 5);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.8), "Total:", 6);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.9), "CSM O2 Hose:", 12);
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
+			skp->Text((int)(width * 0.1), (int)(height * 0.6), "Heating:", 8);
+			skp->Text((int)(width * 0.1), (int)(height * 0.65), "Actual:", 7);
+			skp->Text((int)(width * 0.1), (int)(height * 0.7), "Test:", 5);
+			skp->Text((int)(width * 0.1), (int)(height * 0.8), "Total:", 6);
+			skp->Text((int)(width * 0.1), (int)(height * 0.9), "CSM O2 Hose:", 12);
 
-			SetTextAlign(hDC, TA_CENTER);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
 			sprintf(buffer, "%.0lfW", ecs.PrimECSHeating);
-			TextOut(hDC, (int)(width * 0.6), (int)(height * 0.65), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.6), (int)(height * 0.65), buffer, strlen(buffer));
 			sprintf(buffer, "%.0lfW", ecs.PrimECSTestHeating);
-			TextOut(hDC, (int)(width * 0.6), (int)(height * 0.7), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.6), (int)(height * 0.7), buffer, strlen(buffer));
 			sprintf(buffer, "%.0lfW", ecs.PrimECSHeating + ecs.PrimECSTestHeating);
-			TextOut(hDC, (int)(width * 0.6), (int)(height * 0.8), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.6), (int)(height * 0.8), buffer, strlen(buffer));
 			sprintf(buffer, "%.0lfW", ecs.SecECSHeating);
-			TextOut(hDC, (int)(width * 0.8), (int)(height * 0.65), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.8), (int)(height * 0.65), buffer, strlen(buffer));
 			sprintf(buffer, "%.0lfW", ecs.SecECSTestHeating);
-			TextOut(hDC, (int)(width * 0.8), (int)(height * 0.7), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.8), (int)(height * 0.7), buffer, strlen(buffer));
 			sprintf(buffer, "%.0lfW", ecs.SecECSHeating + ecs.SecECSTestHeating);
-			TextOut(hDC, (int)(width * 0.8), (int)(height * 0.8), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.8), (int)(height * 0.8), buffer, strlen(buffer));
 
-			MoveToEx(hDC, (int)(width * 0.5), (int)(height * 0.775), 0);
-			LineTo(hDC, (int)(width * 0.9), (int)(height * 0.775));
+			skp->MoveTo((int)(width * 0.5), (int)(height * 0.775));
+			skp->LineTo((int)(width * 0.9), (int)(height * 0.775));
 
 			if (ecs.CSMO2HoseConnected)
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.9), "Connected", 9);
+				skp->Text((int)(width * 0.7), (int)(height * 0.9), "Connected", 9);
 			}
 			else
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.9), "Disconnected", 12);
+				skp->Text((int)(width * 0.7), (int)(height * 0.9), "Disconnected", 12);
 			}
 
 		}
 		else if (lem)
 		{
-			SetTextAlign(hDC, TA_LEFT);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.4), "Crew status:", 12);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.45), "Crew number:", 12);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.5), "CDR status:", 11);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.55), "LMP status:", 11);
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
+			skp->Text((int)(width * 0.1), (int)(height * 0.4), "Crew status:", 12);
+			skp->Text((int)(width * 0.1), (int)(height * 0.45), "Crew number:", 12);
+			skp->Text((int)(width * 0.1), (int)(height * 0.5), "CDR status:", 11);
+			skp->Text((int)(width * 0.1), (int)(height * 0.55), "LMP status:", 11);
 
 			LEMECSStatus ecs;
 			lem->GetECSStatus(ecs);
 
-			SetTextAlign(hDC, TA_CENTER);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
 			if (ecs.crewStatus == ECS_CREWSTATUS_OK) {
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.4), "OK", 2);
+				skp->Text((int)(width * 0.7), (int)(height * 0.4), "OK", 2);
 			}
 			else if (ecs.crewStatus == ECS_CREWSTATUS_CRITICAL) {
-				SetTextColor(hDC, RGB(255, 255, 0));
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.4), "CRITICAL", 8);
-				SetTextColor(hDC, RGB(0, 255, 0));
+				skp->SetTextColor(RGB(255, 255, 0));
+				skp->Text((int)(width * 0.7), (int)(height * 0.4), "CRITICAL", 8);
+				skp->SetTextColor(RGB(0, 255, 0));
 			}
 			else {
-				SetTextColor(hDC, RGB(255, 0, 0));
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.4), "DEAD", 4);
-				SetTextColor(hDC, RGB(0, 255, 0));
+				skp->SetTextColor(RGB(255, 0, 0));
+				skp->Text((int)(width * 0.7), (int)(height * 0.4), "DEAD", 4);
+				skp->SetTextColor(RGB(0, 255, 0));
 			}
 
 			sprintf(buffer, "%d", ecs.crewNumber);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.45), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.7), (int)(height * 0.45), buffer, strlen(buffer));
 
 			if (ecs.cdrStatus == 0)
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.5), "In Cabin", 8);
+				skp->Text((int)(width * 0.7), (int)(height * 0.5), "In Cabin", 8);
 			}
 			else if (ecs.cdrStatus == 1)
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.5), "In Suit", 7);
+				skp->Text((int)(width * 0.7), (int)(height * 0.5), "In Suit", 7);
 			}
 			else if (ecs.cdrStatus == 2)
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.5), "EVA", 3);
+				skp->Text((int)(width * 0.7), (int)(height * 0.5), "EVA", 3);
 			}
 			else
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.5), "PLSS", 4);
+				skp->Text((int)(width * 0.7), (int)(height * 0.5), "PLSS", 4);
 			}
 
 
 			if (ecs.lmpStatus == 0)
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.55), "In Cabin", 8);
+				skp->Text((int)(width * 0.7), (int)(height * 0.55), "In Cabin", 8);
 			}
 			else if (ecs.lmpStatus == 1)
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.55), "In Suit", 7);
+				skp->Text((int)(width * 0.7), (int)(height * 0.55), "In Suit", 7);
 			}
 			else if (ecs.lmpStatus == 2)
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.55), "EVA", 3);
+				skp->Text((int)(width * 0.7), (int)(height * 0.55), "EVA", 3);
 			}
 			else
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.55), "PLSS", 4);
+				skp->Text((int)(width * 0.7), (int)(height * 0.55), "PLSS", 4);
 			}
 		}
 		else
 		{
-			TextOut(hDC, width / 2, (int)(height * 0.4), "Unsupported vehicle", 19);
+		skp->Text(width / 2, (int)(height * 0.4), "Unsupported vehicle", 19);
 		}
 	// Draw IMFD
 	} else if (screen == m_buttonPages.page.IU) {
-		TextOut(hDC, width / 2, (int) (height * 0.3), "IU Uplink Data", 14);
-		SetTextAlign (hDC, TA_LEFT);
-		TextOut(hDC, (int) (width * 0.1), (int) (height * 0.35), "Type:", 5);
+		skp->Text(width / 2, (int)(height * 0.3), "IU Uplink Data", 14);
+		skp->SetTextAlign(oapi::Sketchpad::LEFT);
+		skp->Text((int)(width * 0.1), (int)(height * 0.35), "Type:", 5);
 
 		if (g_Data.iuUplinkType == DCSUPLINK_SWITCH_SELECTOR)
 		{
-			SetTextAlign(hDC, TA_CENTER);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.35), "Switch Selector", 15);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text((int)(width * 0.7), (int)(height * 0.35), "Switch Selector", 15);
 
-			SetTextAlign(hDC, TA_LEFT);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.45), "Stage:", 6);
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
+			skp->Text((int)(width * 0.1), (int)(height * 0.45), "Stage:", 6);
 
-			SetTextAlign(hDC, TA_CENTER);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
 			if (g_Data.iuUplinkSwitSelStage == 0)
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.45), "IU", 2);
+				skp->Text((int)(width * 0.7), (int)(height * 0.45), "IU", 2);
 			}
 			else if (g_Data.iuUplinkSwitSelStage == 1)
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.45), "S-I", 3);
+				skp->Text((int)(width * 0.7), (int)(height * 0.45), "S-I", 3);
 			}
 			else if (g_Data.iuUplinkSwitSelStage == 2)
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.45), "S-II", 4);
+				skp->Text((int)(width * 0.7), (int)(height * 0.45), "S-II", 4);
 			}
 			else if (g_Data.iuUplinkSwitSelStage == 3)
 			{
-				TextOut(hDC, (int)(width * 0.7), (int)(height * 0.45), "S-IVB", 5);
+				skp->Text((int)(width * 0.7), (int)(height * 0.45), "S-IVB", 5);
 			}
 
-			SetTextAlign(hDC, TA_LEFT);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.5), "Channel:", 8);
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
+			skp->Text((int)(width * 0.1), (int)(height * 0.5), "Channel:", 8);
 
 			sprintf(buffer, "%d", g_Data.iuUplinkSwitSelChannel);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.5), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.7), (int)(height * 0.5), buffer, strlen(buffer));
 		}
 		else if (g_Data.iuUplinkType == DCSUPLINK_TIMEBASE_UPDATE)
 		{
-			SetTextAlign(hDC, TA_CENTER);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.35), "Timebase Update", 15);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text((int)(width * 0.7), (int)(height * 0.35), "Timebase Update", 15);
 
-			SetTextAlign(hDC, TA_LEFT);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.45), "Delta T:", 8);
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
+			skp->Text((int)(width * 0.1), (int)(height * 0.45), "Delta T:", 8);
 
 			sprintf(buffer, "%+.1f s", g_Data.iuUplinkTimebaseUpdateTime);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.45), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.7), (int)(height * 0.45), buffer, strlen(buffer));
 		}
 		else if (g_Data.iuUplinkType == DCSUPLINK_LM_ABORT)
 		{
-			SetTextAlign(hDC, TA_CENTER);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.35), "LM Abort (Apollo 5)", 19);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text((int)(width * 0.7), (int)(height * 0.35), "LM Abort (Apollo 5)", 19);
 		}
 		else if (g_Data.iuUplinkType == DCSUPLINK_TDE_ENABLE)
 		{
-			SetTextAlign(hDC, TA_CENTER);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.35), "TD&E Enable", 11);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text((int)(width * 0.7), (int)(height * 0.35), "TD&E Enable", 11);
 		}
 		else if (g_Data.iuUplinkType == DCSUPLINK_RESTART_MANEUVER_ENABLE)
 		{
-			SetTextAlign(hDC, TA_CENTER);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.35), "Restart Maneuver Enable", 23);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text((int)(width * 0.7), (int)(height * 0.35), "Restart Maneuver Enable", 23);
 		}
 		else if (g_Data.iuUplinkType == DCSUPLINK_TIMEBASE_8_ENABLE)
 		{
-			SetTextAlign(hDC, TA_CENTER);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.35), "Timebase 8 Enable", 17);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text((int)(width * 0.7), (int)(height * 0.35), "Timebase 8 Enable", 17);
 		}
 		else if (g_Data.iuUplinkType == DCSUPLINK_EVASIVE_MANEUVER_ENABLE)
 		{
-			SetTextAlign(hDC, TA_CENTER);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.35), "Evasive Yaw Mnvr Enable", 23);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text((int)(width * 0.7), (int)(height * 0.35), "Evasive Yaw Mnvr Enable", 23);
 		}
 		else if (g_Data.iuUplinkType == DCSUPLINK_EXECUTE_COMM_MANEUVER)
 		{
-			SetTextAlign(hDC, TA_CENTER);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.35), "Execute Comm Maneuver", 21);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text((int)(width * 0.7), (int)(height * 0.35), "Execute Comm Maneuver", 21);
 		}
 		else if (g_Data.iuUplinkType == DCSUPLINK_SIVBIU_LUNAR_IMPACT)
 		{
-			SetTextAlign(hDC, TA_CENTER);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.35), "S-IVB/IU Lunar Impact", 21);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text((int)(width * 0.7), (int)(height * 0.35), "S-IVB/IU Lunar Impact", 21);
 
-			SetTextAlign(hDC, TA_LEFT);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.45), "TIG:", 4);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.5), "BT:", 3);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.55), "Pitch:", 6);
-			TextOut(hDC, (int)(width * 0.1), (int)(height * 0.6), "Yaw:", 4);
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
+			skp->Text((int)(width * 0.1), (int)(height * 0.45), "TIG:", 4);
+			skp->Text((int)(width * 0.1), (int)(height * 0.5), "BT:", 3);
+			skp->Text((int)(width * 0.1), (int)(height * 0.55), "Pitch:", 6);
+			skp->Text((int)(width * 0.1), (int)(height * 0.6), "Yaw:", 4);
 
 			sprintf(buffer, "TB8+%.0f s", g_Data.iuUplinkTIG);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.45), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.7), (int)(height * 0.45), buffer, strlen(buffer));
 			sprintf(buffer, "%.1f s", g_Data.iuUplinkDT);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.5), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.7), (int)(height * 0.5), buffer, strlen(buffer));
 			sprintf(buffer, "%.01f°", g_Data.iuUplinkPitch*DEG);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.55), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.7), (int)(height * 0.55), buffer, strlen(buffer));
 			sprintf(buffer, "%.01f°", g_Data.iuUplinkYaw*DEG);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.6), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.7), (int)(height * 0.6), buffer, strlen(buffer));
 		}
 		else if (g_Data.iuUplinkType == DCSUPLINK_REMOVE_INHIBIT_MANEUVER4)
 		{
-			SetTextAlign(hDC, TA_CENTER);
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.35), "Remove Inhibit Mnv. 4", 21);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
+			skp->Text((int)(width * 0.7), (int)(height * 0.35), "Remove Inhibit Mnv. 4", 21);
 		}
 
-		SetTextAlign (hDC, TA_CENTER);
-		TextOut(hDC, width / 2, (int) (height * 0.75), "IU Uplink Result", 16);
-		SetTextAlign (hDC, TA_LEFT);
-		TextOut(hDC, (int) (width * 0.1), (int) (height * 0.8), "Status:", 7);
+		skp->SetTextAlign(oapi::Sketchpad::CENTER);
+		skp->Text(width / 2, (int)(height * 0.75), "IU Uplink Result", 16);
+		skp->SetTextAlign(oapi::Sketchpad::LEFT);
+		skp->Text((int)(width * 0.1), (int)(height * 0.8), "Status:", 7);
 
-		SetTextAlign(hDC, TA_CENTER);
+		skp->SetTextAlign(oapi::Sketchpad::CENTER);
 		if (g_Data.iuUplinkResult == 1)
 		{
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.8), "Uplink accepted", 15);
+			skp->Text((int)(width * 0.7), (int)(height * 0.8), "Uplink accepted", 15);
 		}
 		else if (g_Data.iuUplinkResult == 2)
 		{
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.8), "Vessel has no IU", 16);
+			skp->Text((int)(width * 0.7), (int)(height * 0.8), "Vessel has no IU", 16);
 		}
 		else if (g_Data.iuUplinkResult == 3)
 		{
-			TextOut(hDC, (int)(width * 0.7), (int)(height * 0.8), "Uplink rejected", 15);
+			skp->Text((int)(width * 0.7), (int)(height * 0.8), "Uplink rejected", 15);
 		}
 
-		SetTextAlign(hDC, TA_LEFT);
-		SetTextColor(hDC, RGB(128, 128, 128));
+		skp->SetTextAlign(oapi::Sketchpad::LEFT);
+		skp->SetTextColor(RGB(128, 128, 128));
 		if (g_Data.iuVessel)
 		{
 			oapiGetObjectName(g_Data.iuVessel->GetHandle(), buffer, 100);
@@ -1127,42 +1129,42 @@ void ProjectApolloMFD::Update (HDC hDC)
 		{
 			sprintf(buffer, "No Target!");
 		}
-		TextOut(hDC, (int)(width * 0.05), (int)(height * 0.95), buffer, strlen(buffer));
+		skp->Text((int)(width * 0.05), (int)(height * 0.95), buffer, strlen(buffer));
 	}
 	//Draw Telemetry
 	else if (screen == m_buttonPages.page.TELE) {
-		SetTextAlign (hDC, TA_LEFT);
+		skp->SetTextAlign(oapi::Sketchpad::LEFT);
 		sprintf(buffer, "Telemetry: %s", debugWinsock);
-		TextOut(hDC, (int) (width * 0.1), (int) (height * 0.30), "Telemetry:", 10);
-		TextOut(hDC, (int) (width * 0.6), (int) (height * 0.30), debugWinsock, strlen(debugWinsock));
+		skp->Text((int)(width * 0.1), (int)(height * 0.30), "Telemetry:", 10);
+		skp->Text((int)(width * 0.6), (int)(height * 0.30), debugWinsock, strlen(debugWinsock));
 
 		if (g_Data.uplinkDataReady == 1 || g_Data.updateClockReady == 1) {
 			if (lem) {
-				SetTextAlign (hDC, TA_CENTER);
+				skp->SetTextAlign(oapi::Sketchpad::CENTER);
 				sprintf(buffer, "Checklist");
-				TextOut(hDC, width / 2, (int) (height * 0.45), buffer, strlen(buffer));
-				SetTextAlign (hDC, TA_LEFT);
+				skp->Text(width / 2, (int)(height * 0.45), buffer, strlen(buffer));
+				skp->SetTextAlign(oapi::Sketchpad::LEFT);
 				sprintf(buffer, "LGC: IDLE (P00 DESIRED)");
-				TextOut(hDC, (int) (width * 0.1), (int) (height * 0.55), buffer, strlen(buffer));
+				skp->Text((int)(width * 0.1), (int)(height * 0.55), buffer, strlen(buffer));
 				sprintf(buffer, "P12: UPDATA LINK - DATA (down)");
-				TextOut(hDC, (int) (width * 0.1), (int) (height * 0.60), buffer, strlen(buffer));
+				skp->Text((int)(width * 0.1), (int)(height * 0.60), buffer, strlen(buffer));
 				sprintf(buffer, "P11: UP DATA LINK CB - IN");
-				TextOut(hDC, (int) (width * 0.1), (int) (height * 0.65), buffer, strlen(buffer));
-				SetTextAlign (hDC, TA_CENTER);				
+				skp->Text((int)(width * 0.1), (int)(height * 0.65), buffer, strlen(buffer));
+				skp->SetTextAlign(oapi::Sketchpad::CENTER);
 			} else {
-				SetTextAlign (hDC, TA_CENTER);
+				skp->SetTextAlign(oapi::Sketchpad::CENTER);
 				sprintf(buffer, "Checklist");
-				TextOut(hDC, width / 2, (int) (height * 0.45), buffer, strlen(buffer));
-				SetTextAlign (hDC, TA_LEFT);
+				skp->Text(width / 2, (int)(height * 0.45), buffer, strlen(buffer));
+				skp->SetTextAlign(oapi::Sketchpad::LEFT);
 				sprintf(buffer, "DSKY - V37E 00E");
-				TextOut(hDC, (int) (width * 0.1), (int) (height * 0.55), buffer, strlen(buffer));
+				skp->Text((int)(width * 0.1), (int)(height * 0.55), buffer, strlen(buffer));
 				sprintf(buffer, "UPTLM CM - ACCEPT (up)   2, 122");
-				TextOut(hDC, (int) (width * 0.1), (int) (height * 0.60), buffer, strlen(buffer));
+				skp->Text((int)(width * 0.1), (int)(height * 0.60), buffer, strlen(buffer));
 				sprintf(buffer, "UP TLM - DATA (up)            3");
-				TextOut(hDC, (int) (width * 0.1), (int) (height * 0.65), buffer, strlen(buffer));
+				skp->Text((int)(width * 0.1), (int)(height * 0.65), buffer, strlen(buffer));
 				sprintf(buffer, "PCM BIT RATE - HIGH (up)      3");
-				TextOut(hDC, (int) (width * 0.1), (int) (height * 0.7), buffer, strlen(buffer));
-				SetTextAlign (hDC, TA_CENTER);
+				skp->Text((int)(width * 0.1), (int)(height * 0.7), buffer, strlen(buffer));
+				skp->SetTextAlign(oapi::Sketchpad::CENTER);
 			}
 			if (g_Data.uplinkDataReady == 1) {
 				if (g_Data.uplinkDataType == UPLINK_SV)
@@ -1170,73 +1172,73 @@ void ProjectApolloMFD::Update (HDC hDC)
 			}
 			else
 				sprintf(buffer, "Press CLK to start upload");
-			TextOut(hDC, width / 2, (int) (height * 0.8), buffer, strlen(buffer));
+			skp->Text(width / 2, (int)(height * 0.8), buffer, strlen(buffer));
 		}
 		else if(g_Data.uplinkDataReady == 2) {
 			double linepos = 0.4;
-			SetTextAlign (hDC, TA_LEFT);
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
 			sprintf(buffer, "304   %ld", g_Data.emem[0]);
-			TextOut(hDC, (int) (width * 0.1), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.1), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			sprintf(buffer, "305   %ld", g_Data.emem[1]);
-			TextOut(hDC, (int) (width * 0.1), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.1), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			sprintf(buffer, "306   %ld", g_Data.emem[2]);
-			TextOut(hDC, (int) (width * 0.1), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.1), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			sprintf(buffer, "307   %ld", g_Data.emem[3]);
-			TextOut(hDC, (int) (width * 0.1), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.1), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			sprintf(buffer, "310   %ld", g_Data.emem[4]);
-			TextOut(hDC, (int) (width * 0.1), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.1), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			sprintf(buffer, "311   %ld", g_Data.emem[5]);
-			TextOut(hDC, (int) (width * 0.1), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.1), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			sprintf(buffer, "312   %ld", g_Data.emem[6]);
-			TextOut(hDC, (int) (width * 0.1), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.1), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			sprintf(buffer, "313   %ld", g_Data.emem[7]);
-			TextOut(hDC, (int) (width * 0.1), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
-			sprintf(buffer, "314   %ld", g_Data.emem[8]);		
-			TextOut(hDC, (int) (width * 0.1), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.1), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
+			sprintf(buffer, "314   %ld", g_Data.emem[8]);
+			skp->Text((int)(width * 0.1), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			sprintf(buffer, "315   %ld", g_Data.emem[9]);
-			TextOut(hDC, (int) (width * 0.1), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));		
+			skp->Text((int)(width * 0.1), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			linepos = 0.4;
 			sprintf(buffer, "316   %ld", g_Data.emem[10]);
-			TextOut(hDC, (int) (width * 0.55), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.55), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			sprintf(buffer, "317   %ld", g_Data.emem[11]);
-			TextOut(hDC, (int) (width * 0.55), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.55), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			sprintf(buffer, "320   %ld", g_Data.emem[12]);
-			TextOut(hDC, (int) (width * 0.55), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+			skp->Text((int)(width * 0.55), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			if (g_Data.uplinkDataType >= UPLINK_SV) {
 				sprintf(buffer, "321   %ld", g_Data.emem[13]);
-				TextOut(hDC, (int) (width * 0.55), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+				skp->Text((int)(width * 0.55), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 				sprintf(buffer, "322   %ld", g_Data.emem[14]);
-				TextOut(hDC, (int) (width * 0.55), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+				skp->Text((int)(width * 0.55), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 				sprintf(buffer, "323   %ld", g_Data.emem[15]);
-				TextOut(hDC, (int) (width * 0.55), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+				skp->Text((int)(width * 0.55), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 				sprintf(buffer, "324   %ld", g_Data.emem[16]);
-				TextOut(hDC, (int) (width * 0.55), (int) (height * (linepos+=0.05)), buffer, strlen(buffer));
+				skp->Text((int)(width * 0.55), (int)(height* (linepos += 0.05)), buffer, strlen(buffer));
 			}
 		}
 		else if (g_Data.uplinkDataReady == 3)
 		{
-			SetTextAlign(hDC, TA_LEFT);
+			skp->SetTextAlign(oapi::Sketchpad::LEFT);
 
 			if (g_Data.uplinkBuffer.size() > 0)
 			{
 				sprintf(buffer, "Uplink word: %d", g_Data.uplinkBuffer.front());
-				TextOut(hDC, (int)(width * 0.1), (int)(height * 0.4), buffer, strlen(buffer));
+				skp->Text((int)(width * 0.1), (int)(height * 0.4), buffer, strlen(buffer));
 			}
 		}
-		SetTextAlign (hDC, TA_LEFT);
-		SetTextColor (hDC, RGB(128, 128, 128));
+		skp->SetTextAlign(oapi::Sketchpad::LEFT);
+		skp->SetTextColor(RGB(128, 128, 128));
 		oapiGetObjectName(g_Data.vessel->GetHandle(), buffer, 100);
-		TextOut(hDC, (int) (width * 0.05), (int) (height * 0.95), buffer, strlen(buffer));
-		SetTextAlign (hDC, TA_CENTER);
+		skp->Text((int)(width * 0.05), (int)(height * 0.95), buffer, strlen(buffer));
+		skp->SetTextAlign(oapi::Sketchpad::CENTER);
 		oapiGetObjectName(g_Data.planet, buffer, 100);
-		TextOut(hDC, (int) (width * 0.5), (int) (height * 0.95), buffer, strlen(buffer));
-		SetTextAlign (hDC, TA_RIGHT);
+		skp->Text((int)(width * 0.5), (int)(height * 0.95), buffer, strlen(buffer));
+		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
 		if (g_Data.uplinkSlot == 0) {
 			sprintf(buffer, "This");
 		} else {
 			sprintf(buffer, "Other");
 		}		
-		TextOut(hDC, (int) (width * 0.95), (int) (height * 0.95), buffer, strlen(buffer));
+		skp->Text((int)(width * 0.95), (int)(height * 0.95), buffer, strlen(buffer));
 
 	}
 	else if (screen == m_buttonPages.page.Debug)
@@ -1247,7 +1249,7 @@ void ProjectApolloMFD::Update (HDC hDC)
 			strcpy(debugString, debugStringBuffer);
 			sprintf(debugStringBuffer,"");
 		}
-		TextOut(hDC, width / 2, (int)(height * 0.3), "Debug Data",10);
+		skp->Text(width / 2, (int)(height * 0.3), "Debug Data", 10);
 		if (strlen(debugString) > 35)
 		{
 			int i = 0;
@@ -1257,27 +1259,27 @@ void ProjectApolloMFD::Update (HDC hDC)
 			{
 				if (strlen(&debugString[i]) > 35)
 				{
-					TextOut(hDC, width / 2, (int) (height * h), &debugString[i], 35);
+					skp->Text(width / 2, (int)(height* h), &debugString[i], 35);
 					i = i + 35;
 					h = h + 0.05;
 				}
 				else
 				{
-					TextOut(hDC, width / 2, (int) (height * h), &debugString[i], strlen(&debugString[i]));
+					skp->Text(width / 2, (int)(height* h), &debugString[i], strlen(&debugString[i]));
 					done = true;
 				}
 			}
 		}
-		else TextOut(hDC, width / 2, (int) (height * 0.4), debugString, strlen(debugString));
+		else skp->Text(width / 2, (int)(height * 0.4), debugString, strlen(debugString));
 	}
 	// Draw LGC Setup screen
 	else if (screen == m_buttonPages.page.LGC) {
 		OBJHANDLE object;
 		VESSEL *vessel;
-		TextOut(hDC, width / 2, (int) (height * 0.3), "LGC Docked Init Data", 20);
+		skp->Text(width / 2, (int)(height * 0.3), "LGC Docked Init Data", 20);
 		// What's our status?
 		if(saturn == NULL){
-			// TextOut(hDC, width / 2, (int) (height * 0.4), "We are in the LM", 16);
+			// skp->Text(width / 2, (int) (height * 0.4), "We are in the LM", 16);
 			// We need to find the CM.
 			// In all of the scenarios in which the LM is present and selectable, the CM is already separated from the S4B.
 			object = oapiGetVesselByName("Gumdrop"); // A9
@@ -1337,33 +1339,33 @@ void ProjectApolloMFD::Update (HDC hDC)
 						tephem[1] = saturn->agc.vagc.Erasable[0][01707];
 						tephem[2] = saturn->agc.vagc.Erasable[0][01710];
 						sprintf(buffer,"TEPHEM: %05o %05o %05o",tephem[0],tephem[1],tephem[2]);
-						TextOut(hDC, width / 2, (int) (height * 0.4), buffer, strlen(buffer));
+						skp->Text(width / 2, (int)(height * 0.4), buffer, strlen(buffer));
 						// Format gimbal angles and print them
 						sprintf(buffer, "CSM O/I/M: %+07.2f %+07.2f %+07.2f", CMattitude.x*DEG, CMattitude.y*DEG, CMattitude.z*DEG);
-						TextOut(hDC, width / 2, (int) (height * 0.45), buffer, strlen(buffer));
+						skp->Text(width / 2, (int)(height * 0.45), buffer, strlen(buffer));
 						sprintf(buffer, "LM O/I/M: %+07.2f %+07.2f %+07.2f", LMattitude.x*DEG, LMattitude.y*DEG, LMattitude.z*DEG);
-						TextOut(hDC, width / 2, (int) (height * 0.5), buffer, strlen(buffer));
+						skp->Text(width / 2, (int)(height * 0.5), buffer, strlen(buffer));
 
 						//Docked IMU Fine Alignment
-						TextOut(hDC, width / 2, (int)(height * 0.6), "Docked IMU Fine Alignment", 25);
+						skp->Text(width / 2, (int)(height * 0.6), "Docked IMU Fine Alignment", 25);
 
 						sprintf(buffer, "V42: %+07.3f %+07.3f %+07.3f", g_Data.V42angles.x*DEG, g_Data.V42angles.y*DEG, g_Data.V42angles.z*DEG);
-						TextOut(hDC, width / 2, (int)(height * 0.7), buffer, strlen(buffer));
+						skp->Text(width / 2, (int)(height * 0.7), buffer, strlen(buffer));
 
 						if (g_Data.lmAlignType)
 						{
-							TextOut(hDC, width / 2, (int)(height * 0.85), "Alignment: Identical", 20);
+							skp->Text(width / 2, (int)(height * 0.85), "Alignment: Identical", 20);
 						}
 						else
 						{
-							TextOut(hDC, width / 2, (int)(height * 0.85), "Alignment: LVLH", 15);
+							skp->Text(width / 2, (int)(height * 0.85), "Alignment: LVLH", 15);
 						}
 
 						saturn = NULL; // Clobber
 				}
 			}
 		}else{
-			TextOut(hDC, width / 2, (int) (height * 0.4), "Do this from the LM", 19);
+			skp->Text(width / 2, (int)(height * 0.4), "Do this from the LM", 19);
 		}
 		/*
 		sprintf(buffer, "Socket: %i", close_Socket);
@@ -1374,45 +1376,45 @@ void ProjectApolloMFD::Update (HDC hDC)
 	{
 		if (saturn)
 		{
-			SetTextAlign(hDC, TA_CENTER);
+			skp->SetTextAlign(oapi::Sketchpad::CENTER);
 
 			if (FailureSubpage == 0)
 			{
-				TextOut(hDC, width / 2, (int)(height * 0.3), "CSM SECS Failures", 17);
+				skp->Text(width / 2, (int)(height * 0.3), "CSM SECS Failures", 17);
 
 				sprintf(buffer, "1: LET AutoJet Fail: %d", saturn->LaunchFail.LETAutoJetFail);
-				TextOut(hDC, width / 2, (int)(height * 0.4), buffer, strlen(buffer));
+				skp->Text(width / 2, (int)(height * 0.4), buffer, strlen(buffer));
 				sprintf(buffer, "2: LES Jet Motor Fail: %d", saturn->LaunchFail.LESJetMotorFail);
-				TextOut(hDC, width / 2, (int)(height * 0.45), buffer, strlen(buffer));
+				skp->Text(width / 2, (int)(height * 0.45), buffer, strlen(buffer));
 				if (saturn->stage < CSM_LEM_STAGE)
 				{
 					sprintf(buffer, "3: Liftoff Signal A Fail: %d", saturn->GetIU()->GetEDS()->GetLiftoffCircuitAFailure());
-					TextOut(hDC, width / 2, (int)(height * 0.5), buffer, strlen(buffer));
+					skp->Text(width / 2, (int)(height * 0.5), buffer, strlen(buffer));
 					sprintf(buffer, "4: Liftoff Signal B Fail: %d", saturn->GetIU()->GetEDS()->GetLiftoffCircuitBFailure());
-					TextOut(hDC, width / 2, (int)(height * 0.55), buffer, strlen(buffer));
+					skp->Text(width / 2, (int)(height * 0.55), buffer, strlen(buffer));
 				}
 				sprintf(buffer, "5: Auto Abort Enable Fail: %d", saturn->LaunchFail.AutoAbortEnableFail);
-				TextOut(hDC, width / 2, (int)(height * 0.6), buffer, strlen(buffer));
+				skp->Text(width / 2, (int)(height * 0.6), buffer, strlen(buffer));
 				sprintf(buffer, "6: Tower Jett 1 Fail: %d", saturn->SwitchFail.TowerJett1Fail);
-				TextOut(hDC, width / 2, (int)(height * 0.65), buffer, strlen(buffer));
+				skp->Text(width / 2, (int)(height * 0.65), buffer, strlen(buffer));
 				sprintf(buffer, "7: Tower Jett 2 Fail: %d", saturn->SwitchFail.TowerJett2Fail);
-				TextOut(hDC, width / 2, (int)(height * 0.7), buffer, strlen(buffer));
+				skp->Text(width / 2, (int)(height * 0.7), buffer, strlen(buffer));
 				sprintf(buffer, "8: SM Jett 1 Fail: %d", saturn->SwitchFail.SMJett1Fail);
-				TextOut(hDC, width / 2, (int)(height * 0.75), buffer, strlen(buffer));
+				skp->Text(width / 2, (int)(height * 0.75), buffer, strlen(buffer));
 				sprintf(buffer, "9: SM Jett 2 Fail: %d", saturn->SwitchFail.SMJett2Fail);
-				TextOut(hDC, width / 2, (int)(height * 0.8), buffer, strlen(buffer));
+				skp->Text(width / 2, (int)(height * 0.8), buffer, strlen(buffer));
 				sprintf(buffer, "10: Auto Apex Cover Deploy Fail: %d", saturn->LandFail.CoverFail);
-				TextOut(hDC, width / 2, (int)(height * 0.85), buffer, strlen(buffer));
+				skp->Text(width / 2, (int)(height * 0.85), buffer, strlen(buffer));
 				sprintf(buffer, "11: Auto Drogue Chute Deploy Fail: %d", saturn->LandFail.DrogueFail);
-				TextOut(hDC, width / 2, (int)(height * 0.9), buffer, strlen(buffer));
+				skp->Text(width / 2, (int)(height * 0.9), buffer, strlen(buffer));
 				sprintf(buffer, "12: Auto Main Chute Deploy Fail: %d", saturn->LandFail.MainFail);
-				TextOut(hDC, width / 2, (int)(height * 0.95), buffer, strlen(buffer));
+				skp->Text(width / 2, (int)(height * 0.95), buffer, strlen(buffer));
 			}
 			else if (FailureSubpage == 1)
 			{
 				if (isSaturnV)
 				{
-					TextOut(hDC, width / 2, (int)(height * 0.3), "Saturn V Failures", 17);
+					skp->Text(width / 2, (int)(height * 0.3), "Saturn V Failures", 17);
 
 					bool fail = 0.0;
 					double failtime = 0.0;
@@ -1422,25 +1424,25 @@ void ProjectApolloMFD::Update (HDC hDC)
 						{
 							saturn->GetEngineFailure(1, i + 1, fail, failtime);
 							sprintf(buffer, "S-IC Eng %d Fail: %d at T%+.1lf s", i + 1, fail, failtime);
-							TextOut(hDC, width / 2, (int)(height * (0.5 + 0.04*(double)i)), buffer, strlen(buffer));
+							skp->Text(width / 2, (int)(height * (0.5 + 0.04 * (double)i)), buffer, strlen(buffer));
 						}
 					}
 					if (saturn->stage < LAUNCH_STAGE_SIVB)
 					{
 						sprintf(buffer, "13: S-II Auto Sep Fail: %d", saturn->LaunchFail.SIIAutoSepFail);
-						TextOut(hDC, width / 2, (int)(height * 0.45), buffer, strlen(buffer));
+						skp->Text(width / 2, (int)(height * 0.45), buffer, strlen(buffer));
 
 						for (int i = 0;i < 5;i++)
 						{
 							saturn->GetEngineFailure(2, i + 1, fail, failtime);
 							sprintf(buffer, "S-II Eng %d Fail: %d at Ign%+.1lf s", i + 1, fail, failtime);
-							TextOut(hDC, width / 2, (int)(height * (0.75 + 0.04*(double)i)), buffer, strlen(buffer));
+							skp->Text(width / 2, (int)(height * (0.75 + 0.04 * (double)i)), buffer, strlen(buffer));
 						}
 					}
 				}
 				else
 				{
-					TextOut(hDC, width / 2, (int)(height * 0.3), "Saturn IB Failures", 18);
+					skp->Text(width / 2, (int)(height * 0.3), "Saturn IB Failures", 18);
 
 					bool fail = 0.0;
 					double failtime = 0.0;
@@ -1450,7 +1452,7 @@ void ProjectApolloMFD::Update (HDC hDC)
 						{
 							saturn->GetEngineFailure(1, i + 1, fail, failtime);
 							sprintf(buffer, "S-IB Eng %d Fail: %d at T%+.1lf s", i + 1, fail, failtime);
-							TextOut(hDC, width / 2, (int)(height * (0.5 + 0.04*(double)i)), buffer, strlen(buffer));
+							skp->Text(width / 2, (int)(height* (0.5 + 0.04 * (double)i)), buffer, strlen(buffer));
 						}
 					}
 				}
@@ -1458,15 +1460,16 @@ void ProjectApolloMFD::Update (HDC hDC)
 				if (saturn->stage < CSM_LEM_STAGE)
 				{
 					sprintf(buffer, "IU Platform Fail: %d at T%+.1lf s", saturn->GetIU()->GetEDS()->GetPlatformFail() ? 1 : 0, saturn->GetIU()->GetEDS()->GetPlatformFailTime());
-					TextOut(hDC, width / 2, (int)(height * 0.4), buffer, strlen(buffer));
+					skp->Text(width / 2, (int)(height * 0.4), buffer, strlen(buffer));
 				}
 			}
 		}
 		else
 		{
-			TextOut(hDC, width / 2, (int)(height * 0.5), "Failures not supported!", 23);
+			skp->Text(width / 2, (int)(height * 0.5), "Failures not supported!", 23);
 		}
 	}
+	return true;
 }
 
 // =============================================================================================

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.h
@@ -34,7 +34,7 @@ class Crawler;
 ///
 /// \ingroup MFD
 ///
-class ProjectApolloMFD: public MFD {
+class ProjectApolloMFD: public MFD2 {
 public:
 	ProjectApolloMFD (DWORD w, DWORD h, VESSEL *vessel);
 	~ProjectApolloMFD ();
@@ -42,7 +42,7 @@ public:
 	int ButtonMenu (const MFDBUTTONMENU **menu) const;
 	bool ConsumeButton (int bt, int event);
 	bool ConsumeKeyBuffered (DWORD key);
-	void Update (HDC hDC);
+	bool Update (oapi::Sketchpad* skp);
 	void GetStateVector (void);
 	bool SetSource(char *rstr);
 	bool SetIUSource(char *rstr);
@@ -125,7 +125,7 @@ protected:
 
 	void GetCSM();
 
-	HBITMAP hBmpLogo;
+	SURFHANDLE hLogo;
 	DWORD width;
 	DWORD height;
 	//We can link to the Saturn OR the Crawler.  Only the Saturn has full funcionality.  The Crawler can ONLY read the mission time.

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/BUILD.CPP
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/BUILD.CPP
@@ -279,7 +279,7 @@ fclose(config_file);
 fclose(debug);
 #endif
 
-if (NumPanels) panels[0]->GDI_Init_Resources();
+if (NumPanels) panels[0]->Sketchpad_Init_Resources();
 THERMAL->InitThermal();
 THERMAL->v=v;
 }
@@ -287,7 +287,7 @@ THERMAL->v=v;
 void PanelSDK::DoPanel(char *name)
 {
 panels[NumPanels]=new Panel;
-panels[NumPanels]->GDI_res=GDI_res; //same as before
+panels[NumPanels]->skp_res=skp_res; //same as before
 panels[NumPanels]->idx=NumPanels;
 panels[NumPanels]->v=v;
 panels[NumPanels]->parent=this;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Panel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Panel.cpp
@@ -25,7 +25,7 @@
 #include "instruments.h"
 #include <stdio.h>
 
-GDI_resources::~GDI_resources()
+Sketchpad_resources::~Sketchpad_resources()
 {
 
 if (Panel_Resources_Loaded){
@@ -49,7 +49,7 @@ for (i=1;i<num_brush;i++)
 
 Panel::Panel()
 {instruments=NULL;//no instruments
-GDI_res=NULL;
+skp_res=NULL;
 panel_logic=0;    //no lights.
 text_logic=0;
 pl_handle=-1;
@@ -188,25 +188,26 @@ return NULL;//problem, yes
 
 }
 
-void Panel::GDI_Init_Resources()
+void Panel::Sketchpad_Init_Resources()
 {
-  if (GDI_res==NULL) return; //nothing to load
- if (GDI_res->Panel_Resources_Loaded) return; //already loaded
+  if (skp_res==NULL) return; //nothing to load
+ if (skp_res->Panel_Resources_Loaded) return; //already loaded
  //load the default resources first
   //GDI_res->hFNT_MFD=CreateFont(12,0,0,0,FW_NORMAL,0,0,0,ANSI_CHARSET,OUT_RASTER_PRECIS,
 	//		 CLIP_DEFAULT_PRECIS,PROOF_QUALITY,DEFAULT_PITCH,"Arial");
-  GDI_res->hPEN_NULL=CreatePen(PS_NULL,1,RGB(0,0,0));
-  GDI_res->hPEN_Cyan=CreatePen(PS_SOLID,1,RGB(0,95,235));
-  GDI_res->hPEN_Green=CreatePen(PS_SOLID,1,RGB(0,255,0));
-  GDI_res->hBRUSH_TotalBlack=CreateSolidBrush(RGB(0,0,0));
-  GDI_res->hBRUSH_TotalWhite=CreateSolidBrush(RGB(255,255,255));
-  GDI_res->hBRUSH_Gray=CreateSolidBrush(RGB(200,200,200));
-  GDI_res->hPEN_Brown=CreatePen(PS_SOLID,1,RGB(90,90,90));
+ skp_res->hPEN_NULL= oapiCreatePen(0,1,RGB(0,0,0));
+ skp_res->hPEN_Cyan= oapiCreatePen(1,1,RGB(0,95,235));
+ skp_res->hPEN_Green= oapiCreatePen(1,1,RGB(0,255,0));
+ skp_res->hBRUSH_TotalBlack= oapiCreateBrush(RGB(0,0,0));
+ skp_res->hBRUSH_TotalWhite= oapiCreateBrush(RGB(255,255,255));
+ skp_res->hBRUSH_Gray= oapiCreateBrush(RGB(200,200,200));
+ skp_res->hPEN_Brown= oapiCreatePen(1,1,RGB(90,90,90));
 
-  GDI_res->Panel_Resources_Loaded=1;
+ skp_res->Panel_Resources_Loaded=1;
  }
 
 
-void Panel::SetGDI(GDI_resources *GDI)
-{GDI_res=GDI;};
-
+void Panel::SetResources(Sketchpad_resources *sr)
+{
+	skp_res=sr;
+}

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/PanelSDK.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/PanelSDK.cpp
@@ -35,7 +35,7 @@ PanelSDK::PanelSDK() {
 	NumPanels = 0;
 	InstDescriptor = NULL;
 	CustomVarList = NULL;
-	GDI_res = NULL;
+	skp_res = NULL;
 
     ELECTRIC = new E_system;
 	HYDRAULIC = new H_system;
@@ -53,7 +53,7 @@ PanelSDK::PanelSDK() {
 
 PanelSDK::~PanelSDK()
 {
-	if (GDI_res) delete GDI_res;
+	if (skp_res) delete skp_res;
 	if (InstDescriptor)	{
 		InstrumentDescriptor *runner;
 		runner = InstDescriptor;
@@ -97,32 +97,31 @@ InstDescriptor=new_desc;
 
 int PanelSDK::AddBitmapResource(char* BitmapName)
 {
-if (!GDI_res) GDI_res=new GDI_resources;
-GDI_res->num_surfaces++;
+if (!skp_res) skp_res=new Sketchpad_resources;
+skp_res->num_surfaces++;
 HBITMAP new_b=(HBITMAP)LoadImage(NULL,BitmapName,IMAGE_BITMAP,0,0,LR_LOADFROMFILE);
-GDI_res->h_Surface[GDI_res->num_surfaces]=oapiCreateSurface (new_b);
+skp_res->h_Surface[skp_res->num_surfaces]=oapiCreateSurface (new_b);
 if (new_b)
-return GDI_res->num_surfaces;
+return skp_res->num_surfaces;
 else
 return 0;
 }
 int PanelSDK::AddFontResource(char *FontName,int size)
 {
-if (!GDI_res) GDI_res=new GDI_resources;
-GDI_res->num_fonts++;
-GDI_res->hFNT_Panel[GDI_res->num_fonts]=CreateFont(size,0,0,0,FW_NORMAL,0,0,0,ANSI_CHARSET,OUT_RASTER_PRECIS,
-			 CLIP_DEFAULT_PRECIS,PROOF_QUALITY,DEFAULT_PITCH,FontName);
-if (GDI_res->hFNT_Panel[GDI_res->num_fonts])
-return GDI_res->num_fonts;
+if (!skp_res) skp_res=new Sketchpad_resources;
+skp_res->num_fonts++;
+skp_res->hFNT_Panel[skp_res->num_fonts]= oapiCreateFont(size, true, FontName);
+if (skp_res->hFNT_Panel[skp_res->num_fonts])
+return skp_res->num_fonts;
 else
 return 0;
 }
 int PanelSDK::AddBrushResource(int red,int green,int blue)
 {
-if (!GDI_res) GDI_res=new GDI_resources;
-GDI_res->num_brush++;
-GDI_res->hPEN[GDI_res->num_brush]=CreatePen(PS_SOLID,1,RGB(red,green,blue));
-return GDI_res->num_brush;
+if (!skp_res) skp_res=new Sketchpad_resources;
+skp_res->num_brush++;
+skp_res->hPEN[skp_res->num_brush]=oapiCreatePen(1,1,RGB(red,green,blue));
+return skp_res->num_brush;
 }
 bool  PanelSDK::LoadPanel(int id)
 {

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/PanelSDK.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/PanelSDK.h
@@ -50,7 +50,7 @@
 class Panel;
 class InstrumentDescriptor;
 class CustomVariable;
-class GDI_resources;
+class Sketchpad_resources;
 class VESSEL;
 class E_system;
 class H_system;
@@ -125,7 +125,7 @@ private:
 	int AddBrushResource(int red,int green, int blue);
 	int NumPanels;
 	int Current_Panel;
-	GDI_resources *GDI_res;	//panel SDK holds the resources
+	Sketchpad_resources *skp_res;	//panel SDK holds the resources
 };
 
 #endif

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/instruments.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/instruments.h
@@ -290,25 +290,25 @@ public:
 //--------------------------------PANEL STUFF STARTS FROM HERE ----------------
 
 
-class  GDI_resources //global holder of resources
+class  Sketchpad_resources //global holder of resources
 {public:
 	//these are always present
-    HBRUSH hBRUSH_TotalBlack;
-	HBRUSH hBRUSH_TotalWhite;
-	HBRUSH hBRUSH_Gray;
+	oapi::Brush *hBRUSH_TotalBlack;
+	oapi::Brush *hBRUSH_TotalWhite;
+	oapi::Brush *hBRUSH_Gray;
 
-	HPEN  hPEN_NULL,hPEN_Cyan,hPEN_Brown;
-	HPEN  hPEN_Green;
+	oapi::Pen *hPEN_NULL, *hPEN_Cyan, *hPEN_Brown;
+	oapi::Pen *hPEN_Green;
 
 	SURFHANDLE h_Surface[50]; //up to 50 resources can be defined
-	HFONT hFNT_Panel[10];	//we can use up to 10 fonts on texts
-    HPEN  hPEN[10];
+	oapi::Font *hFNT_Panel[10];	//we can use up to 10 fonts on texts
+	oapi::Pen *hPEN[10];
 	bool Panel_Resources_Loaded;
 	int num_surfaces;
 	int num_fonts;
 	int num_brush;
-	GDI_resources() {Panel_Resources_Loaded=0;num_surfaces=0;num_fonts=0;num_brush=0;};
-	~GDI_resources();
+	Sketchpad_resources() {Panel_Resources_Loaded=0;num_surfaces=0;num_fonts=0;num_brush=0;};
+	~Sketchpad_resources();
 
 };
 
@@ -343,7 +343,6 @@ public:
    char name[25];					//the name of the panel
 
    HINSTANCE hModule;				//handle to program instance // ??need this to load resource bitmaps.. ugh.. windows is idiot!!!
-   HDC hDC;
 
    instrument_list *instruments;	//list of instruments
 
@@ -384,10 +383,10 @@ public:
    void SetNeighbours();
 
 	//GDI management
-   GDI_resources *GDI_res;
-   void SetGDI(GDI_resources *GDI);
-   void GDI_Init_Resources();
-   void GDI_Dealocate_Resources();
+   Sketchpad_resources*skp_res;
+   void SetResources(Sketchpad_resources*sr);
+   void Sketchpad_Init_Resources();
+   void Sketchpad_Deallocate_Resources();
 
 
    void CodeCallFromSwitch(int index);	//some swithces need to run a code when activated

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/intruments.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/intruments.cpp
@@ -57,28 +57,28 @@ idx=index;
 
 void CText::PaintMe()
 {
-  HDC hDC=oapiGetDC(parent->surf);
-  SetBkMode(hDC,TRANSPARENT);
+	oapi::Sketchpad *skp = oapiGetSketchpad(parent->surf);
+	skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
 
-  if (parent->text_logic) {SetTextColor(hDC,RGB(color[0],color[1],color[2]));
-						   SelectObject(hDC,parent->GDI_res->hPEN[ColPenIndex]);
-							}
-  else					   {SetTextColor(hDC,RGB(nocol[0],nocol[1],nocol[2]));
-							 SelectObject(hDC,parent->GDI_res->hPEN[NoColPenIndex]);
-							};
-  SetTextAlign(hDC,TA_CENTER);
-  SetBkMode(hDC,TRANSPARENT);
-  SelectObject(hDC,parent->GDI_res->hFNT_Panel[FontIndex]);
-  if (direction){
-  MoveToEx(hDC,length-1, direction*7+5,NULL);
-  LineTo(hDC,length-1,5);
-  LineTo(hDC,length/2+slen/2,5);
-  MoveToEx(hDC,length/2-slen/2, 5,NULL);
-  LineTo(hDC,0,5);
-  LineTo(hDC,0,direction*7+5);};
-  TextOut(hDC,length/2,0,text, sizeof(char)*strlen(text));
+	if (parent->text_logic) {skp->SetTextColor(oapiGetColour(color[0],color[1],color[2]));
+							skp->SetPen(parent->skp_res->hPEN[ColPenIndex]);
+								}
+	else					   {skp->SetTextColor(oapiGetColour(nocol[0],nocol[1],nocol[2]));
+								skp->SetPen(parent->skp_res->hPEN[NoColPenIndex]);
+								};
+	skp->SetTextAlign(oapi::Sketchpad::CENTER);
+	skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
+	skp->SetFont(parent->skp_res->hFNT_Panel[FontIndex]);
+	if (direction){
+	skp->MoveTo(length-1, direction*7+5);
+	skp->LineTo(length-1,5);
+	skp->LineTo(length/2+slen/2,5);
+	skp->MoveTo(length/2-slen/2, 5);
+	skp->LineTo(0,5);
+	skp->LineTo(0,direction*7+5);};
+	skp->Text(length/2,0,text, sizeof(char)*strlen(text));
 
- oapiReleaseDC(parent->surf,hDC);
+	oapiReleaseSketchpad(skp);
 };
 void CText::SetLight()
 {
@@ -102,9 +102,9 @@ void Switch::RegisterMe(int index)
 void Switch::PaintMe()
 { if (SRF_index){
 	if (parent->panel_logic)
-	oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,size_x-pos*size_x,size_y,size_x,size_y,0xFFFFFF);
+	oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,size_x-pos*size_x,size_y,size_x,size_y,0xFFFFFF);
 	else
-	oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,size_x-pos*size_x,0,size_x,size_y,0xFFFFFF);
+	oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,size_x-pos*size_x,0,size_x,size_y,0xFFFFFF);
 }
 };
 
@@ -193,14 +193,14 @@ void Rotational::RegisterMe(int index)
 void Rotational::PaintMe()
 {
 if (parent->panel_logic)
- oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,0,size_y,size_x,size_y);
+ oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,0,size_y,size_x,size_y);
 else
- oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,0,0,size_x,size_y);
+ oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,0,0,size_x,size_y);
 
-HDC hDC=oapiGetDC(local_blt);
-SelectObject(hDC,parent->GDI_res->hBRUSH_TotalWhite);
-SelectObject(hDC,parent->GDI_res->hPEN_NULL);
-Rectangle(hDC,0,0,2*board_size+1,2*board_size+1);
+oapi::Sketchpad* skp = oapiGetSketchpad(local_blt);
+skp->SetBrush(parent->skp_res->hBRUSH_TotalWhite);
+skp->SetPen(parent->skp_res->hPEN_NULL);
+skp->Rectangle(0, 0, 2 * board_size + 1, 2 * board_size + 1);
 
 double ang;
 if (G)
@@ -213,18 +213,18 @@ if (last_paint<ang) {if (ang-last_paint<0.01) last_paint=ang;
 					};
 
 ang=last_paint;
-POINT S[3];
+oapi::IVECTOR2 S[3];
 
 for (int i=0;i<3;i++) // rotate the pointer by 'ang'
 {
    S[i].x = (long)(board_size+ TR[i].x*cos(ang)-TR[i].y*sin(ang));
    S[i].y = (long)(board_size+ TR[i].x*sin(ang)+TR[i].y*cos(ang));
 }
-SelectObject(hDC,parent->GDI_res->hBRUSH_TotalBlack);
-SelectObject(hDC,parent->GDI_res->hPEN_NULL);
+skp->SetBrush(parent->skp_res->hBRUSH_TotalBlack);
+skp->SetPen(parent->skp_res->hPEN_NULL);
 
-Polygon(hDC,S,3);// then the pointer
-oapiReleaseDC(local_blt,hDC);
+skp->Polygon(S, 3);// then the pointer
+oapiReleaseSketchpad(skp);
 //we need to find the blit point aswell
 //double blt_x=33 - cos(ang)*20; //40-5-sin(angle)*radiu
 //double blt_y=30 - sin(ang)*20;
@@ -258,12 +258,12 @@ sprintf(format_string,"%%%i.0f",size);
 sprintf(bit_blf,format_string,last_value);
 for (int i=0;i<size;i++)
 {	if (bit_blf[i]==32)//space
-			oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],i*size_x,0,0,0,size_x,size_y);	//put a 0 there
+			oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],i*size_x,0,0,0,size_x,size_y);	//put a 0 there
 	else if (bit_blf[i]=='.')
-			oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],i*size_x,0,0,0,size_x,size_y);	//put a 0 there;//comma
+			oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],i*size_x,0,0,0,size_x,size_y);	//put a 0 there;//comma
 
 	else
-	oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],i*size_x,0,(bit_blf[i]-48)*size_x,0,size_x,size_y);
+	oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],i*size_x,0,(bit_blf[i]-48)*size_x,0,size_x,size_y);
 
 }
 
@@ -304,25 +304,25 @@ void Linear::SetAngle(double ang)
 void Linear::DoNeedle()
 {
 local_blt=oapiCreateSurface(needle_h+3,needle_h+3);
-POINT TR[3];
+oapi::IVECTOR2 TR[3];
 TR[0].x = (long)(-needle_h/2.0); TR[0].y = (long)(-needle_w/2.0);
 TR[1].x = (long)(-needle_h/2.0); TR[1].y = (long)(needle_w/2.0);
 TR[2].x = (long)(needle_h/2.0);  TR[2].y=0;
-POINT S[3];
+oapi::IVECTOR2 S[3];
 for (int i=0;i<3;i++) // rotate the pointer by 'ang'
 {
    S[i].x = (long)(1+needle_h/2.0+ TR[i].x*cos(angle)-TR[i].y*sin(angle));
    S[i].y = (long)(1+needle_h/2.0+ TR[i].x*sin(angle)+TR[i].y*cos(angle));
 }
-HDC hDC=oapiGetDC(local_blt);
- //SelectObject(hDC,parent->GDI_res->hBRUSH_TotalWhite);
- //SelectObject(hDC,parent->GDI_res->hPEN_NULL);
- Rectangle(hDC,0,0,needle_h+2,needle_h+2);
+oapi::Sketchpad* skp = oapiGetSketchpad(local_blt);
+ //skp->SetBrush(parent->skp_res->hBRUSH_TotalWhite);
+ //skp->SetPen(parent->skp_res->hPEN_NULL);
+skp->Rectangle(0, 0, needle_h + 2, needle_h + 2);
 
- SelectObject(hDC,parent->GDI_res->hBRUSH_TotalBlack);
- SelectObject(hDC,parent->GDI_res->hPEN_NULL);
- Polygon(hDC,S,3);// draw the pointer
-oapiReleaseDC(local_blt,hDC);
+skp->SetBrush(parent->skp_res->hBRUSH_TotalBlack);
+skp->SetPen(parent->skp_res->hPEN_NULL);
+skp->Polygon(S, 3);// draw the pointer
+oapiReleaseSketchpad(skp);
 }
 void Linear::SetNeedleSize(int w, int h)
 {needle_h=h;
@@ -358,9 +358,9 @@ void Linear::PrintBackground()
 {
 //first, copy the appropriate background,
  if (parent->panel_logic)
-	oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,size_x,0,size_x,size_y);
+	oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,size_x,0,size_x,size_y);
  else
-    oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,0,0,size_x,size_y);
+    oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,0,0,size_x,size_y);
  bkg_printed=1;
 };
 void Linear::PaintMe()
@@ -371,10 +371,10 @@ PrintBackground();
 
 GetPixel1();
 if (parent->panel_logic)
-oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],last_x,last_y,size_x+last_x,last_y,needle_h,needle_h);
+oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],last_x,last_y,size_x+last_x,last_y,needle_h,needle_h);
 
 else
-oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],last_x,last_y,last_x,last_y,needle_h,needle_h);
+oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],last_x,last_y,last_x,last_y,needle_h,needle_h);
 
 //oapiBlt(parent->surf,local_blt,6,last1,1,0,9,9,0xFFFFFF);
 oapiBlt(parent->surf,local_blt,point_x,point_y,1,1,needle_h,needle_h,0xFFFFFF);
@@ -419,19 +419,19 @@ void TB::PaintMe()
 if ((IsOn())){
 if (blink){
 if (paint_on==1)
-	oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,size_x,0,size_x,size_y);
+	oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,size_x,0,size_x,size_y);
 else
-    oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,2*size_x,0,size_x,size_y);
+    oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,2*size_x,0,size_x,size_y);
 
 }else {
 
-	oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,size_x,0,size_x,size_y);
+	oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,size_x,0,size_x,size_y);
 	paint_on=1;
 	}
 
 }
 else{
-    oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,0,0,size_x,size_y);
+    oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,0,0,size_x,size_y);
 	paint_on=0;blink_on=0;timer=0;
 };
 
@@ -488,7 +488,7 @@ oapiRegisterPanelArea(index,_R(ScrX,ScrY,ScrX+size_x,ScrY+size_y),PANEL_REDRAW_M
 
 void Rot::PaintMe()
 {
-oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,(c_pos-min)*size_x,0,size_x,size_y,0xFFFFFF);
+oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,(c_pos-min)*size_x,0,size_x,size_y,0xFFFFFF);
 }
 void Rot::RefreshMe()
 {PaintMe();}
@@ -554,7 +554,6 @@ int offs=120;
 if ((armed)&(parent->panel_logic)) offs=0;
 if (armed)
 {
-//HDC hDC=oapiGetDC(parent->GDI_res->hReentrySRF);
 double x,y;
 //get the position of the marker:
 
@@ -573,13 +572,13 @@ if (y>pointer_y) pointer_y+=0.2;
 if (y<pointer_y) pointer_y-=0.2;
 pointer_x=(int)x;
 if (trace) //if we trace, then we blit directly to the surf
-oapiBlt(parent->GDI_res->h_Surface[SRF_index],
-		parent->GDI_res->h_Surface[SRF_bug_index],pointer_x,(int)pointer_y,0,0,bug_x,bug_y,0xFFFFFF);
+oapiBlt(parent->skp_res->h_Surface[SRF_index],
+		parent->skp_res->h_Surface[SRF_bug_index],pointer_x,(int)pointer_y,0,0,bug_x,bug_y,0xFFFFFF);
 
 
 }
-oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_index],0,0,strip_offset,0,size_x,size_y);
-oapiBlt(parent->surf,parent->GDI_res->h_Surface[SRF_mask_index],0,0,0,0,size_x,size_y,0x00);
+oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_index],0,0,strip_offset,0,size_x,size_y);
+oapiBlt(parent->surf,parent->skp_res->h_Surface[SRF_mask_index],0,0,0,0,size_x,size_y,0x00);
 }
 void Plot::RefreshMe()
 {
@@ -628,24 +627,24 @@ oapiRegisterMFD(mfd_type,mfdspecs);
 void inst_MFD::PaintMe()
 {
 
-HDC hDC=oapiGetDC(parent->surf);
+	oapi::Sketchpad* skp = oapiGetSketchpad(parent->surf);
 
-SelectObject(hDC, parent->GDI_res->hFNT_Panel[FontIndex]);
-SetTextColor (hDC, RGB(red,green,blue));
-SetTextAlign (hDC, TA_CENTER);
-SetBkMode (hDC, TRANSPARENT);
+	skp->SetFont(parent->skp_res->hFNT_Panel[FontIndex]);
+	skp->SetTextColor(RGB(red, green, blue));
+	skp->SetTextAlign(oapi::Sketchpad::CENTER);
+	skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
 
-const char *label;
+	const char *label;
 	for (int bt = 0; bt < mfdspecs.nbt_left+mfdspecs.nbt_right; bt++) {
-		if (label = oapiMFDButtonLabel (mfd_type, bt))
-			{if (bt<mfdspecs.nbt_left)
-					TextOut (hDC, (int)(button_w/2.0), mfdspecs.bt_yofs+
-					mfdspecs.bt_ydist*bt, label, strlen(label));
-			else TextOut (hDC, (int)(width+button_w*1.5), mfdspecs.bt_yofs+
-					mfdspecs.bt_ydist*(bt-6), label, strlen(label));}
+		if (label = oapiMFDButtonLabel (mfd_type, bt)) {
+			if (bt<mfdspecs.nbt_left)
+				skp->Text((int)(button_w / 2.0), mfdspecs.bt_yofs +
+					mfdspecs.bt_ydist * bt, label, strlen(label));
+			else skp->Text((int)(width + button_w * 1.5), mfdspecs.bt_yofs +
+				mfdspecs.bt_ydist * (bt - 6), label, strlen(label));
+		}
 	}
-oapiReleaseDC(parent->surf,hDC);
-
+	oapiReleaseSketchpad(skp);
 };
 
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/nasspdefs.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/nasspdefs.h
@@ -223,10 +223,10 @@
 ///
 typedef struct {
 	HINSTANCE hDLL;		///< DLL handle.
-	HFONT font[3];		///< GDI fonts.
+	oapi::Font  *font[3];		///< GDI fonts.
 	DWORD col[6];		///< GDI colors.
-	HBRUSH brush[4];	///< GDI brushes.
-	HPEN pen[7];		///< GDI pens.
+	oapi::Brush *brush[4];	///< GDI brushes.
+	oapi::Pen   *pen[7];		///< GDI pens.
 } GDIParams;
 
 //

--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
@@ -3914,16 +3914,13 @@ void RoundMeter::DrawNeedle (SURFHANDLE surf, int x, int y, double rad, double a
 	// Needle function by Rob Conley from Mercury code
 	
 	double dx = rad * cos(angle), dy = rad * sin(angle);
-	HGDIOBJ oldObj;
 
-	HDC hDC = oapiGetDC (surf);
-	oldObj = SelectObject (hDC, Pen1);
-	MoveToEx (hDC, x, y, 0); LineTo (hDC, x + (int)(0.85*dx+0.5), y - (int)(0.85*dy+0.5));
-	SelectObject (hDC, oldObj);
-	oldObj = SelectObject (hDC, Pen0);
-	MoveToEx (hDC, x, y, 0); LineTo (hDC, x + (int)(dx+0.5), y - (int)(dy+0.5));
-	SelectObject (hDC, oldObj);
-	oapiReleaseDC (surf, hDC);
+	oapi::Sketchpad* skp = oapiGetSketchpad(surf);
+	skp->SetPen(Pen1);
+	skp->MoveTo(x, y); skp->LineTo(x + (int)(0.85 * dx + 0.5), y - (int)(0.85 * dy + 0.5));
+	skp->SetPen(Pen0);
+	skp->MoveTo(x, y); skp->LineTo(x + (int)(dx + 0.5), y - (int)(dy + 0.5));
+	oapiReleaseSketchpad(skp);
 }
 
 ElectricMeter::ElectricMeter(double minVal, double maxVal, double vMin, double vMax)

--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
@@ -3857,7 +3857,7 @@ RoundMeter::~RoundMeter()
 		delete pswitchrot;
 }
 
-void RoundMeter::Init(HPEN p0, HPEN p1, SwitchRow &row)
+void RoundMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row)
 
 {
 	MeterSwitch::Init(row);
@@ -3932,7 +3932,7 @@ void ElectricMeter::SetSurface(SURFHANDLE srf, int x, int y)
 	FrameSurface = srf;
 }
 
-void ElectricMeter::Init(HPEN p0, HPEN p1, SwitchRow &row, e_object *dcindicatorswitch)
+void ElectricMeter::Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, e_object *dcindicatorswitch)
 
 {
 	RoundMeter::Init(p0, p1, row);

--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
@@ -2851,20 +2851,25 @@ void OrdealRotationalSwitch::DrawSwitch(SURFHANDLE drawSurface) {
 		char label[100];
 		sprintf(label, "%d", value);
 
-		HDC hDC = oapiGetDC(drawSurface);
-		HFONT font = CreateFont(22, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, 0, 0, 0, 0, "Arial");
-		SelectObject(hDC, font);
-		SetTextColor(hDC, RGB(255, 255, 255));
-		SetTextAlign(hDC, TA_CENTER);
-		SetBkMode(hDC, OPAQUE);
-		SetBkColor(hDC, RGB(146, 146, 146));
+		oapi::Sketchpad* skp = oapiGetSketchpad(drawSurface);
+		oapi::Font* font = oapiCreateFont(22, true, "Arial", FONT_BOLD);
+		oapi::Brush* brush = oapiCreateBrush(RGB(146, 146, 146));
+		oapi::Pen* pen = oapiCreatePen(1, 1, RGB(146, 146, 146));
+		skp->SetBrush(brush);
+		skp->SetPen(pen);
+		skp->SetFont(font);
+		skp->SetTextColor(RGB(255, 255, 255));
+		skp->SetTextAlign(oapi::Sketchpad::CENTER);
+		skp->SetBackgroundMode(oapi::Sketchpad::BK_OPAQUE);
+		skp->SetBackgroundColor(RGB(146, 146, 146));
 
 		if (GetState() == 0) {
 			rt.left = 29 + x;
 			rt.top = 24 + y;
 			rt.right = 60 + x;
 			rt.bottom = 55 + y;
-			ExtTextOut(hDC, 44 + x, 28 + y, ETO_OPAQUE, &rt, label, strlen(label), NULL);
+			skp->Rectangle(rt.left, rt.top, rt.right, rt.bottom);
+			skp->Text(44 + x, 28 + y, label, strlen(label));
 
 		}
 		else if (GetState() == 1) {
@@ -2872,7 +2877,8 @@ void OrdealRotationalSwitch::DrawSwitch(SURFHANDLE drawSurface) {
 			rt.top = 30 + y;
 			rt.right = 59 + x;
 			rt.bottom = 52 + y;
-			ExtTextOut(hDC, 49 + x, 31 + y, ETO_OPAQUE, &rt, label, strlen(label), NULL);
+			skp->Rectangle(rt.left, rt.top, rt.right, rt.bottom);
+			skp->Text(49 + x, 31 + y, label, strlen(label));
 
 		}
 		else if (GetState() == 2) {
@@ -2880,11 +2886,17 @@ void OrdealRotationalSwitch::DrawSwitch(SURFHANDLE drawSurface) {
 			rt.top = 29 + y;
 			rt.right = 60 + x;
 			rt.bottom = 59 + y;
-			ExtTextOut(hDC, 44 + x, 34 + y, ETO_OPAQUE, &rt, label, strlen(label), NULL);
+			skp->Rectangle(rt.left, rt.top, rt.right, rt.bottom);
+			skp->Text(44 + x, 34 + y, label, strlen(label));
 
 		}
 		else if (GetState() == 3) {
-			TextOut(hDC, 42 + x, 36 + y, label, strlen(label));
+			rt.left = 29 + x;
+			rt.top = 35 + y;
+			rt.right = 57 + x;
+			rt.bottom = 59 + y;
+			skp->Rectangle(rt.left, rt.top, rt.right, rt.bottom);
+			skp->Text(42 + x, 36 + y, label, strlen(label));
 
 		}
 		else if (GetState() == 4) {
@@ -2892,11 +2904,12 @@ void OrdealRotationalSwitch::DrawSwitch(SURFHANDLE drawSurface) {
 			rt.top = 30 + y;
 			rt.right = 54 + x;
 			rt.bottom = 60 + y;
-			ExtTextOut(hDC, 37 + x, 34 + y, ETO_OPAQUE, &rt, label, strlen(label), NULL);
+			skp->Rectangle(rt.left, rt.top, rt.right, rt.bottom);
+			skp->Text(37 + x, 34 + y, label, strlen(label));
 
 		}
 		else if (GetState() == 5) {
-			TextOut(hDC, 32 + x, 31 + y, label, strlen(label));
+			skp->Text(32 + x, 31 + y, label, strlen(label));
 
 		}
 		else if (GetState() == 6) {
@@ -2904,11 +2917,14 @@ void OrdealRotationalSwitch::DrawSwitch(SURFHANDLE drawSurface) {
 			rt.top = 24 + y;
 			rt.right = 55 + x;
 			rt.bottom = 54 + y;
-			ExtTextOut(hDC, 39 + x, 28 + y, ETO_OPAQUE, &rt, label, strlen(label), NULL);
+			skp->Rectangle(rt.left, rt.top, rt.right, rt.bottom);
+			skp->Text(39 + x, 28 + y, label, strlen(label));
 		}
 
-		DeleteObject(font);
-		oapiReleaseDC(drawSurface, hDC);
+		oapiReleaseFont(font);
+		oapiReleaseBrush(brush);
+		oapiReleasePen(pen);
+		oapiReleaseSketchpad(skp);
 	}
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.h
@@ -1632,14 +1632,14 @@ class RoundMeter : public MeterSwitch {
 public:
 	RoundMeter();
 	virtual ~RoundMeter();
-	void Init(HPEN p0, HPEN p1, SwitchRow &row);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row);
 	void DefineVCAnimations(UINT vc_idx);
 	void SetRotationRange(const double range);
 	virtual void OnPostStep(double SimT, double DeltaT, double MJD);
 	
 protected:
-	HPEN Pen0;
-	HPEN Pen1;
+	oapi::Pen *Pen0;
+	oapi::Pen *Pen1;
 
 	void DrawNeedle (SURFHANDLE surf, int x, int y, double rad, double angle);
 
@@ -1670,7 +1670,7 @@ public:
 	///
 	/// \brief Initialise the meter.
 	///
-	void Init(HPEN p0, HPEN p1, SwitchRow &row, e_object *dcindicatorswitch);
+	void Init(oapi::Pen *p0, oapi::Pen *p1, SwitchRow &row, e_object *dcindicatorswitch);
 
 	///
 	/// \brief Actually draw the switch.


### PR DESCRIPTION
This is work to switch graphics from the GDI API to the sketchpad API.
There are some visual differences as noted here with the D3D9Client (these are animated gif, you may have to zoom in a little to see what happens...)
- ~~On the EMS the "RSITriangle" is fatter on GDI and there's some kind of shadowing effect~~ (fixed) :
![EMS](https://user-images.githubusercontent.com/103931250/211054057-f8b9479b-f591-44d6-bb0d-1762c961f6e2.gif)
- The text on the MFD buttons is also shifted for some texts :
![MFD-v2](https://user-images.githubusercontent.com/103931250/211165689-eb59a68a-422f-40a9-88d3-350f0949ee00.gif)

Any ideas about the cause of these differences? Are they significant enough to be a problem?