### PR TITLE
Provide safe Watt to dBm conversion

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_aux/RF_calc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_aux/RF_calc.h
@@ -29,6 +29,18 @@
 
 #define RF_ZERO_POWER_DBM -1000.0; //safe "0" for power, nothing should ever get this low
 
+/// \brief Safe conversion from W to dBm
+/// \param W The power in watts RMS
+/// \return The power in dBm
+static inline double RFCALC_W2dBm(double W) {
+	if (W > 0.0) {
+		return 10.0 * log10(W) + 30.0;
+	}
+	else {
+		return RF_ZERO_POWER_DBM;
+	}
+}
+
 /// \brief Calcluate Received Power
 ///
 /// This function is a simple inplimentation of Friis transmission equation.
@@ -50,12 +62,7 @@ static inline double RFCALC_rcvdPower(double xmitrPower, double xmitrGain, doubl
 	wavelength = C0 / (frequency);
 
 	rcvdPower = xmitrPower * xmitrGain * rcvrGain * pow((wavelength / (4 * PI * distance)), 2); //watts
-	rcvdPower = 10.0 * log10(1000.0 * rcvdPower); //convert to dBm
-
-	if (fpclassify(rcvdPower) != FP_NORMAL)
-	{
-		return RF_ZERO_POWER_DBM;
-	}
+	rcvdPower = RFCALC_W2dBm(rcvdPower); //convert to dBm
 
 	return rcvdPower;
 }

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
@@ -1074,7 +1074,7 @@ void HGA::TimeStep(double simt, double simdt)
 	}
 
 	RecvdHGAPower = GroundTransmitterRFProperties.Power * GroundTransmitterRFProperties.Gain *gain*pow(HGAWavelength/(4*PI*EarthSignalDist),2); //maximum recieved power to the HGA on axis in watts
-	RecvdHGAPower_dBm = 10*log10(1000*RecvdHGAPower);
+	RecvdHGAPower_dBm = RFCALC_W2dBm(RecvdHGAPower);
 	SignalStrengthScaleFactor = SBandAntenna::dBm2SignalStrength(RecvdHGAPower_dBm);
 
 	//sprintf(oapiDebugString(), "Received HGA Power: %lf fW, %lf dBm", RecvdHGAPower*1000000000000000, RecvdHGAPower_dBm); //show theoretical max HGA recieved in Femtowatts and dBm
@@ -1336,7 +1336,7 @@ void OMNI::TimeStep()
 	EarthSignalDist = length(pos - GroundTransmitterRFProperties.GlobalPosition) - oapiGetSize(hEarth); //distance from earth's surface in meters
 
 	RecvdOMNIPower = GroundTransmitterRFProperties.Power * GroundTransmitterRFProperties.Gain * OMNI_Gain * pow(OMNIWavelength / (4 * PI*EarthSignalDist), 2); //maximum recieved power to the HGA on axis in watts
-	RecvdOMNIPower_dBm = 10 * log10(1000 * RecvdOMNIPower);
+	RecvdOMNIPower_dBm = RFCALC_W2dBm(RecvdOMNIPower);
 	SignalStrengthScaleFactor = SBandAntenna::dBm2SignalStrength(RecvdOMNIPower_dBm);
 
 	if (relang < 160*RAD)
@@ -5686,7 +5686,7 @@ void RNDZXPDRSystem::TimeStep(double simdt)
 		if (RadarDist > 80.0*0.3048)
 		{
 			RCVDPowerdB = RCVDgain * RNDZXPDRGain * RCVDpow*pow((C0 / (RCVDfreq * 1000000)) / (4 * PI*RadarDist), 2); //watts
-			RCVDPowerdB = 10.0 * log10(1000.0 * RCVDPowerdB); //convert to dBm
+			RCVDPowerdB = RFCALC_W2dBm(RCVDPowerdB); //convert to dBm
 		}
 		else
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_rr.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_rr.cpp
@@ -403,7 +403,7 @@ void LEM_RR::Timestep(double simdt) {
 			RCVDgain = pow(10.0, (RCVDgain / 10.0)); //convert to ratio from dB
 
 			RecvdRRPower = RCVDpow*AntennaGain*RCVDgain*pow((C0 / (RCVDfreq * 1000000)) / (4.0 * PI*length(R)), 2.0);
-			RecvdRRPower_dBm = 10 * log10(1000 * RecvdRRPower);
+			RecvdRRPower_dBm = RFCALC_W2dBm(RecvdRRPower);
 			//sprintf(oapiDebugString(), "RecvdRRPower_dBm = %lf dBm", RecvdRRPower_dBm);
 			SignalStrengthScaleFactor = LEM_RR::dBm2SignalStrength(RecvdRRPower_dBm);
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
@@ -2858,7 +2858,7 @@ void LEM_SteerableAnt::Timestep(double simdt){
 	EarthSignalDist = length(pos - GroundTransmitterRFProperties.GlobalPosition) - oapiGetSize(hEarth); //distance from earth's surface in meters
 
 	RecvdLEM_SteerableAntPower = GroundTransmitterRFProperties.Power * GroundTransmitterRFProperties.Gain * LEM_SteerableAntGain * pow((LEM_SteerableAntWavelength /(4 * PI*EarthSignalDist)), 2); //maximum recieved power to the HGA on axis in watts
-	RecvdLEM_SteerableAntPower_dBm = 10 * log10(1000 * RecvdLEM_SteerableAntPower);
+	RecvdLEM_SteerableAntPower_dBm = RFCALC_W2dBm(RecvdLEM_SteerableAntPower);
 
 	double SignalStrengthScaleFactor = LEM_SteerableAnt::dBm2SignalStrength(RecvdLEM_SteerableAntPower_dBm);
 
@@ -3063,7 +3063,7 @@ void LM_OMNI::Timestep()
 	EarthSignalDist = length(pos - GroundTransmitterRFProperties.GlobalPosition) - oapiGetSize(hEarth); //distance from earth's surface in meters
 
 	RecvdOMNIPower = GroundTransmitterRFProperties.Power * GroundTransmitterRFProperties.Gain * OMNI_Gain * pow(OMNIWavelength / (4 * PI*EarthSignalDist), 2); //maximum recieved power to the HGA on axis in watts
-	RecvdOMNIPower_dBm = 10 * log10(1000 * RecvdOMNIPower);
+	RecvdOMNIPower_dBm = RFCALC_W2dBm(RecvdOMNIPower);
 	SignalStrengthScaleFactor = LM_SBandAntenna::dBm2SignalStrength(RecvdOMNIPower_dBm);
 
 	if (relang < 160 * RAD) //this is a litteral copy of the CSM OMNI but should be fairly close


### PR DESCRIPTION
With FPU exceptions on, the conversion to dBm can stop the program because taking the log10 of 0 triggers an exception.
This PR proposes a new function to do the conversion safely by checking the power beforehand and returning RF_ZERO_POWER_DBM if it is zero.
Edit: forced pushed an amend to use RFCALC_W2dBm in RFCALC_rcvdPower.