### PR TITLE
MCC transearth coast midcourse corrections

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
@@ -2152,19 +2152,8 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 		}
 		else if (fcn == 93 || fcn == 94)
 		{
-			MCCtime = calcParams.EI - 2.0*3600.0;
+			MCCtime = calcParams.EI - 3.0*3600.0;
 			sprintf(manname, "MCC-7");
-		}
-
-		//Only corridor control after EI-24h
-		if (MCCtime > calcParams.EI - 24.0*3600.0)
-		{
-			entopt.type = 3;
-		}
-		else
-		{
-			entopt.type = 1;
-			entopt.t_Z = OrbMech::HHMMSSToSS(192.0, 0.0, 0.0);
 		}
 
 		GETbase = CalcGETBase();
@@ -2177,10 +2166,21 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 		entopt.RV_MCC = sv;
 		entopt.TIGguess = MCCtime;
 		entopt.vessel = calcParams.src;
+		entopt.type = 3;
 
-		EntryTargeting(&entopt, &res);//dV_LVLH, P30TIG, latitude, longitude, RET, RTGO, VIO, ReA, prec); //Target Load for uplink
+		//Calculate corridor control burn
+		EntryTargeting(&entopt, &res);
 
-									  //Apollo 10 Mission Rules
+		//If time to EI is more than 24 hours and the splashdown longitude is not within 2° of desired, then perform a longitude control burn
+		if (MCCtime < calcParams.EI - 24.0*3600.0 && abs(res.longitude - entopt.lng) > 2.0*RAD)
+		{
+			entopt.type = 1;
+			entopt.t_Z = res.GET400K;
+
+			EntryTargeting(&entopt, &res);
+		}
+
+		//Apollo 10 Mission Rules
 		if (MCCtime > calcParams.EI - 50.0*3600.0)
 		{
 			if (length(res.dV_LVLH) < 1.0*0.3048)

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
@@ -3097,7 +3097,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 		}
 		else if (fcn == 211 || fcn == 212)
 		{
-			MCCtime = calcParams.EI - 23.0*3600.0;
+			MCCtime = calcParams.EI - 22.0*3600.0;
 			sprintf(manname, "MCC-6");
 		}
 		else if (fcn == 213 || fcn == 214)


### PR DESCRIPTION
-TEC midcourse corrections now only use longitude control if the predicted splashdown longitude is too far off. Not implemented for Apollo 12 yet, because I couldn't find a good scenario to test the change
-fix Apollo 10 MCC-7 and Apollo 12 MCC-6 times

