### PR TITLE
Generalize usage of IsVessel

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/LCC.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/LCC.vcxproj
@@ -96,7 +96,7 @@
       <AssemblerListingLocation>.\Release\LCC/</AssemblerListingLocation>
       <ObjectFileName>.\Release\LCC/</ObjectFileName>
       <ProgramDataBaseFileName>.\Release\LCC/</ProgramDataBaseFileName>
-      <AdditionalIncludeDirectories>C:\github\NASSP\Orbitersdk\samples\ProjectApollo\src_aux;../../src_rtccmfd;../../src_sys;../../../../include;../../../../../Sound/OrbiterSound_SDK/VESSELSOUND_SDK/ShuttlePB_project</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../src_aux;../../src_rtccmfd;../../src_sys;../../../../include;../../../../../Sound/OrbiterSound_SDK/VESSELSOUND_SDK/ShuttlePB_project</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>DIRECTSOUNDENABLED;WIN32;NDEBUG;_WINDOWS;_USRDLL;MCC_EXPORTS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
@@ -127,7 +127,7 @@
       <AssemblerListingLocation>.\Debug\LCC/</AssemblerListingLocation>
       <ObjectFileName>.\Debug\LCC/</ObjectFileName>
       <ProgramDataBaseFileName>.\Debug\LCC/</ProgramDataBaseFileName>
-      <AdditionalIncludeDirectories>C:\github\NASSP\Orbitersdk\samples\ProjectApollo\src_aux;../../src_rtccmfd;../../src_sys;../../../../include;../../../../../Sound/OrbiterSound_SDK/VESSELSOUND_SDK/ShuttlePB_project</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../src_aux;../../src_rtccmfd;../../src_sys;../../../../include;../../../../../Sound/OrbiterSound_SDK/VESSELSOUND_SDK/ShuttlePB_project</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>DIRECTSOUNDENABLED;WIN32;_DEBUG;_WINDOWS;_USRDLL;MCC_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/LCC.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/LCC.vcxproj
@@ -96,7 +96,7 @@
       <AssemblerListingLocation>.\Release\LCC/</AssemblerListingLocation>
       <ObjectFileName>.\Release\LCC/</ObjectFileName>
       <ProgramDataBaseFileName>.\Release\LCC/</ProgramDataBaseFileName>
-      <AdditionalIncludeDirectories>../../src_rtccmfd;../../src_sys;../../../../include;../../../../../Sound/OrbiterSound_SDK/VESSELSOUND_SDK/ShuttlePB_project;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\github\NASSP\Orbitersdk\samples\ProjectApollo\src_aux;../../src_rtccmfd;../../src_sys;../../../../include;../../../../../Sound/OrbiterSound_SDK/VESSELSOUND_SDK/ShuttlePB_project</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>DIRECTSOUNDENABLED;WIN32;NDEBUG;_WINDOWS;_USRDLL;MCC_EXPORTS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
@@ -127,7 +127,7 @@
       <AssemblerListingLocation>.\Debug\LCC/</AssemblerListingLocation>
       <ObjectFileName>.\Debug\LCC/</ObjectFileName>
       <ProgramDataBaseFileName>.\Debug\LCC/</ProgramDataBaseFileName>
-      <AdditionalIncludeDirectories>../../src_rtccmfd;../../src_sys;../../../../include;../../../../../Sound/OrbiterSound_SDK/VESSELSOUND_SDK/ShuttlePB_project;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\github\NASSP\Orbitersdk\samples\ProjectApollo\src_aux;../../src_rtccmfd;../../src_sys;../../../../include;../../../../../Sound/OrbiterSound_SDK/VESSELSOUND_SDK/ShuttlePB_project</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>DIRECTSOUNDENABLED;WIN32;_DEBUG;_WINDOWS;_USRDLL;MCC_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -164,6 +164,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\src_aux\nassputils.h" />
     <ClInclude Include="..\..\src_launch\LCC.h" />
     <ClInclude Include="..\..\src_launch\LCCMFDButtons.h" />
     <ClInclude Include="..\..\src_launch\LCC_MFD.h" />

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/LCC.vcxproj.filters
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/LCC.vcxproj.filters
@@ -44,5 +44,8 @@
     <ClInclude Include="..\..\src_launch\LCCMFDButtons.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src_aux\nassputils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj
@@ -403,6 +403,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\src_aux\animations.h" />
     <ClInclude Include="..\..\src_aux\Mission.h" />
+    <ClInclude Include="..\..\src_aux\nassputils.h" />
     <ClInclude Include="..\..\src_aux\vesim.h" />
     <ClInclude Include="..\..\src_csm\CM_VC_Resource.h" />
     <ClInclude Include="..\..\src_aux\RF_calc.h" />

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj.filters
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Saturn5NASP.vcxproj.filters
@@ -461,6 +461,9 @@
     <ClInclude Include="..\..\src_sys\inertial.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src_aux\nassputils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\Abort.bmp">

--- a/Orbitersdk/samples/ProjectApollo/src_aux/nassputils.h
+++ b/Orbitersdk/samples/ProjectApollo/src_aux/nassputils.h
@@ -45,39 +45,40 @@ namespace nassp
 			DrogueChute
 		};
 
-		constexpr bool IsVessel(VESSEL *v, ClassNames name)
+		static inline bool IsVessel(VESSEL *v, ClassNames name)
 		{
+			const char *classname = v->GetClassName();
 			switch (name)
 			{
 			case SaturnIB:
-				if (!stricmp(v->GetClassName(), "ProjectApollo\\Saturn1b") || !stricmp(v->GetClassName(), "ProjectApollo/Saturn1b")) return true;
+				if (!_stricmp(classname, "ProjectApollo\\Saturn1b") || !_stricmp(classname, "ProjectApollo/Saturn1b")) return true;
 				return false;
 			case SaturnV:
-				if (!stricmp(v->GetClassName(), "ProjectApollo\\Saturn5") || !stricmp(v->GetClassName(), "ProjectApollo/Saturn5")) return true;
+				if (!_stricmp(classname, "ProjectApollo\\Saturn5") || !_stricmp(classname, "ProjectApollo/Saturn5")) return true;
 				return false;
 			case LEM:
-				if (!stricmp(v->GetClassName(), "ProjectApollo\\LEM") || !stricmp(v->GetClassName(), "ProjectApollo/LEM")) return true;
+				if (!_stricmp(classname, "ProjectApollo\\LEM") || !_stricmp(classname, "ProjectApollo/LEM")) return true;
 				return false;
 			case MCC:
-				if (!stricmp(v->GetClassName(), "ProjectApollo\\MCC") || !stricmp(v->GetClassName(), "ProjectApollo/MCC")) return true;
+				if (!_stricmp(classname, "ProjectApollo\\MCC") || !_stricmp(classname, "ProjectApollo/MCC")) return true;
 				return false;
 			case SaturnIB_SIVB:
-				if (!stricmp(v->GetClassName(), "ProjectApollo\\nsat1stg2") || !stricmp(v->GetClassName(), "ProjectApollo/nsat1stg2")) return true;
+				if (!_stricmp(classname, "ProjectApollo\\nsat1stg2") || !_stricmp(classname, "ProjectApollo/nsat1stg2")) return true;
 				return false;
 			case SaturnV_SIVB:
-				if (!stricmp(v->GetClassName(), "ProjectApollo\\sat5stg3") || !stricmp(v->GetClassName(), "ProjectApollo/sat5stg3")) return true;
+				if (!_stricmp(classname, "ProjectApollo\\sat5stg3") || !_stricmp(classname, "ProjectApollo/sat5stg3")) return true;
 				return false;
 			case ML:
-				if (!stricmp(v->GetClassName(), "ProjectApollo\\ML") || !stricmp(v->GetClassName(), "ProjectApollo/ML")) return true;
+				if (!_stricmp(classname, "ProjectApollo\\ML") || !_stricmp(classname, "ProjectApollo/ML")) return true;
 				return false;
 			case Crawler:
-				if (!stricmp(v->GetClassName(), "ProjectApollo\\Crawler") || !stricmp(v->GetClassName(), "ProjectApollo/Crawler")) return true;
+				if (!_stricmp(classname, "ProjectApollo\\Crawler") || !_stricmp(classname, "ProjectApollo/Crawler")) return true;
 				return false;
 			case MainChute:
-				if (!stricmp(v->GetClassName(), "ProjectApollo\\MainChute") || !stricmp(v->GetClassName(), "ProjectApollo/MainChute")) return true;
+				if (!_stricmp(classname, "ProjectApollo\\MainChute") || !_stricmp(classname, "ProjectApollo/MainChute")) return true;
 				return false;
 			case DrogueChute:
-				if (!stricmp(v->GetClassName(), "ProjectApollo\\DrogueChute") || !stricmp(v->GetClassName(), "ProjectApollo/DrogueChute")) return true;
+				if (!_stricmp(classname, "ProjectApollo\\DrogueChute") || !_stricmp(classname, "ProjectApollo/DrogueChute")) return true;
 				return false;
 			case Saturn:
 				return (IsVessel(v, SaturnIB) || IsVessel(v, SaturnV));

--- a/Orbitersdk/samples/ProjectApollo/src_aux/nassputils.h
+++ b/Orbitersdk/samples/ProjectApollo/src_aux/nassputils.h
@@ -38,10 +38,14 @@ namespace nassp
 			MCC,
 			SaturnIB_SIVB,
 			SaturnV_SIVB,
-			SIVB
+			SIVB,
+			ML,
+			Crawler,
+			MainChute,
+			DrogueChute
 		};
 
-		bool IsVessel(VESSEL *v, ClassNames name)
+		constexpr bool IsVessel(VESSEL *v, ClassNames name)
 		{
 			switch (name)
 			{
@@ -62,6 +66,18 @@ namespace nassp
 				return false;
 			case SaturnV_SIVB:
 				if (!stricmp(v->GetClassName(), "ProjectApollo\\sat5stg3") || !stricmp(v->GetClassName(), "ProjectApollo/sat5stg3")) return true;
+				return false;
+			case ML:
+				if (!stricmp(v->GetClassName(), "ProjectApollo\\ML") || !stricmp(v->GetClassName(), "ProjectApollo/ML")) return true;
+				return false;
+			case Crawler:
+				if (!stricmp(v->GetClassName(), "ProjectApollo\\Crawler") || !stricmp(v->GetClassName(), "ProjectApollo/Crawler")) return true;
+				return false;
+			case MainChute:
+				if (!stricmp(v->GetClassName(), "ProjectApollo\\MainChute") || !stricmp(v->GetClassName(), "ProjectApollo/MainChute")) return true;
+				return false;
+			case DrogueChute:
+				if (!stricmp(v->GetClassName(), "ProjectApollo\\DrogueChute") || !stricmp(v->GetClassName(), "ProjectApollo/DrogueChute")) return true;
 				return false;
 			case Saturn:
 				return (IsVessel(v, SaturnIB) || IsVessel(v, SaturnV));

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
@@ -31,6 +31,7 @@
 #include "resource.h"
 #include "nasspdefs.h"
 #include "nasspsound.h"
+#include "nassputils.h"
 #include "toggleswitch.h"
 #include "apolloguidance.h"
 #include "CSMcomputer.h"
@@ -40,6 +41,8 @@
 #include "tracer.h"
 #include "Mission.h"
 #include "papi.h"
+
+using namespace nassp;
 
 // DS20060326 TELECOM OBJECTS
 
@@ -1456,7 +1459,7 @@ void VHFAMTransceiver::Timestep()
 	{
 		OBJHANDLE hVessel = oapiGetVesselByIndex(i);
 		VESSEL* pVessel = oapiGetVesselInterface(hVessel);
-		if (!_strnicmp(pVessel->GetClassName(), "ProjectApollo/LEM", 17))
+		if (utils::IsVessel(pVessel, utils::LEM))
 		{
 			isLem = true;
 		}
@@ -1714,7 +1717,7 @@ void VHFRangingSystem::TimeStep(double simdt)
 	{
 		OBJHANDLE hVessel = oapiGetVesselByIndex(i);
 		VESSEL* pVessel = oapiGetVesselInterface(hVessel);
-		if (!_strnicmp(pVessel->GetClassName(), "ProjectApollo/LEM", 17))
+		if (utils::IsVessel(pVessel, utils::LEM))
 		{
 			isLem = true;
 		}
@@ -5572,7 +5575,7 @@ void RNDZXPDRSystem::TimeStep(double simdt)
 	{
 		OBJHANDLE hVessel = oapiGetVesselByIndex(i);
 		VESSEL* pVessel = oapiGetVesselInterface(hVessel);
-		if (!_strnicmp(pVessel->GetClassName(), "ProjectApollo/LEM", 17))
+		if (utils::IsVessel(pVessel, utils::LEM))
 		{
 			isLem = true;
 		}

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -33,6 +33,7 @@
 #include "resource.h"
 #include "nasspdefs.h"
 #include "nasspsound.h"
+#include "nassputils.h"
 
 #include "toggleswitch.h"
 #include "apolloguidance.h"
@@ -66,6 +67,8 @@ extern "C" {
 	void srandom (unsigned int x);
 	long int random ();
 }
+
+using namespace nassp;
 
 //extern FILE *PanelsdkLogFile;
 
@@ -1208,7 +1211,7 @@ void Saturn::clbkPostCreation()
 	if (hMCC != NULL) {
 		VESSEL* pVessel = oapiGetVesselInterface(hMCC);
 		if (pVessel) {
-			if (!_strnicmp(pVessel->GetClassName(), "ProjectApollo\\MCC", 17) || !_strnicmp(pVessel->GetClassName(), "ProjectApollo/MCC", 17))
+			if (utils::IsVessel(pVessel, utils::MCC))
 			{
 				MCCVessel *pMCCVessel = static_cast<MCCVessel*>(pVessel);
 				if (pMCCVessel->mcc)

--- a/Orbitersdk/samples/ProjectApollo/src_landing/CMChute.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_landing/CMChute.cpp
@@ -32,6 +32,10 @@
 #include "tracer.h"
 #include "CMChute.h"
 #include "papi.h"
+#include "nassputils.h"
+
+using namespace nassp;
+
 char trace_file[]="ProjectApollo CMChute.log";
 
 const double timprc[3]={1,6,5};
@@ -52,17 +56,20 @@ DLLCLBK void    ovcExit(VESSEL *vessel)                  {if(vessel)delete(CMChu
 //############################################################################//
 CMChute::CMChute(OBJHANDLE hObj,int fmodel):VESSEL2(hObj,fmodel)
 {
- mode=CH_WRONG;    
- char *classname;
- classname=GetClassName();
+    mode = CH_WRONG;    
 
- if(!strnicmp(classname,"ProjectApollo/MainChute",14+9))mode=CH_MAIN;
- if(!strnicmp(classname,"ProjectApollo/DrogueChute",14+11))mode=CH_DROGUE;
+    if(utils::IsVessel(this, utils::MainChute))
+        mode = CH_MAIN;
+    else if(utils::IsVessel(this, utils::DrogueChute))
+        mode = CH_DROGUE;
  
- state=STATE_CHUTE0;
- for(int i=0;i<4;i++){anim[i]=0;proc[i]=1;}
- animLanding=0;
- procLanding=0;
+    state = STATE_CHUTE0;
+    for(int i = 0; i < 4; i++) {
+        anim[i] = 0;
+        proc[i] = 1;
+    }
+    animLanding = 0;
+    procLanding = 0;
 }
 CMChute::~CMChute(){}
 //############################################################################//

--- a/Orbitersdk/samples/ProjectApollo/src_launch/LCC.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/LCC.cpp
@@ -28,6 +28,9 @@
 #include "ML.h"
 #include "LC34.h"
 #include "LC37.h"
+#include "nassputils.h"
+
+using namespace nassp;
 
 #define ORBITER_MODULE
 
@@ -62,9 +65,8 @@ void LCC::clbkPostCreation()
 		VESSEL* pVessel = oapiGetVesselInterface(hPad);
 		if (pVessel != NULL)
 		{
-			if (!_stricmp(pVessel->GetClassName(), "ProjectApollo\\ML")) pPad = static_cast<ML*>(pVessel);
-			else if (!_stricmp(pVessel->GetClassName(), "ProjectApollo/ML")) pPad = static_cast<ML*>(pVessel);
-			//else if (!_strnicmp(pVessel->GetClassName(), "LC34", 8)) pPad = static_cast<LC34*>(pVessel);
+			if (utils::IsVessel(pVessel, utils::ML)) pPad = static_cast<ML*>(pVessel);
+			//else if (utils::IsVessel(pVessel, utils::LC34)) pPad = static_cast<LC34*>(pVessel);
 
 			if (pPad)
 			{

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_D.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_D.cpp
@@ -32,6 +32,9 @@ See http://nassp.sourceforge.net/license/ for more details.
 #include "rtcc.h"
 #include "MCC_Mission_D.h"
 #include "iu.h"
+#include "nassputils.h"
+
+using namespace nassp;
 
 void MCC::MissionSequence_D()
 {
@@ -64,9 +67,8 @@ void MCC::MissionSequence_D()
 					if (hLV != NULL)
 					{
 						v = oapiGetVesselInterface(hLV);
-
-						if (!stricmp(v->GetClassName(), "ProjectApollo\\sat5stg3") ||
-							!stricmp(v->GetClassName(), "ProjectApollo/sat5stg3")) {
+						
+						if (utils::IsVessel(v, utils::SaturnV_SIVB)) {
 							sivb = (SIVB *)v;
 						}
 					}

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_F.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_F.cpp
@@ -32,6 +32,9 @@ See http://nassp.sourceforge.net/license/ for more details.
 #include "rtcc.h"
 #include "MCC_Mission_F.h"
 #include "iu.h"
+#include "nassputils.h"
+
+using namespace nassp;
 
 void MCC::MissionSequence_F()
 {
@@ -113,8 +116,7 @@ void MCC::MissionSequence_F()
 				{
 					v = oapiGetVesselInterface(hLV);
 
-					if (!stricmp(v->GetClassName(), "ProjectApollo\\sat5stg3") ||
-						!stricmp(v->GetClassName(), "ProjectApollo/sat5stg3")) {
+					if (utils::IsVessel(v, utils::SaturnV_SIVB)) {
 						sivb = (SIVB *)v;
 					}
 				}

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_G.cpp
@@ -30,6 +30,9 @@ See http://nassp.sourceforge.net/license/ for more details.
 #include "rtcc.h"
 #include "MCC_Mission_G.h"
 #include "iu.h"
+#include "nassputils.h"
+
+using namespace nassp;
 
 void MCC::MissionSequence_G()
 {
@@ -105,8 +108,7 @@ void MCC::MissionSequence_G()
 				{
 					v = oapiGetVesselInterface(hLV);
 
-					if (!stricmp(v->GetClassName(), "ProjectApollo\\sat5stg3") ||
-						!stricmp(v->GetClassName(), "ProjectApollo/sat5stg3")) {
+					if (utils::IsVessel(v, utils::SaturnV_SIVB)) {
 						sivb = (SIVB *)v;
 					}
 				}

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_H1.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_H1.cpp
@@ -30,6 +30,9 @@ See http://nassp.sourceforge.net/license/ for more details.
 #include "rtcc.h"
 #include "MCC_Mission_H1.h"
 #include "iu.h"
+#include "nassputils.h"
+
+using namespace nassp;
 
 void MCC::MissionSequence_H1()
 {
@@ -102,8 +105,7 @@ void MCC::MissionSequence_H1()
 				{
 					v = oapiGetVesselInterface(hLV);
 
-					if (!stricmp(v->GetClassName(), "ProjectApollo\\sat5stg3") ||
-						!stricmp(v->GetClassName(), "ProjectApollo/sat5stg3")) {
+					if (utils::IsVessel(v, utils::SaturnV_SIVB)) {
 						sivb = (SIVB *)v;
 					}
 				}
@@ -151,8 +153,7 @@ void MCC::MissionSequence_H1()
 				{
 					v = oapiGetVesselInterface(hLV);
 
-					if (!stricmp(v->GetClassName(), "ProjectApollo\\sat5stg3") ||
-						!stricmp(v->GetClassName(), "ProjectApollo/sat5stg3")) {
+					if (utils::IsVessel(v, utils::SaturnV_SIVB)) {
 						sivb = (SIVB *)v;
 					}
 				}

--- a/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
@@ -45,6 +45,9 @@
 #include "rtcc.h"
 #include "LVDC.h"
 #include "iu.h"
+#include "nassputils.h"
+
+using namespace nassp;
 
 // SCENARIO FILE MACROLOGY
 #define SAVE_BOOL(KEY,VALUE) oapiWriteScenario_int(scn, KEY, VALUE)
@@ -4349,10 +4352,7 @@ void MCC::SetCSM(char *csmname)
 	{
 		v = oapiGetVesselInterface(hVessel);
 
-		if (!_stricmp(v->GetClassName(), "ProjectApollo\\Saturn5") ||
-			!_stricmp(v->GetClassName(), "ProjectApollo/Saturn5") ||
-			!_stricmp(v->GetClassName(), "ProjectApollo\\Saturn1b") ||
-			!_stricmp(v->GetClassName(), "ProjectApollo/Saturn1b")) {
+		if (utils::IsVessel(v, utils::Saturn)) {
 			cm = (Saturn *)v;
 			rtcc->calcParams.src = cm;
 		}
@@ -4370,8 +4370,7 @@ void MCC::SetLM(char *lemname)
 	{
 		v = oapiGetVesselInterface(hVessel);
 
-		if (!_stricmp(v->GetClassName(), "ProjectApollo\\LEM") ||
-			!_stricmp(v->GetClassName(), "ProjectApollo/LEM")) {
+		if (utils::IsVessel(v, utils::LEM)) {
 			lm = (LEM *)v;
 			rtcc->calcParams.tgt = v;
 		}
@@ -4390,10 +4389,7 @@ void MCC::SetLV(char *lvname)
 	{
 		v = oapiGetVesselInterface(hVessel);
 
-		if (!_stricmp(v->GetClassName(), "ProjectApollo\\sat5stg3") ||
-			!_stricmp(v->GetClassName(), "ProjectApollo/sat5stg3") ||
-			!_stricmp(v->GetClassName(), "ProjectApollo\\nsat1stg2") ||
-			!_stricmp(v->GetClassName(), "ProjectApollo/nsat1stg2")) {
+		if (utils::IsVessel(v, utils::SIVB)) {
 			sivb = (SIVB *)v;
 		}
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -43,6 +43,9 @@ See http://nassp.sourceforge.net/license/ for more details.
 #include "../src_rtccmfd/ReentryNumericalIntegrator.h"
 #include "mcc.h"
 #include "rtcc.h"
+#include "nassputils.h"
+
+using namespace nassp;
 
 // SCENARIO FILE MACROLOGY
 #define SAVE_BOOL(KEY,VALUE) oapiWriteScenario_int(scn, KEY, VALUE)
@@ -4381,8 +4384,7 @@ void RTCC::LMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool docked, bool asc)
 
 	if (asc)
 	{
-		if (!stricmp(v->GetClassName(), "ProjectApollo\\LEM") ||
-			!stricmp(v->GetClassName(), "ProjectApollo/LEM")) {
+		if (utils::IsVessel(v, utils::LEM)) {
 			LEM *lem = (LEM *)v;
 			LMmass = lem->GetAscentStageMass();
 		}
@@ -8106,8 +8108,7 @@ double RTCC::GetDockedVesselMass(VESSEL *vessel)
 		lm = oapiGetVesselInterface(hLM);
 
 		//Special case: S-IVB, but we want the LM mass
-		if (!stricmp(lm->GetClassName(), "ProjectApollo\\sat5stg3") ||
-			!stricmp(lm->GetClassName(), "ProjectApollo/sat5stg3"))
+		if (utils::IsVessel(lm, utils::SaturnV_SIVB))
 		{
 			SIVB *sivb = (SIVB *)lm;
 			LMmass = sivb->GetPayloadMass();
@@ -12409,26 +12410,15 @@ void RTCC::MPTMassUpdate(VESSEL *vessel, MED_M50 &med1, MED_M55 &med2, MED_M49 &
 
 	if (vessel == NULL) return;
 
-	char Buffer[100];
-
-	sprintf_s(Buffer, vessel->GetClassNameA());
-
-	if (!stricmp(Buffer, "ProjectApollo\\Saturn5") ||
-		!stricmp(Buffer, "ProjectApollo/Saturn5") ||
-		!stricmp(Buffer, "ProjectApollo\\Saturn1b") ||
-		!stricmp(Buffer, "ProjectApollo/Saturn1b"))
+	if (utils::IsVessel(vessel, utils::Saturn))
 	{
 		vesseltype = 0;
 	}
-	else if (!stricmp(vessel->GetClassName(), "ProjectApollo\\LEM") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo/LEM"))
+	else if (utils::IsVessel(vessel, utils::LEM))
 	{
 		vesseltype = 1;
 	}
-	else if (!stricmp(vessel->GetClassName(), "ProjectApollo\\sat5stg3") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo/sat5stg3") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo\\nsat1stg2") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo/nsat1stg2"))
+	else if (utils::IsVessel(vessel, utils::SIVB))
 	{
 		vesseltype = 2;
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -45,6 +45,9 @@
 #include "Mission.h"
 
 #include "connector.h"
+#include "nassputils.h"
+
+using namespace nassp;
 
 char trace_file[] = "ProjectApollo LM.log";
 
@@ -1877,7 +1880,7 @@ void LEM::clbkPostCreation()
 	if (hMCC != NULL) {
 		VESSEL* pVessel = oapiGetVesselInterface(hMCC);
 		if (pVessel) {
-			if (!_strnicmp(pVessel->GetClassName(), "ProjectApollo\\MCC", 17) || !_strnicmp(pVessel->GetClassName(), "ProjectApollo/MCC", 17))
+			if (utils::IsVessel(pVessel, utils::MCC))
 			{
 				MCCVessel *pMCCVessel = static_cast<MCCVessel*>(pVessel);
 				if (pMCCVessel->mcc)

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
@@ -32,6 +32,7 @@
 
 #include "nasspdefs.h"
 #include "nasspsound.h"
+#include "nassputils.h"
 
 #include "soundlib.h"
 #include "toggleswitch.h"
@@ -47,6 +48,8 @@
 #include "connector.h"
 #include "lm_channels.h"
 #include "LM_AscentStageResource.h"
+
+using namespace nassp;
 
 //VHF Antenna
 
@@ -255,7 +258,7 @@ void LM_VHF::Timestep(double simt)
 	{
 		OBJHANDLE hVessel = oapiGetVesselByIndex(i);
 		VESSEL* pVessel = oapiGetVesselInterface(hVessel);
-		if (!_strnicmp(pVessel->GetClassName(), "ProjectApollo\\Saturn5", 21)) //some day: if (!_strnicmp(pVessel->GetClassName(), "ProjectApollo\CSM", 17))
+		if (utils::IsVessel(pVessel, utils::SaturnV)) //some day: if (utils::IsVessel(pVessel, utils::CSM))
 		{
 			isCSM = true;
 		}

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
@@ -32,6 +32,7 @@
 #include "soundlib.h"
 #include "tracer.h"
 #include "nasspdefs.h"
+#include "nassputils.h"
 #include "toggleswitch.h"
 #include "apolloguidance.h"
 #include "CSMcomputer.h"
@@ -45,6 +46,8 @@
 
 #include "MFDResource.h"
 #include "ProjectApolloChecklistMFD.h"
+
+using namespace nassp;
 
 #define PROG_CHKLST			0
 #define PROG_CHKLSTNAV		1
@@ -114,18 +117,13 @@ ProjectApolloChecklistMFD::ProjectApolloChecklistMFD (DWORD w, DWORD h, VESSEL *
 
 	//We need to find out what type of vessel it is, so we check for the class name.
 	//Saturns have different functions than Crawlers.  But we have methods for both.
-	if (!stricmp(vessel->GetClassName(), "ProjectApollo\\Saturn5") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo/Saturn5") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo\\Saturn1b") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo/Saturn1b")) {
+	if (utils::IsVessel(vessel, utils::Saturn)) {
 		saturn = (Saturn *)vessel;
 	}
-	else if (!stricmp(vessel->GetClassName(), "ProjectApollo\\Crawler") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo/Crawler"))  {
+	else if (utils::IsVessel(vessel, utils::Crawler))  {
 			crawler = (Crawler *)vessel;
 	}
-	else if (!stricmp(vessel->GetClassName(), "ProjectApollo\\LEM") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo/LEM")) {
+	else if (utils::IsVessel(vessel, utils::LEM)) {
 			lem = (LEM *)vessel;
 	}
 

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.cpp
@@ -666,8 +666,7 @@ ProjectApolloMFD::ProjectApolloMFD (DWORD w, DWORD h, VESSEL *vessel) : MFD2 (w,
 			isSaturnV = true;
 		}
 	}
-	else if (!stricmp(vessel->GetClassName(), "ProjectApollo\\Crawler") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo/Crawler"))  {
+	else if (utils::IsVessel(vessel, utils::Crawler))  {
 			crawler = (Crawler *)vessel;
 			g_Data.planet = crawler->GetGravityRef();
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -20,6 +20,9 @@
 #include "iu.h"
 #include "ARoapiModule.h"
 #include "TLMCC.h"
+#include "nassputils.h"
+
+using namespace nassp;
 
 // ==============================================================
 // Global variables
@@ -7158,8 +7161,7 @@ void ApolloRTCCMFD::menuDAPPADCalc()
 
 void ApolloRTCCMFD::menuLaunchAzimuthCalc()
 {
-	if (!stricmp(G->vessel->GetClassName(), "ProjectApollo\\Saturn5") ||
-		!stricmp(G->vessel->GetClassName(), "ProjectApollo/Saturn5")) {
+	if (utils::IsVessel(G->vessel, utils::SaturnV)) {
 
 		SaturnV *SatV = (SaturnV*)G->vessel;
 		if (SatV->iu)

--- a/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.cpp
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <math.h>
 #include "nasspdefs.h"
+#include "nassputils.h"
 #include "checklistController.h"
 #include "saturn.h"
 #include "LEM.h"
@@ -37,6 +38,7 @@
 #pragma warning ( push )
 #pragma warning ( disable:4018 )
 
+using namespace nassp;
 using namespace std;
 
 // Stuff for the connector
@@ -128,14 +130,10 @@ bool ChecklistDataInterface::ReceiveMessage(Connector *from, ConnectorMessage &m
 		return false; // Go away
 	}
 
-	if (!stricmp(vessel->GetClassName(), "ProjectApollo\\Saturn5") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo/Saturn5") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo\\Saturn1b") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo/Saturn1b")) {
+	if (utils::IsVessel(vessel, utils::Saturn)) {
 		vessel_type = 1;
 	}
-	else if (!stricmp(vessel->GetClassName(), "ProjectApollo\\LEM") ||
-		!stricmp(vessel->GetClassName(), "ProjectApollo/LEM")) {
+	else if (utils::IsVessel(vessel, utils::LEM)) {
 		vessel_type = 2;
 	}
 


### PR DESCRIPTION
nassputils.h defines an IsVessel helper to test for a vessel class, use it where applicable.
This commits adds support for ML, Crawler, MainChute and DrogueChute to it.
This fixes lm_telecom.cpp where it tested only for "ProjectApollo\\Saturn5"