### PR TITLE
Use oapiGetViewportSize to compute aspect ratio

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_aux/ProjectApolloConfigurator/ProjectApolloConfigurator.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_aux/ProjectApolloConfigurator/ProjectApolloConfigurator.cpp
@@ -700,24 +700,3 @@ DLLCLBK void opcDLLExit (HINSTANCE hDLL)
 	oapiUnregisterLaunchpadItem (gParams.item);
 	delete gParams.item;
 }
-
-// 0 = 4:3
-// 1 = 16:10
-// 2 = 16:9
-static int renderViewportIsWideScreen = 0;
-
-DLLCLBK void opcOpenRenderViewport(HWND renderWnd, DWORD width, DWORD height, BOOL fullscreen)
-
-{
-	if (((double) width) / ((double) height) < 1.47) 
-		renderViewportIsWideScreen = 0;
-	else if (((double) width) / ((double) height) < 1.69) 
-		renderViewportIsWideScreen = 1;
-	else
-		renderViewportIsWideScreen = 2;
-}
-
-DLLCLBK int pacRenderViewportIsWideScreen() 
-{
-	return renderViewportIsWideScreen;
-}

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
@@ -672,17 +672,21 @@ void Saturn::InitPanel (int panel)
 	SetSwitches(panel);
 }
 
-int Saturn::GetRenderViewportIsWideScreen() {
+// GetRenderViewportIsWideScreen
+// Return value :
+// 0 = 4:3
+// 1 = 16:10
+// 2 = 16:9
 
-	HMODULE hpac = GetModuleHandle("Modules\\Startup\\ProjectApolloConfigurator.dll");
-	if (hpac) {
-		int (*pacRenderViewportIsWideScreen)();
-		pacRenderViewportIsWideScreen = (int (*)()) GetProcAddress(hpac, "pacRenderViewportIsWideScreen");
-		if (pacRenderViewportIsWideScreen) {
-			return pacRenderViewportIsWideScreen();
-		}
-	}
-	return 0;
+int Saturn::GetRenderViewportIsWideScreen() {
+	unsigned long w, h;
+	oapiGetViewportSize(&w, &h);
+	if (((double)w) / ((double)h) < 1.47)
+		return 0;
+	else if (((double)w) / ((double)h) < 1.69)
+		return 1;
+	else
+		return 2;
 }
 
 bool Saturn::clbkLoadPanel (int id) {


### PR DESCRIPTION
The aspect ratio computation is rather convoluted (opcOpenRenderViewport callback and cross DLL dialog via GetModuleHandle + GetProcAddress).
This replaces it with a simple and portable oapiGetViewportSize based method.