### PR TITLE
Use InitModule/ExitModule for LEM and saturn

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -21,6 +21,7 @@
   See http://nassp.sourceforge.net/license/ for more details.
 
   **************************************************************************/
+#define ORBITER_MODULE
 
 // To force Orbitersdk.h to use <fstream> in any compiler version
 #pragma include_alias( <fstream.h>, <fstream> )
@@ -3821,26 +3822,6 @@ void Saturn::FireSeperationThrusters(THRUSTER_HANDLE *pth)
 		if (pth[i])
 			SetThrusterLevel(pth[i], 1.0);
 	}
-}
-
-// ==============================================================
-// DLL entry point
-// ==============================================================
-
-BOOL WINAPI DllMain (HINSTANCE hModule,
-					 DWORD ul_reason_for_call,
-					 LPVOID lpReserved)
-{
-	switch (ul_reason_for_call) {
-	case DLL_PROCESS_ATTACH:
-		SetupgParam(hModule);
-		break;
-
-	case DLL_PROCESS_DETACH:
-		DeletegParam();
-		break;
-	}
-	return TRUE;
 }
 
 void Saturn::GenericTimestepStage(double simt, double simdt)

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -4612,7 +4612,4 @@ extern MESHHANDLE hcmseatsunfolded;
 extern MESHHANDLE hcmCOAScdr;
 extern MESHHANDLE hcmCOAScdrreticle;
 
-extern void SetupgParam(HINSTANCE hModule);
-extern void DeletegParam();
-
 #endif // _PA_SATURN_H

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
@@ -3582,7 +3582,7 @@ DLLCLBK void InitModule(HINSTANCE hModule) {
 	g_Param.pen[6] = oapiCreatePen (1, 3, RGB(255, 255, 255));
 }
 
-DLLCLBK void ExitModule() {
+DLLCLBK void ExitModule(HINSTANCE hDll) {
 
 	int i;
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
@@ -3558,7 +3558,7 @@ void Saturn::SetSwitches(int panel) {
 	Altimeter.Init(srf[SRF_ALTIMETER], srf[SRF_ALTIMETER2], this);
 }
 
-void SetupgParam(HINSTANCE hModule) {
+DLLCLBK void InitModule(HINSTANCE hModule) {
 
 	g_Param.hDLL = hModule;
 
@@ -3582,7 +3582,7 @@ void SetupgParam(HINSTANCE hModule) {
 	g_Param.pen[6] = oapiCreatePen (1, 3, RGB(255, 255, 255));
 }
 
-void DeletegParam() {
+DLLCLBK void ExitModule() {
 
 	int i;
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -21,6 +21,7 @@
   See http://nassp.sourceforge.net/license/ for more details.
 
   **************************************************************************/
+#define ORBITER_MODULE
 
 // To force Orbitersdk.h to use <fstream> in any compiler version
 #pragma include_alias( <fstream.h>, <fstream> )
@@ -82,23 +83,6 @@ static GDIParams g_Param;
 // ==============================================================
 // API interface
 // ==============================================================
-
-BOOL WINAPI DllMain (HINSTANCE hModule,
-					 DWORD ul_reason_for_call,
-					 LPVOID lpReserved)
-{
-	switch (ul_reason_for_call) {
-	case DLL_PROCESS_ATTACH:
-		InitGParam(hModule);
-		g_Param.hDLL = hModule; // DS20060413 Save for later
-		break;
-
-	case DLL_PROCESS_DETACH:
-		FreeGParam();
-		break;
-	}
-	return TRUE;
-}
 
 DLLCLBK VESSEL *ovcInit(OBJHANDLE hvessel, int flightmodel)
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -2081,8 +2081,6 @@ extern MESHHANDLE hAstro1;
 extern MESHHANDLE hLMVC;
 
 extern void LEMLoadMeshes();
-extern void InitGParam(HINSTANCE hModule);
-extern void FreeGParam();
 
 //Offset from center of LM mesh (full LM) to center of descent stage mesh (for staging)
 const VECTOR3 OFS_LM_DSC = { 0, -1.25, 0.0 };

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lempanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lempanel.cpp
@@ -46,7 +46,7 @@
 
 static GDIParams g_Param;
 
-void InitGParam(HINSTANCE hModule)
+DLLCLBK void InitModule(HINSTANCE hModule)
 
 {
 	g_Param.hDLL = hModule;
@@ -71,7 +71,7 @@ void InitGParam(HINSTANCE hModule)
 	g_Param.col[4] = oapiGetColour(255,0,255);
 }
 
-void FreeGParam()
+DLLCLBK void ExitModule()
 
 {
 	int i;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lempanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lempanel.cpp
@@ -71,7 +71,7 @@ DLLCLBK void InitModule(HINSTANCE hModule)
 	g_Param.col[4] = oapiGetColour(255,0,255);
 }
 
-DLLCLBK void ExitModule()
+DLLCLBK void ExitModule(HINSTANCE hDll)
 
 {
 	int i;


### PR DESCRIPTION
The LEM and saturn modules are using DllMain to handle sketchpad ressources.
This commit changes that to use the standard InitModule/ExitModule API.
I set it as a draft for now in case someone can remember if there is a valid reason for using DllMain