### PR TITLE
Improve Pipe/Valve flow rate stability with a simple RK4 implementation

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Esystems.cpp
@@ -1449,7 +1449,7 @@ void AtmRegen::refresh(double dt) {
 	if (delta_p < 0)
 		delta_p = 0;
 
-	h_volume fanned = in->GetFlow(dt * delta_p);
+	h_volume fanned = in->GetFlow(delta_p, dt);
 	co2removalrate = fanned.composition[SUBSTANCE_CO2].mass / dt;
 
 	if (co2removalrate <= 0.0356) {
@@ -1641,7 +1641,7 @@ void Pump::refresh(double dt)
 	if (delta_p < 0)
 		delta_p = 0;
 
-	h_volume fanned = in->GetFlow(dt * delta_p);
+	h_volume fanned = in->GetFlow(delta_p, dt);
 	flow = fanned.GetMass() / dt;
 	out->Flow(fanned);
 }

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Hsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Hsystems.cpp
@@ -640,8 +640,8 @@ int h_Valve::Flow(h_volume block) { //valves are simply sockets, forward this to
 double h_Valve::RK4FlowSolver(const double dP, const double size, const double dt)
 {
 	RK4IntegrationScratch[0] = size * dP * dt;
-	RK4IntegrationScratch[1] = size * (dP - RK4IntegrationScratch[0] / size / 2) * dt / 2;
-	RK4IntegrationScratch[2] = size * (dP - RK4IntegrationScratch[1] / size / 2) * dt / 2;
+	RK4IntegrationScratch[1] = size * (dP - RK4IntegrationScratch[0] / size / 2) * dt;
+	RK4IntegrationScratch[2] = size * (dP - RK4IntegrationScratch[1] / size / 2) * dt;
 	RK4IntegrationScratch[3] = size * (dP - RK4IntegrationScratch[2] / size) * dt;
 
 	return (RK4IntegrationScratch[0] + 2 * RK4IntegrationScratch[1] + 2 * RK4IntegrationScratch[2] + RK4IntegrationScratch[3]) / 6;
@@ -1021,7 +1021,7 @@ h_Radiator::~h_Radiator() {
 
 void h_Radiator::refresh(double dt) 
 {
-	Qr = rad * size * 5.67e-8 * dt * pow(Temp - 2.7, 4); //Stefan–Boltzmann law
+	Qr = rad * size * 5.67e-8 * dt * pow(Temp - 2.7, 4); //StefanÂ–Boltzmann law
 	Qc = rad * (100 * size * (Temp - parent->Vessel->GetAtmTemperature()))*(parent->Vessel->GetAtmDensity() / 1.225)*dt; //convective heat transfer, useful for preventing the radiators from cooling to 0K on the pad
 	
 	//if (!strcmp(name, "ECSRADIATOR1"))

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Hsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Hsystems.cpp
@@ -639,11 +639,16 @@ int h_Valve::Flow(h_volume block) { //valves are simply sockets, forward this to
 
 double h_Valve::RK4FlowSolver(const double dP, const double size, const double dt)
 {
+	//Flow Rate based on Euler
 	RK4IntegrationScratch[0] = size * dP * dt;
-	RK4IntegrationScratch[1] = size * (dP - RK4IntegrationScratch[0] / size / 2) * dt;
-	RK4IntegrationScratch[2] = size * (dP - RK4IntegrationScratch[1] / size / 2) * dt;
-	RK4IntegrationScratch[3] = size * (dP - RK4IntegrationScratch[2] / size) * dt;
+	//Midpoint estimation, size*dP factored out
+	RK4IntegrationScratch[1] = RK4IntegrationScratch[0] * exp(-dt / 2);
+	//midpoint estimation 2
+	RK4IntegrationScratch[2] = RK4IntegrationScratch[1] * exp(-dt / 2);
+	//end point estimation
+	RK4IntegrationScratch[3] = RK4IntegrationScratch[2] * exp(-dt);
 
+	//Weighted average
 	return (RK4IntegrationScratch[0] + 2 * RK4IntegrationScratch[1] + 2 * RK4IntegrationScratch[2] + RK4IntegrationScratch[3]) / 6;
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Hsystems.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/PanelSDK/Internals/Hsystems.h
@@ -166,10 +166,14 @@ public:
 	double GetTemp();
 	void thermic(double _en);
 	int Flow(h_volume block);//block of substance flowing INTO  the valve
-	h_volume GetFlow(double dPdT, double maxMass = 0);//deltaP * deltaT gives us flow rate OUTOF(in volume)
+	h_volume GetFlow(double dP, double dT, double maxMass = 0);//deltaP * deltaT gives us flow rate OUTOF(in volume)
 	virtual void refresh(double dt);	//for open/close updating
 	virtual void Save(FILEHANDLE scn);
 	virtual void* GetComponent(char *component_name);
+protected:
+	double RK4FlowSolver(const double dP, const double size, const double dt);
+private:
+	double RK4IntegrationScratch[4];
 };
 
 class h_Tank : public h_object, public therm_obj {	//tanks is just a basic receptacle of liquid or gas..


### PR DESCRIPTION
This will need some extensive testing.
It certainly doesn't remove all instability, but it should improve it.

CSM and LM ECS systems were able to survive a dT if ~20 seconds for extended periods of running. This equates to an Orbiter time compression of 1000x (With the breakers pulled in the CMC and LGC), with no obvious adverse effects.