### PR TITLE
LEVA Suit Names Bugfix

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_moon/leva.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_moon/leva.cpp
@@ -854,7 +854,7 @@ void LEVA::clbkLoadStateEx(FILEHANDLE scn, void *vs)
 			sscanf(line + 7, "%s", &LEMName);
 		}
 		else if (!strnicmp(line, "SUITNAME", 8)) {
-			sscanf(line + 8, "%s", &SuitName);
+			strcpy(SuitName, line + 9);
 		}
 		else if (!strnicmp(line, "STATE", 5)) {
 			int	s;


### PR DESCRIPTION
When exiting and reloading a scenario with LEVAs in it, the names on the suits would be messed up. "C. CONRAD" would become "C." because of the way the suit name line was being read.