### PR TITLE
Fix DSKY power distribution in CSM & LM

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -249,6 +249,8 @@ void Saturn::SystemsInit() {
 	FlightBus.WireTo(&FlightBusFeeder);
 	Panelsdk.AddElectrical(&FlightBus, false);
 
+	CMCDCBusFeeder.WireToBuses(&GNComputerMnACircuitBraker, &GNComputerMnBCircuitBraker);
+
 
 	// Feeder for LM umbilical
 	LMUmbilicalFeeder.WireToBuses(&MnbLMPWR1CircuitBraker,&MnbLMPWR2CircuitBraker);

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -362,7 +362,8 @@ Saturn::Saturn(OBJHANDLE hObj, int fmodel) : ProjectApolloConnectorVessel (hObj,
 	inertialData(this),
 	agc(soundlib, dsky, dsky2, imu, scdu, tcdu, Panelsdk),
 	dsky(soundlib, agc, 015),
-	dsky2(soundlib, agc, 016), 
+	dsky2(soundlib, agc, 016),
+	CMCDCBusFeeder("CMC-DCBus-Feeder", Panelsdk),
 	imu(agc, Panelsdk, inertialData),
 	scdu(agc, RegOPTX, 0140, 2),
 	tcdu(agc, RegOPTY, 0141, 2),
@@ -782,8 +783,8 @@ void Saturn::initSaturn()
 
 	agc.ControlVessel(this);
 	imu.SetVessel(this, false);
-	dsky.Init(&LightingNumIntLMDCCB, &NumericRotarySwitch);
-	dsky2.Init(&LightingNumIntLEBCB, &Panel100NumericRotarySwitch);
+	dsky.Init(&LightingNumIntLMDCCB, &CMCDCBusFeeder, &NumericRotarySwitch);
+	dsky2.Init(&LightingNumIntLEBCB, &CMCDCBusFeeder, &Panel100NumericRotarySwitch);
 
 	//
 	// Configure SECS.

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -3792,6 +3792,7 @@ protected:
 	// both.
 	DSKY dsky;
 	DSKY dsky2;
+	PowerMerge CMCDCBusFeeder;
 	CSMcomputer agc;	
 	IMU imu;
 	CDU tcdu;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -452,11 +452,13 @@ LEM::LEM(OBJHANDLE hObj, int fmodel) : Payload (hObj, fmodel),
 	lm_vhf_to_csm_csm_connector(this, &VHF),
 	cdi(this),
 	AOTLampFeeder("AOT-Lamp-Feeder", Panelsdk),
+	NumDockCompLTGFeeder("Num-Dock-Comp-LTG-Feeder", Panelsdk),
 	DescentECAMainFeeder("Descent-ECA-Main-Feeder", Panelsdk),
 	DescentECAContFeeder("Descent-ECA-Cont-Feeder", Panelsdk),
 	AscentECAMainFeeder("Ascent-ECA-Main-Feeder", Panelsdk),
 	AscentECAContFeeder("Ascent-ECA-Cont-Feeder", Panelsdk),
 	vesim(&cbLMVesim, this)
+
 {
 	dllhandle = g_Param.hDLL; // DS20060413 Save for later
 	InitLEMCalled = false;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -1554,6 +1554,7 @@ protected:
 
 	LEMPanelOrdeal PanelOrdeal;		// Dummy switch/display for checklist controller
 	PowerMerge AOTLampFeeder;
+	PowerMerge NumDockCompLTGFeeder;
 
 	int ordealEnabled;
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -382,7 +382,7 @@ void LEM::SystemsInit()
 	agc.WirePower(&LGC_DSKY_CB, NULL);
 	// The DSKY brightness IS controlled by the ANUN/NUM knob on panel 5, but by means of an isolated section of it.
 	// The source of the isolated section is coming from the LGC supply.
-	dsky.Init(&LGC_DSKY_CB, &LtgAnunNumKnob);
+	dsky.Init(&lca, &LGC_DSKY_CB, &LtgAnunNumKnob);
 	agc.InitHeat((h_HeatLoad *)Panelsdk.GetPointerByString("HYDRAULIC:LGCHEAT"));
 
 	// AGS stuff

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -382,7 +382,7 @@ void LEM::SystemsInit()
 	agc.WirePower(&LGC_DSKY_CB, NULL);
 	// The DSKY brightness IS controlled by the ANUN/NUM knob on panel 5, but by means of an isolated section of it.
 	// The source of the isolated section is coming from the LGC supply.
-	NumDockCompLTGFeeder.WireToBuses(&CDR_LTG_ANUN_DOCK_COMPNT_CB, &LTG_ANUN_DOCK_COMPNT_CB);
+	NumDockCompLTGFeeder.WireToBuses(&CDR_LTG_ANUN_DOCK_COMPNT_CB, &LTG_ANUN_DOCK_COMPNT_CB); //This should be handled in the LCA, powermerger for temporary functionality
 	dsky.Init(&NumDockCompLTGFeeder, &LGC_DSKY_CB, &LtgAnunNumKnob);
 	agc.InitHeat((h_HeatLoad *)Panelsdk.GetPointerByString("HYDRAULIC:LGCHEAT"));
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -382,7 +382,8 @@ void LEM::SystemsInit()
 	agc.WirePower(&LGC_DSKY_CB, NULL);
 	// The DSKY brightness IS controlled by the ANUN/NUM knob on panel 5, but by means of an isolated section of it.
 	// The source of the isolated section is coming from the LGC supply.
-	dsky.Init(&lca, &LGC_DSKY_CB, &LtgAnunNumKnob);
+	NumDockCompLTGFeeder.WireToBuses(&CDR_LTG_ANUN_DOCK_COMPNT_CB, &LTG_ANUN_DOCK_COMPNT_CB);
+	dsky.Init(&NumDockCompLTGFeeder, &LGC_DSKY_CB, &LtgAnunNumKnob);
 	agc.InitHeat((h_HeatLoad *)Panelsdk.GetPointerByString("HYDRAULIC:LGCHEAT"));
 
 	// AGS stuff

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_eps.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_eps.cpp
@@ -1282,7 +1282,7 @@ void LEM_LCA::UpdateFlow(double dt)
 
 void LEM_LCA::SystemTimestep(double simdt)
 {
-
+	//LCA Heating to be added
 }
 
 double LEM_LCA::GetCompDockVoltage()

--- a/Orbitersdk/samples/ProjectApollo/src_sys/dsky.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/dsky.cpp
@@ -157,6 +157,8 @@ DSKY::DSKY(SoundLib &s, ApolloGuidance &computer, int IOChannel) : soundlib(s), 
 
 {
 	DimmerRotationalSwitch = NULL;
+	StatusPower = NULL;
+	SegmentPower = NULL;
 	Reset();
 	ResetKeyDown();
 	KeyCodeIOChannel = IOChannel;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/dsky.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/dsky.cpp
@@ -204,17 +204,29 @@ DSKY::~DSKY()
 	//
 }
 
-void DSKY::Init(e_object *powered, RotationalSwitch *dimmer)
+void DSKY::Init(e_object *statuslightpower, e_object *segmentlightpower, RotationalSwitch *dimmer)
 
 {
-	WireTo(powered);
+	StatusPower = statuslightpower;
+	SegmentPower = segmentlightpower;
 	DimmerRotationalSwitch = dimmer;
 	Reset();
 	FirstTimeStep = true;
 }
 
-bool DSKY::IsPowered() {
-	if (Voltage() < SP_MIN_DCVOLTAGE){ return false; }
+bool DSKY::IsStatusPowered() {
+	if (StatusPower->Voltage() < 2){ return false; } //Used 2V for now as input voltage can be 0-5V AC or DC here
+
+	if (DimmerRotationalSwitch != NULL) {
+		if (DimmerRotationalSwitch->GetState() == 0) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool DSKY::IsSegmentPowered() {
+	if (SegmentPower->Voltage() < SP_MIN_DCVOLTAGE) { return false; }
 
 	if (DimmerRotationalSwitch != NULL) {
 		if (DimmerRotationalSwitch->GetState() == 0) {
@@ -237,7 +249,7 @@ void DSKY::Timestep(double simt)
 void DSKY::SystemTimestep(double simdt)
 
 {
-	if (!IsPowered()){ return; }
+	if (!IsStatusPowered() || !IsSegmentPowered()){ return; }
 	//
 	// The DSKY power consumption is a little bit hard to figure out. According 
 	// to the Systems Handbook the complete interior lightning draws about 30W, so
@@ -246,40 +258,49 @@ void DSKY::SystemTimestep(double simdt)
 	// code causes wrong power loads
 	//
 
-	//
-	// Check the lights.
-	//
+	if (IsStatusPowered())
+	{
+		//
+		// Check the lights.
+		//
 
-	LightsLit = 0;
-	if (UplinkLit()) LightsLit++;
-	if (NoAttLit()) LightsLit++;
-	if (StbyLit()) LightsLit++;
-	if (KbRelLit()) LightsLit++;
-	if (OprErrLit()) LightsLit++;
-	if (TempLit()) LightsLit++;
-	if (GimbalLockLit()) LightsLit++;
-	if (ProgLit()) LightsLit++;
-	if (RestartLit()) LightsLit++;
-	if (TrackerLit()) LightsLit++;
+		LightsLit = 0;
+		if (UplinkLit()) LightsLit++;
+		if (NoAttLit()) LightsLit++;
+		if (StbyLit()) LightsLit++;
+		if (KbRelLit()) LightsLit++;
+		if (OprErrLit()) LightsLit++;
+		if (TempLit()) LightsLit++;
+		if (GimbalLockLit()) LightsLit++;
+		if (ProgLit()) LightsLit++;
+		if (RestartLit()) LightsLit++;
+		if (TrackerLit()) LightsLit++;
 
-	//
-	// Check the segments
-	//
+		// 10 lights with together max. 6W, 
+		StatusPower->DrawPower(LightsLit * 0.6);
+	}
 
-	SegmentsLit = 6;
-	if (CompActy) 
-		SegmentsLit += 4;
+	if (IsSegmentPowered())
+	{
+		//
+		// Check the segments
+		//
 
-	SegmentsLit += TwoDigitDisplaySegmentsLit(Prog, false, ELOff);
-	SegmentsLit += TwoDigitDisplaySegmentsLit(Verb, VerbFlashing, ELOff);
-	SegmentsLit += TwoDigitDisplaySegmentsLit(Noun, NounFlashing, ELOff);
+		SegmentsLit = 6;
+		if (CompActy)
+			SegmentsLit += 4;
 
-	SegmentsLit += SixDigitDisplaySegmentsLit(R1, ELOff);
-	SegmentsLit += SixDigitDisplaySegmentsLit(R2, ELOff);
-	SegmentsLit += SixDigitDisplaySegmentsLit(R3, ELOff);
+		SegmentsLit += TwoDigitDisplaySegmentsLit(Prog, false, ELOff);
+		SegmentsLit += TwoDigitDisplaySegmentsLit(Verb, VerbFlashing, ELOff);
+		SegmentsLit += TwoDigitDisplaySegmentsLit(Noun, NounFlashing, ELOff);
 
-	// 10 lights with together max. 6W, 184 segments with together max. 4W  
-	DrawPower((LightsLit * 0.6) + (SegmentsLit * 0.022));
+		SegmentsLit += SixDigitDisplaySegmentsLit(R1, ELOff);
+		SegmentsLit += SixDigitDisplaySegmentsLit(R2, ELOff);
+		SegmentsLit += SixDigitDisplaySegmentsLit(R3, ELOff);
+
+		// 184 segments with together max. 4W  
+		SegmentPower->DrawPower(SegmentsLit * 0.022);
+	}
 
 	//sprintf(oapiDebugString(), "DSKY %f", (LightsLit * 0.6) + (SegmentsLit * 0.022));
 }
@@ -439,7 +460,7 @@ void DSKY::DSKYLightBlt(SURFHANDLE surf, SURFHANDLE lights, int dstx, int dsty, 
 void DSKY::RenderLights(SURFHANDLE surf, SURFHANDLE lights, int xOffset, int yOffset, bool hasAltVel, bool hasDAPPrioDisp)
 
 {
-	if (!IsPowered())
+	if (!IsStatusPowered())
 	{
 		if (hasAltVel) {
 			DSKYLightBlt(surf, lights, 52, 121, false, xOffset, yOffset);
@@ -727,7 +748,7 @@ int DSKY::SixDigitDisplaySegmentsLit(char *Str, bool Off)
 void DSKY::RenderData(SURFHANDLE surf, SURFHANDLE digits, SURFHANDLE disp, int xOffset, int yOffset)
 
 {
-	if (!IsPowered() || ELOff)
+	if (!IsSegmentPowered() || ELOff)
 		return;
 
 	oapiBlt(surf, disp, 66 + xOffset,   3 + yOffset, 35,  0, 35, 10, SURF_PREDEF_CK);

--- a/Orbitersdk/samples/ProjectApollo/src_sys/dsky.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/dsky.h
@@ -41,7 +41,7 @@ public:
 	DSKY(SoundLib &s, ApolloGuidance &computer, int IOChannel = 015);
 	virtual ~DSKY();
 
-	void Init(e_object *powered, RotationalSwitch *dimmer);
+	void Init(e_object *statuslightpower, e_object *segmentlightpower, RotationalSwitch *dimmer);
 	void Reset();
 
 	//
@@ -161,7 +161,8 @@ public:
 
 protected:
 
-	bool IsPowered();
+	bool IsStatusPowered();
+	bool IsSegmentPowered();
 	void SendKeyCode(int val);
 
 	//
@@ -269,6 +270,8 @@ protected:
 	Sound Sclick;
 
 	bool FirstTimeStep;
+	e_object *StatusPower;
+	e_object *SegmentPower;
 	RotationalSwitch *DimmerRotationalSwitch;
 
 	//


### PR DESCRIPTION
This changes power flow to the DSKY in the CSM and LM to use the appropriate sources. Previously, the CSM incorrectly used the CM AC bus for DSKY power where power for the segment was generated internally.

This adds power mergers (for now) to allow the GN MNA&B breakers in the CM power the DSKY segmented lighting and the AC bus power the status light. In the LM, the same AC internal generation is done via the LGC/DSKY cb for the segmented displays, but status lights now correctly use the DC LTG NUM DOCK COMP cbs on a power merger until the LCA is better implemented.