### PR TITLE
Remove some duplicate variables in TLMCC processor leading to zero sp…

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -3301,7 +3301,7 @@ int ARCore::subThread()
 
 			CSMmass = vessel->GetMass();
 			//Assume pre CSM separation from the S-IVB
-			if (CSMmass > 30000.0)
+			if (CSMmass > 40000.0)
 			{
 				CSMmass = 28860.0;
 			}

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/TLMCC.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/TLMCC.cpp
@@ -28,8 +28,7 @@ See http://nassp.sourceforge.net/license/ for more details.
 
 TLMCCProcessor::TLMCCProcessor(RTCC *r) : TLTrajectoryComputers(r)
 {
-	isp_SPS = 3080.0;
-	isp_DPS = 3107.0;
+
 }
 
 void TLMCCProcessor::Init(TLMCCDataTable data, TLMCCMEDQuantities med, TLMCCMissionConstants cst, double GMTBase)
@@ -65,6 +64,8 @@ void TLMCCProcessor::Init(TLMCCDataTable data, TLMCCMEDQuantities med, TLMCCMiss
 
 void TLMCCProcessor::Main(TLMCCOutputData &out)
 {
+	double Wdot;
+
 	//Propagate state vector to time of ignition
 	int ITS;
 	pRTCC->PMMCEN(MEDQuantities.sv0, 0.0, 10.0*24.0*3600.0, 1, MEDQuantities.T_MCC - MEDQuantities.sv0.GMT, 1.0, sv_MCC, ITS);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/TLMCC.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/TLMCC.h
@@ -221,7 +221,4 @@ protected:
 	TLMCCMEDQuantities MEDQuantities;
 
 	TLMCCDataTable outtab;
-
-	//Constants
-	double isp_SPS, isp_DPS, isp_MCC, Wdot;
 };

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/TLTrajectoryComputers.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/TLTrajectoryComputers.cpp
@@ -32,6 +32,9 @@ TLTrajectoryComputers::TLTrajectoryComputers(RTCC *r) : RTCCModule(r)
 	mu_E = OrbMech::mu_Earth;
 	mu_M = OrbMech::mu_Moon;
 
+	isp_SPS = 3080.0;
+	isp_DPS = 3107.0;
+
 	F_I_SIVB = 179847.1544797684; //LBF, 800000.0 Newton
 	F_SIVB = 202328.0487897395; //LBF, 900000.0 Newton
 	WDOT_SIVB = 1677750.443641722;; //LBS per hours, 211.393 kg/s

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/TLTrajectoryComputers.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/TLTrajectoryComputers.h
@@ -214,7 +214,7 @@ protected:
 
 	//Constants
 	double R_E, R_M, mu_E, mu_M;
-	double isp_SPS, isp_DPS, isp_MCC, Wdot;
+	double isp_SPS, isp_DPS, isp_MCC;
 	double F_I_SIVB; //S-IVB thrust magnitude from ignition to MRS
 	double F_SIVB; //S-IVB thrust magnitude from MRS to cutoff
 	double WDOT_SIVB; //Mass flow rate of S-IVB


### PR DESCRIPTION
…ecific impulse being used in burn optimization