### PR TITLE
CMVC Free Flying Viewpoint

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3303,7 +3303,7 @@ int Saturn::clbkConsumeDirectKey(char *kstate)
 			if (setFreeCam == true) {
 				VCFreeCam(camDir, camSlow);
 			}
-			return 1;
+			//return 1;
 		}
 	}
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3298,8 +3298,8 @@ int Saturn::clbkConsumeDirectKey(char *kstate)
 		}
 	}
 
-	if ((!KEYMOD_CONTROL(kstate)) & (!KEYMOD_ALT(kstate))) {
-		if ((oapiCockpitMode() == COCKPIT_VIRTUAL) & (oapiCameraMode() == CAM_COCKPIT)) {
+	if ((!KEYMOD_CONTROL(kstate)) && (!KEYMOD_ALT(kstate))) {
+		if ((oapiCockpitMode() == COCKPIT_VIRTUAL) && (oapiCameraMode() == CAM_COCKPIT)) {
 			if (setFreeCam == true) {
 				VCFreeCam(camDir, camSlow);
 			}

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3261,32 +3261,44 @@ int Saturn::clbkConsumeDirectKey(char *kstate)
 		camSlow = true;
 	}
 
-	if (KEYDOWN(kstate, OAPI_KEY_LEFT)) {
-		camDir.x = -1;
-		setFreeCam = true;
+	if (!KEYDOWN(kstate, OAPI_KEY_GRAVE)) {
+		if (KEYDOWN(kstate, OAPI_KEY_LEFT)) {
+			camDir.x = -1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_RIGHT)) {
+			camDir.x = 1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_UP)) {
+			camDir.y = 1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_DOWN)) {
+			camDir.y = -1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_INSERT)) {
+			camDir.z = 1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_DELETE)) {
+			camDir.z = -1;
+			setFreeCam = true;
+		}
 	}
-	if (KEYDOWN(kstate, OAPI_KEY_RIGHT)) {
-		camDir.x = 1;
-		setFreeCam = true;
-	}
-	if (KEYDOWN(kstate, OAPI_KEY_UP)) {
-		camDir.y = 1;
-		setFreeCam = true;
-	}
-	if (KEYDOWN(kstate, OAPI_KEY_DOWN)) {
-		camDir.y = -1;
-		setFreeCam = true;
-	}
-	if (KEYDOWN(kstate, OAPI_KEY_INSERT)) {
-		camDir.z = 1;
-		setFreeCam = true;
-	}
-	if (KEYDOWN(kstate, OAPI_KEY_DELETE)) {
-		camDir.z = -1;
-		setFreeCam = true;
+	else {
+		if (KEYDOWN(kstate, OAPI_KEY_UP)) {
+			camDir.z = 1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_DOWN)) {
+			camDir.z = -1;
+			setFreeCam = true;
+		}
 	}
 
-	if (!KEYMOD_CONTROL(kstate)) {
+	if ((!KEYMOD_CONTROL(kstate)) & (!KEYMOD_ALT(kstate))) {
 		if ((oapiCockpitMode() == COCKPIT_VIRTUAL) & (oapiCameraMode() == CAM_COCKPIT)) {
 			if (setFreeCam == true) {
 				VCFreeCam(camDir, camSlow);

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -964,6 +964,17 @@ void Saturn::initSaturn()
 	NoiseOffsety = 0;
 	NoiseOffsetz = 0;
 
+	//
+	// VC Free Cam
+	//
+
+	vcFreeCamx = 0;
+	vcFreeCamy = 0;
+	vcFreeCamz = 0;
+	vcFreeCamSpeed = 0.2;
+	vcFreeCamMaxOffset = 0.5;
+
+
 	InVC = false;
 	InPanel = false;
 	CheckPanelIdInTimestep = false;
@@ -3188,9 +3199,9 @@ void StageTransform(VESSEL *vessel, VESSELSTATUS *vs, VECTOR3 ofs, VECTOR3 vel)
 int Saturn::clbkConsumeDirectKey(char *kstate)
 
 {
-	if (KEYMOD_SHIFT(kstate) || KEYMOD_ALT(kstate)) {
-		return 0; 
-	}
+	//if (KEYMOD_SHIFT(kstate) || KEYMOD_ALT(kstate)) {
+	//	return 0; 
+	//}
 
 	// position test
 	/*
@@ -3242,6 +3253,48 @@ int Saturn::clbkConsumeDirectKey(char *kstate)
 	sprintf(oapiDebugString(), "GetCOG_elev %f", GetCOG_elev());
 	*/
 	
+	bool camSlow = false;
+	VECTOR3 camDir = _V(0, 0, 0);
+	bool setFreeCam = false;
+
+	if (KEYMOD_SHIFT(kstate)) {
+		camSlow = true;
+	}
+
+	if (KEYDOWN(kstate, OAPI_KEY_LEFT)) {
+		camDir.x = -1;
+		setFreeCam = true;
+	}
+	if (KEYDOWN(kstate, OAPI_KEY_RIGHT)) {
+		camDir.x = 1;
+		setFreeCam = true;
+	}
+	if (KEYDOWN(kstate, OAPI_KEY_UP)) {
+		camDir.y = 1;
+		setFreeCam = true;
+	}
+	if (KEYDOWN(kstate, OAPI_KEY_DOWN)) {
+		camDir.y = -1;
+		setFreeCam = true;
+	}
+	if (KEYDOWN(kstate, OAPI_KEY_INSERT)) {
+		camDir.z = 1;
+		setFreeCam = true;
+	}
+	if (KEYDOWN(kstate, OAPI_KEY_DELETE)) {
+		camDir.z = -1;
+		setFreeCam = true;
+	}
+
+	if (!KEYMOD_CONTROL(kstate)) {
+		if ((oapiCockpitMode() == COCKPIT_VIRTUAL) & (oapiCameraMode() == CAM_COCKPIT)) {
+			if (setFreeCam == true) {
+				VCFreeCam(camDir, camSlow);
+			}
+			return 1;
+		}
+	}
+
 	return 0;
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -4132,6 +4132,8 @@ protected:
 
 	void InitFDAI(UINT mesh);
 
+	void VCFreeCam(VECTOR3 dir, bool slow);
+
 	//
 	// Systems functions.
 	//
@@ -4384,6 +4386,16 @@ protected:
 	double ViewOffsetx, NoiseOffsetx;
 	double ViewOffsety, NoiseOffsety;
 	double ViewOffsetz, NoiseOffsetz;
+
+	//
+	// VC Free Cam
+	//
+
+	double vcFreeCamx;
+	double vcFreeCamy;
+	double vcFreeCamz;
+	double vcFreeCamSpeed;
+	double vcFreeCamMaxOffset;
 
 	//
 	// Save the last view offset.

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -748,6 +748,11 @@ bool Saturn::clbkLoadVC (int id)
 	//if ((viewpos >= SATVIEW_ENG1) && (viewpos <= SATVIEW_ENG6))
 	//	return true;
 
+	//Reset VC free camera to default
+	vcFreeCamx = 0;
+	vcFreeCamy = 0;
+	vcFreeCamz = 0;
+
 	switch (id) {
 
 	case SATVIEW_LEFTSEAT:
@@ -1865,6 +1870,37 @@ void Saturn::JostleViewpoint(double noiselat, double noiselon, double noisefreq,
 	SetView();
 }
 
+void Saturn::VCFreeCam(VECTOR3 dir, bool slow)
+{
+	//dir is always in Orbiter's vessel XYZ reference frame
+	//in SetView() the shift is adjusted to local viewpoint reference frame to make is seem 'natural' from the observer's viewpoint
+
+	double simdt = oapiGetSimStep();
+
+	if (slow == false) {
+		vcFreeCamx += dir.x * vcFreeCamSpeed * simdt;
+		vcFreeCamy += dir.y * vcFreeCamSpeed * simdt;
+		vcFreeCamz += dir.z * vcFreeCamSpeed * simdt;
+	}
+	else {
+		vcFreeCamx += dir.x * vcFreeCamSpeed * simdt * 0.25;
+		vcFreeCamy += dir.y * vcFreeCamSpeed * simdt * 0.25;
+		vcFreeCamz += dir.z * vcFreeCamSpeed * simdt * 0.25;
+	}
+
+	//Make sure the camera isn't offset to far
+	if (vcFreeCamx > vcFreeCamMaxOffset) { vcFreeCamx = vcFreeCamMaxOffset; }
+	else if (vcFreeCamx < -vcFreeCamMaxOffset) { vcFreeCamx = -vcFreeCamMaxOffset; }
+	
+	if (vcFreeCamy > vcFreeCamMaxOffset) { vcFreeCamy = vcFreeCamMaxOffset; }
+	else if (vcFreeCamy < -vcFreeCamMaxOffset) { vcFreeCamy = -vcFreeCamMaxOffset; }
+
+	if (vcFreeCamz > vcFreeCamMaxOffset) { vcFreeCamz = vcFreeCamMaxOffset; }
+	else if (vcFreeCamz < -vcFreeCamMaxOffset) { vcFreeCamz = -vcFreeCamMaxOffset; }
+
+	SetView();
+}
+
 void Saturn::SetView()
 
 {
@@ -2041,46 +2077,79 @@ void Saturn::SetView(double offset, bool update_direction)
 		switch (viewpos) {
 			case SATVIEW_LEFTSEAT:
 				v = _V(-0.6, 0.85, ofs_vc.z + 0.1);
+				v.x += vcFreeCamx;
+				v.y += (cos(P1_3_TILT) * vcFreeCamy) + (-sin(P1_3_TILT) * vcFreeCamz);
+				v.z += (sin(P1_3_TILT) * vcFreeCamy) + (cos(P1_3_TILT) * vcFreeCamz);
 				break;
 
 			case SATVIEW_CENTERSEAT:
 				v = _V(0, 0.85, ofs_vc.z + 0.1);
+				v.x += vcFreeCamx;
+				v.y += (cos(P1_3_TILT) * vcFreeCamy) + (-sin(P1_3_TILT) * vcFreeCamz);
+				v.z += (sin(P1_3_TILT) * vcFreeCamy) + (cos(P1_3_TILT) * vcFreeCamz);
 				break;
 
 			case SATVIEW_RIGHTSEAT:
 				v = _V(0.6, 0.85, ofs_vc.z + 0.1);
+				v.x += vcFreeCamx;
+				v.y += (cos(P1_3_TILT) * vcFreeCamy) + (-sin(P1_3_TILT) * vcFreeCamz);
+				v.z += (sin(P1_3_TILT) * vcFreeCamy) + (cos(P1_3_TILT) * vcFreeCamz);
 				break;
 
 			case SATVIEW_LEFTDOCK:
 				v = _V(-0.6, 1.05, 0.1 + ofs_vc.z); // Adjusted to line up with LM docking target
+				//v.x += vcFreeCamx;
+				//v.y += vcFreeCamy;
+				//v.z += vcFreeCamz;
 				break;
 			
 			case SATVIEW_RIGHTDOCK:
 				v = _V(0.6, 1.05, 0.1 + ofs_vc.z);
+				//v.x += vcFreeCamx;
+				//v.y += vcFreeCamy;
+				//v.z += vcFreeCamz;
 				break;
 
 			case SATVIEW_GNPANEL:
 				v = _V(-0.05, -0.15, 0.3 + ofs_vc.z);
+				v.x += vcFreeCamx;
+				v.y += -vcFreeCamz;
+				v.z += vcFreeCamy;
 				break;
 
 			case SATVIEW_LEBLEFT:
-				v = _V(-0.8, - 0.5, ofs_vc.z - 0.4);
+				v = _V(-0.8, -0.5, ofs_vc.z - 0.4);
+				v.x += -vcFreeCamz;
+				v.y += vcFreeCamy;
+				v.z += vcFreeCamx;
 				break;
 
 			case SATVIEW_LEBRIGHT:
 				v = _V(0.8, -0.4, ofs_vc.z + 0.1);
+				v.x += vcFreeCamz;
+				v.y += vcFreeCamy;
+				v.z += -vcFreeCamx;
 				break;
 
 			case SATVIEW_LOWER_CENTER:
 				v = _V(0.0, 0.1, 0.65 + ofs_vc.z);
+				//v.x += vcFreeCamx;
+				//v.y += vcFreeCamz;
+				//v.z += vcFreeCamy;
 				break;
 
 			case SATVIEW_UPPER_CENTER:
 				v = _V(0, 1.35, ofs_vc.z - 0.0);
+				v.x += -vcFreeCamx;
+				v.y += vcFreeCamy;
+				v.z += -vcFreeCamz;
 				break;
 
 			case SATVIEW_TUNNEL:
 				v = _V(0.0, 0.0, 0.8 + ofs_vc.z - 0.1);
+				v.x += vcFreeCamx;
+				v.y += vcFreeCamy;
+				v.z += vcFreeCamz;
 				break;
 		}
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -832,8 +832,8 @@ int LEM::clbkConsumeDirectKey(char* kstate)
 		}
 	}
 
-	if ((!KEYMOD_CONTROL(kstate)) & (!KEYMOD_ALT(kstate))) {
-		if ((oapiCockpitMode() == COCKPIT_VIRTUAL) & (oapiCameraMode() == CAM_COCKPIT)) {
+	if ((!KEYMOD_CONTROL(kstate)) && (!KEYMOD_ALT(kstate))) {
+		if ((oapiCockpitMode() == COCKPIT_VIRTUAL) && (oapiCameraMode() == CAM_COCKPIT)) {
 			if (setFreeCam == true) {
 				VCFreeCam(camDir, camSlow);
 			}

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -581,6 +581,13 @@ void LEM::Init()
 	ViewOffsety = 0;
 	ViewOffsetz = 0;
 
+	// VC Free Cam
+	vcFreeCamx = 0;
+	vcFreeCamy = 0;
+	vcFreeCamz = 0;
+	vcFreeCamSpeed = 0.2;
+	vcFreeCamMaxOffset = 0.5;
+
 	DPSPropellant.SetVessel(this);
 	APSPropellant.SetVessel(this);
 	RCSA.SetVessel(this);
@@ -776,6 +783,65 @@ void LEM::LoadDefaultSounds()
     sevent.InitDirectSound(soundlib);
 #endif
 	SoundsLoaded = true;
+}
+
+int LEM::clbkConsumeDirectKey(char* kstate)
+{
+	bool camSlow = false;
+	VECTOR3 camDir = _V(0, 0, 0);
+	bool setFreeCam = false;
+
+	if (KEYMOD_SHIFT(kstate)) {
+		camSlow = true;
+	}
+
+	if (!KEYDOWN(kstate, OAPI_KEY_GRAVE)) {
+		if (KEYDOWN(kstate, OAPI_KEY_LEFT)) {
+			camDir.x = -1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_RIGHT)) {
+			camDir.x = 1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_UP)) {
+			camDir.y = 1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_DOWN)) {
+			camDir.y = -1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_INSERT)) {
+			camDir.z = 1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_DELETE)) {
+			camDir.z = -1;
+			setFreeCam = true;
+		}
+	}
+	else {
+		if (KEYDOWN(kstate, OAPI_KEY_UP)) {
+			camDir.z = 1;
+			setFreeCam = true;
+		}
+		if (KEYDOWN(kstate, OAPI_KEY_DOWN)) {
+			camDir.z = -1;
+			setFreeCam = true;
+		}
+	}
+
+	if ((!KEYMOD_CONTROL(kstate)) & (!KEYMOD_ALT(kstate))) {
+		if ((oapiCockpitMode() == COCKPIT_VIRTUAL) & (oapiCameraMode() == CAM_COCKPIT)) {
+			if (setFreeCam == true) {
+				VCFreeCam(camDir, camSlow);
+			}
+			return 1;
+		}
+	}
+
+	return 0;
 }
 
 int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -837,7 +837,7 @@ int LEM::clbkConsumeDirectKey(char* kstate)
 			if (setFreeCam == true) {
 				VCFreeCam(camDir, camSlow);
 			}
-			return 1;
+			//return 1;
 		}
 	}
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -515,6 +515,7 @@ public:
 	bool clbkVCMouseEvent(int id, int event, VECTOR3 &p);
 	bool clbkVCRedrawEvent(int id, int event, SURFHANDLE surf);
 
+	int clbkConsumeDirectKey(char* keystate);
 	int  clbkConsumeBufferedKey(DWORD key, bool down, char *kstate);
 	void clbkPreStep (double simt, double simdt, double mjd);
 	void clbkPostStep(double simt, double simdt, double mjd);
@@ -718,6 +719,7 @@ protected:
 	void RCSSoundTimestep();
 	// void GetDockStatus();
 	void JostleViewpoint(double amount);
+	void VCFreeCam(VECTOR3 dir, bool slow);
 	void AddDust();
 	void SetCompLight(int m, bool state);
 	void SetContactLight(int m, bool state);
@@ -1733,6 +1735,16 @@ protected:
 	double ViewOffsetx;
 	double ViewOffsety;
 	double ViewOffsetz;
+
+	//
+	// VC Free Cam
+	//
+
+	double vcFreeCamx;
+	double vcFreeCamy;
+	double vcFreeCamz;
+	double vcFreeCamSpeed;
+	double vcFreeCamMaxOffset;
 
 	//
 	// Ground Systems

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
@@ -442,6 +442,37 @@ void LEM::JostleViewpoint(double amount)
 	SetView();
 }
 
+void LEM::VCFreeCam(VECTOR3 dir, bool slow)
+{
+	//dir is always in Orbiter's vessel XYZ reference frame
+	//in SetView() the shift is adjusted to local viewpoint reference frame to make is seem 'natural' from the observer's viewpoint
+
+	double simdt = oapiGetSimStep();
+
+	if (slow == false) {
+		vcFreeCamx += dir.x * vcFreeCamSpeed * simdt;
+		vcFreeCamy += dir.y * vcFreeCamSpeed * simdt;
+		vcFreeCamz += dir.z * vcFreeCamSpeed * simdt;
+	}
+	else {
+		vcFreeCamx += dir.x * vcFreeCamSpeed * simdt * 0.25;
+		vcFreeCamy += dir.y * vcFreeCamSpeed * simdt * 0.25;
+		vcFreeCamz += dir.z * vcFreeCamSpeed * simdt * 0.25;
+	}
+
+	//Make sure the camera isn't offset to far
+	if (vcFreeCamx > vcFreeCamMaxOffset) { vcFreeCamx = vcFreeCamMaxOffset; }
+	else if (vcFreeCamx < -vcFreeCamMaxOffset) { vcFreeCamx = -vcFreeCamMaxOffset; }
+
+	if (vcFreeCamy > vcFreeCamMaxOffset) { vcFreeCamy = vcFreeCamMaxOffset; }
+	else if (vcFreeCamy < -vcFreeCamMaxOffset) { vcFreeCamy = -vcFreeCamMaxOffset; }
+
+	if (vcFreeCamz > vcFreeCamMaxOffset) { vcFreeCamz = vcFreeCamMaxOffset; }
+	else if (vcFreeCamz < -vcFreeCamMaxOffset) { vcFreeCamz = -vcFreeCamMaxOffset; }
+
+	SetView();
+}
+
 void LEM::SetView() {
 
 	VECTOR3 v;
@@ -461,61 +492,97 @@ void LEM::SetView() {
 		case LMVIEW_CDR:
 			v = _V(-0.45, -0.07, 1.25) + ofs;
 			SetCameraDefaultDirection(_V(0.00, -sin(P1_TILT), cos(P1_TILT)));
+			v.x += vcFreeCamx;
+			v.y += (cos(P1_TILT) * vcFreeCamy) + (-sin(P1_TILT) * vcFreeCamz);
+			v.z += (sin(P1_TILT) * vcFreeCamy) + (cos(P1_TILT) * vcFreeCamz);
 			break;
 
 		case LMVIEW_LMP:
 			v = _V(0.45, -0.07, 1.25) + ofs;
 			SetCameraDefaultDirection(_V(0.00, -sin(P2_TILT), cos(P2_TILT)));
+			v.x += vcFreeCamx;
+			v.y += (cos(P2_TILT) * vcFreeCamy) + (-sin(P2_TILT) * vcFreeCamz);
+			v.z += (sin(P2_TILT) * vcFreeCamy) + (cos(P2_TILT) * vcFreeCamz);
 			break;
 
 		case LMVIEW_LPD:
 			v = _V(-0.58, -0.15, 1.40) + ofs;
 			SetCameraDefaultDirection(_V(0.0, -sin(VIEWANGLE * RAD), cos(VIEWANGLE * RAD)));
+			//v.x += vcFreeCamx;
+			//v.y += (cos(VIEWANGLE * RAD) * vcFreeCamy) + (-sin(VIEWANGLE * RAD) * vcFreeCamz);
+			//v.z += (sin(VIEWANGLE * RAD) * vcFreeCamy) + (cos(VIEWANGLE * RAD) * vcFreeCamz);
 			break;
 
 		case LMVIEW_DSKY:
 			v = _V(0.0, -0.4, 1.2) + ofs;
 			SetCameraDefaultDirection(_V(0.00, -sin(P3_TILT), cos(P3_TILT)));
+			v.x += vcFreeCamx;
+			v.y += (cos(P3_TILT) * vcFreeCamy) + (-sin(P3_TILT) * vcFreeCamz);
+			v.z += (sin(P3_TILT) * vcFreeCamy) + (cos(P3_TILT) * vcFreeCamz);
 			break;
 
 		case LMVIEW_CBLEFT:
 			v = _V(-0.55, -0.22, 1.05) + ofs;
 			SetCameraDefaultDirection(_V(-1.0, 0.0, 0.0));
+			v.x += -vcFreeCamz;
+			v.y += vcFreeCamy;
+			v.z += vcFreeCamx;
 			break;
 
 		case LMVIEW_CBRIGHT:
 			v = _V(0.55, -0.22, 1.05) + ofs;
 			SetCameraDefaultDirection(_V(1.0, 0.0, 0.0));
+			v.x += vcFreeCamz;
+			v.y += vcFreeCamy;
+			v.z += -vcFreeCamx;
 			break;
 
 		case LMVIEW_AOT:
 			v = _V(0.0, 0.05, 1.12) + ofs;
 			SetCameraDefaultDirection(_V(0.0, 0.0, 1.0));
+			v.x += vcFreeCamx;
+			v.y += vcFreeCamy;
+			v.z += vcFreeCamz;
 			break;
 
 		case LMVIEW_ECS:
 			v = _V(-0.15, -0.42, 0.10) + ofs;
 			SetCameraDefaultDirection(_V(1.0, 0.0, 0.0));
+			v.x += vcFreeCamz;
+			v.y += vcFreeCamy;
+			v.z += -vcFreeCamx;
 			break;
 
 		case LMVIEW_ECS2:
 			v = _V(0.45, -0.35, 1.0) + ofs;
 			SetCameraDefaultDirection(_V(0.0, 0.0, -1.0));
+			v.x += -vcFreeCamx;
+			v.y += vcFreeCamy;
+			v.z += -vcFreeCamz;
 			break;
 
 		case LMVIEW_FWDHATCH:
 			v = _V(0.0, -1.3, 1.1) + ofs;
 			SetCameraDefaultDirection(_V(0.0, 0.0, 1.0));
+			v.x += vcFreeCamx;
+			v.y += vcFreeCamy;
+			v.z += vcFreeCamz;
 			break;
 
 		case LMVIEW_OVHDHATCH:
 			v = _V(0.0, -0.3, 0.1) + ofs;
 			SetCameraDefaultDirection(_V(0.0, 1.0, 0.0), 180 * RAD);
+			v.x += -vcFreeCamx;
+			v.y += vcFreeCamz;
+			v.z += vcFreeCamy;
 			break;
 
 		case LMVIEW_RDVZWIN:
 			v = _V(-0.58, -0.05, 1.004) + ofs;
 			SetCameraDefaultDirection(_V(0.0, 1.0, 0.0));
+			v.x += vcFreeCamx;
+			v.y += vcFreeCamz;
+			v.z += -vcFreeCamy;
 			break;
 
 		}
@@ -631,6 +698,11 @@ bool LEM::clbkLoadVC (int id)
 
 	//Reset Clip Radius settings
 	SetClipRadius(0.0);
+
+	//Reset VC free camera to default
+	vcFreeCamx = 0;
+	vcFreeCamy = 0;
+	vcFreeCamz = 0;
 
 	switch (id) {
 	case LMVIEW_CDR:


### PR DESCRIPTION
Allows the CM VC to not be locked to a fixed camera position.
The concept is the same as the 2D panels, so the VC can be scrolled left/right/up/down/in/out freely.

Keys:
Arrow keys: Scroll left/right/up/down
Insert/Delete: Scroll forward/backward
Shift: Scroll slowly