### PR TITLE
Update LM pointer in MCC class like target pointer in RTCC class; fix…

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
@@ -1301,6 +1301,7 @@ int MCC::subThread(){
 			if (ves != NULL)
 			{
 				rtcc->calcParams.tgt = oapiGetVesselInterface(ves);
+				lm = (LEM*)rtcc->calcParams.tgt;
 			}
 		}
 


### PR DESCRIPTION
…es bug that crashes the simulation when a LM uplink by the MCC is attempted but the scenario had not been reloaded since the LM got created