### PR TITLE
PDAP modification

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -12628,32 +12628,28 @@ bool RTCC::PoweredDescentAbortProgram(PDAPOpt opt, PDAPResults &res)
 
 		} while (abs(dV_Inc) > 0.1*0.3048 && K_loop < 10);
 
-		if (opt.IsTwoSegment && dt_abort > opt.dt_switch)
+		if (opt.IsTwoSegment && K3 == false && dt_abort > opt.dt_switch)
 		{
-			if (K3 == false)
+			K_loop = 0;
+			dt_CSI += opt.dt_2CSI;
+			conopt.t_TPI += opt.dt_2TPI;
+			res.Theta_LIM = theta_apo + (theta_D - theta_apo) / (R_a - R_a_apo);
+			if (dt_CAN >= dt_CSI)
 			{
-				K_loop = 0;
-				dt_CSI += opt.dt_2CSI;
-				conopt.t_TPI += opt.dt_2TPI;
-				opt.dt_switch += opt.dt_2switch;
-				res.Theta_LIM = theta_apo + (theta_D - theta_apo) / (R_a - R_a_apo);
-				if (dt_CAN >= dt_CSI)
-				{
-					dt_CAN = 0.0;
-				}
+				dt_CAN = 0.0;
+			}
 
-				OrbMech::LinearLeastSquares(Phase_Table, A_ins_Table, res.K1, res.J1);
-				res.DEDA227 = res.K1;
-				res.DEDA224 = res.J1;
-				Phase_Table.clear();
-				A_ins_Table.clear();
-				K3 = true;
-			}
-			else
-			{
-				OrbMech::LinearLeastSquares(Phase_Table, A_ins_Table, res.K2, res.J2);
-				stop = true;
-			}
+			OrbMech::LinearLeastSquares(Phase_Table, A_ins_Table, res.K1, res.J1);
+			res.DEDA227 = res.K1;
+			res.DEDA224 = res.J1;
+			Phase_Table.clear();
+			A_ins_Table.clear();
+			K3 = true;
+		}
+		else if (opt.IsTwoSegment && K3 == true && R_a < res.R_amin)
+		{
+			OrbMech::LinearLeastSquares(Phase_Table, A_ins_Table, res.K2, res.J2);
+			stop = true;
 		}
 		else
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -12628,28 +12628,32 @@ bool RTCC::PoweredDescentAbortProgram(PDAPOpt opt, PDAPResults &res)
 
 		} while (abs(dV_Inc) > 0.1*0.3048 && K_loop < 10);
 
-		if (opt.IsTwoSegment && K3 == false && dt_abort > opt.dt_switch)
+		if (opt.IsTwoSegment && R_a < res.R_amin)
 		{
-			K_loop = 0;
-			dt_CSI += opt.dt_2CSI;
-			conopt.t_TPI += opt.dt_2TPI;
-			res.Theta_LIM = theta_apo + (theta_D - theta_apo) / (R_a - R_a_apo);
-			if (dt_CAN >= dt_CSI)
+			if (K3 == false)
 			{
-				dt_CAN = 0.0;
-			}
+				K_loop = 0;
+				dt_CSI += opt.dt_2CSI;
+				conopt.t_TPI += opt.dt_2TPI;
+				res.Theta_LIM = theta_apo + (theta_D - theta_apo) / (R_a - R_a_apo)*(res.R_amin - R_a_apo);
+				res.R_amin = length(opt.R_LS) + opt.h_2amin;
+				if (dt_CAN >= dt_CSI)
+				{
+					dt_CAN = 0.0;
+				}
 
-			OrbMech::LinearLeastSquares(Phase_Table, A_ins_Table, res.K1, res.J1);
-			res.DEDA227 = res.K1;
-			res.DEDA224 = res.J1;
-			Phase_Table.clear();
-			A_ins_Table.clear();
-			K3 = true;
-		}
-		else if (opt.IsTwoSegment && K3 == true && R_a < res.R_amin)
-		{
-			OrbMech::LinearLeastSquares(Phase_Table, A_ins_Table, res.K2, res.J2);
-			stop = true;
+				OrbMech::LinearLeastSquares(Phase_Table, A_ins_Table, res.K1, res.J1);
+				res.DEDA227 = res.K1;
+				res.DEDA224 = res.J1;
+				Phase_Table.clear();
+				A_ins_Table.clear();
+				K3 = true;
+			}
+			else
+			{
+				OrbMech::LinearLeastSquares(Phase_Table, A_ins_Table, res.K2, res.J2);
+				stop = true;
+			}
 		}
 		else
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -914,12 +914,10 @@ struct PDAPOpt //Powered Descent Abort Program
 	double dt_CAN = 50.0*60.0;
 	//DV of the canned maneuver
 	double dv_CAN = 10.0*0.3048;
-	//Minimum apogee altitude limit for the insertion orbit; reference from the landing site radius;
+	//Minimum apogee altitude limit for the insertion orbit; reference from the landing site radius
 	double h_amin = 30.0*1852.0;
 	//Time from PDI to switchover
 	double dt_switch = 10.0*60.0; //Apollo 12
-	//Time added to dt_switch for generation of the second set of targeting coefficients
-	double dt_2switch = 6.0*60.0 + 20.0; //Apollo 12
 	//Flag to use the long profile in the first set of targeting coefficients
 	bool LongProfileFirst = false;
 };

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -914,8 +914,14 @@ struct PDAPOpt //Powered Descent Abort Program
 	double dt_CAN = 50.0*60.0;
 	//DV of the canned maneuver
 	double dv_CAN = 10.0*0.3048;
-	//Minimum apogee altitude limit for the insertion orbit; reference from the landing site radius
+	//Minimum apogee altitude limit for the insertion orbit; reference from the landing site radius;
 	double h_amin = 30.0*1852.0;
+	//Time from PDI to switchover
+	double dt_switch = 10.0*60.0;
+	//Time added to dt_switch for generation of the second set of targeting coefficients
+	double dt_2switch = 7.0*60.0;
+	//Flag to use the long profile in the first set of targeting coefficients
+	bool LongProfileFirst = false;
 };
 
 struct PDAPResults
@@ -4687,6 +4693,7 @@ private:
 	bool CalculationMTP_F(int fcn, LPVOID &pad, char * upString = NULL, char * upDesc = NULL, char * upMessage = NULL);
 	bool CalculationMTP_G(int fcn, LPVOID &pad, char * upString = NULL, char * upDesc = NULL, char * upMessage = NULL);
 	bool CalculationMTP_H1(int fcn, LPVOID &pad, char * upString = NULL, char * upDesc = NULL, char * upMessage = NULL);
+	bool CalculationMTP_J3(int fcn, LPVOID &pad, char * upString = NULL, char * upDesc = NULL, char * upMessage = NULL);
 
 	//Generalized Contact Generator
 	void EMGENGEN(EphemerisDataTable2 &ephemeris, ManeuverTimesTable &MANTIMES, const StationTable &stationlist, int body, OrbitStationContactsTable &res, LunarStayTimesTable *LUNSTAY = NULL);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -917,9 +917,9 @@ struct PDAPOpt //Powered Descent Abort Program
 	//Minimum apogee altitude limit for the insertion orbit; reference from the landing site radius;
 	double h_amin = 30.0*1852.0;
 	//Time from PDI to switchover
-	double dt_switch = 10.0*60.0;
+	double dt_switch = 10.0*60.0; //Apollo 12
 	//Time added to dt_switch for generation of the second set of targeting coefficients
-	double dt_2switch = 7.0*60.0;
+	double dt_2switch = 6.0*60.0 + 20.0; //Apollo 12
 	//Flag to use the long profile in the first set of targeting coefficients
 	bool LongProfileFirst = false;
 };

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -915,9 +915,8 @@ struct PDAPOpt //Powered Descent Abort Program
 	//DV of the canned maneuver
 	double dv_CAN = 10.0*0.3048;
 	//Minimum apogee altitude limit for the insertion orbit; reference from the landing site radius
-	double h_amin = 30.0*1852.0;
-	//Time from PDI to switchover
-	double dt_switch = 10.0*60.0; //Apollo 12
+	double h_amin = 30.0*1852.0; //First segment
+	double h_2amin = 30.0*1852.0; //Second segment
 	//Flag to use the long profile in the first set of targeting coefficients
 	bool LongProfileFirst = false;
 };

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -4693,7 +4693,6 @@ private:
 	bool CalculationMTP_F(int fcn, LPVOID &pad, char * upString = NULL, char * upDesc = NULL, char * upMessage = NULL);
 	bool CalculationMTP_G(int fcn, LPVOID &pad, char * upString = NULL, char * upDesc = NULL, char * upMessage = NULL);
 	bool CalculationMTP_H1(int fcn, LPVOID &pad, char * upString = NULL, char * upDesc = NULL, char * upMessage = NULL);
-	bool CalculationMTP_J3(int fcn, LPVOID &pad, char * upString = NULL, char * upDesc = NULL, char * upMessage = NULL);
 
 	//Generalized Contact Generator
 	void EMGENGEN(EphemerisDataTable2 &ephemeris, ManeuverTimesTable &MANTIMES, const StationTable &stationlist, int body, OrbitStationContactsTable &res, LunarStayTimesTable *LUNSTAY = NULL);


### PR DESCRIPTION
This modification to the Powered Descent Abort Processor allows the following:
1. A flag to allow the long profile (with canned maneuver) to be used in the 1st segment of coefficients
2. A second apolune threshold for terminating the coefficient segments.