### PR TITLE
LMP vessel name loading bug; it tried to load the CMP vessel name ins…

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_aux/Mission.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_aux/Mission.cpp
@@ -264,7 +264,7 @@ namespace mission {
 			}
 			else if (!_strnicmp(line, "LMPVesselName=", 14)) {
 				strncpy(buffer, line + 14, 255);
-				strCMPName.assign(buffer);
+				strLMPName.assign(buffer);
 			}
 			else if (!_strnicmp(line, "CDRSuitName=", 12)) {
 				strncpy(buffer, line + 12, 255);


### PR DESCRIPTION
…tead, which in most cases isn't set, so it defaulted to calling the LMP vessel "LMP"