### PR TITLE
AGC radar interrupts are done in one central place

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -590,6 +590,14 @@ VESSEL *CSMcomputer::GetLM()
 	return NULL;
 }
 
+void CSMcomputer::GetRadarData(int radarBits)
+{
+	if (radarBits == 4)
+	{
+		sat->vhfranging.GetRangeCMC();
+	}
+}
+
 
 //
 // CM Optics class code

--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.h
@@ -142,6 +142,7 @@ protected:
 	// DS20060308 FDAI NEEDLES
 	void ProcessIMUCDUErrorCount(int channel, ChannelValue val);
 	void ProcessIMUCDUReadCount(int channel, int val);
+	void GetRadarData(int radarBits);
 
 	FILE *Dfile;
 	int count;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.h
@@ -601,6 +601,7 @@ public:
 
 	double GetRange() { return range / 185.20; }
 	void RangingReturnSignal(); // ################# DELETE ME #######################
+	void GetRangeCMC();
 protected:
 
 	bool RangingOffLogic();

--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -737,6 +737,7 @@ void Saturn::SystemsTimestep(double simt, double simdt, double mjd) {
 		omnic.TimeStep();
 		omnid.TimeStep();
 		if (pMission->CSMHasVHFRanging()) vhfranging.TimeStep(simdt);
+		agc.RadarRead();
 		vhftransceiver.Timestep();
 		sce.Timestep();
 		dataRecorder.TimeStep( MissionTime, simdt );

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -120,6 +120,10 @@ public:
 	bool IsVelocityDataGood() { return velocityGood == 1; };
 	double GetAltitude() { return range*0.3048; };
 	double GetAltitudeRate() { return rate[0]*0.3048; };
+	void GetRangeLGC();
+	void GetVelocityXLGC();
+	void GetVelocityYLGC();
+	void GetVelocityZLGC();
 	double GetAltTransmitterPower();
 	double GetVelTransmitterPower();
 
@@ -133,7 +137,6 @@ public:
 	double range;				// Range in feet
 	double rate[3];				// Velocity X/Y/Z in feet/second
 	double antennaAngle;		// Antenna angle
-	int ruptSent;				// Rupt sent
 	int rangeGood;				// RDG flag
 	int velocityGood;			// VDG flag
 };

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.cpp
@@ -390,6 +390,31 @@ VESSEL * LEMcomputer::GetCSM()
 	return NULL;
 }
 
+void LEMcomputer::GetRadarData(int radarBits)
+{
+	switch (radarBits)
+	{
+	case 1: // LR (LR VEL X)
+		lem->LR.GetVelocityXLGC();
+		break;
+	case 2:	// RR RANGE RATE
+		lem->RR.GetRadarRateLGC();
+		break;
+	case 3:	// LR (LR VEL Z)
+		lem->LR.GetVelocityZLGC();
+		break;
+	case 4:	// RR RANGE
+		lem->RR.GetRadarRangeLGC();
+		break;
+	case 5: // LR (LR VEL Y)
+		lem->LR.GetVelocityYLGC();
+		break;
+	case 7: // LR (LR RANGE)
+		lem->LR.GetRangeLGC();
+		break;
+	}
+}
+
 //
 // LM Optics class code
 //

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEMcomputer.h
@@ -70,6 +70,8 @@ protected:
 	void ProcessChannel143(ChannelValue val);
 	void ProcessChannel34(ChannelValue val);
 
+	void GetRadarData(int radarBits);
+
 	//
 	// log file for autoland debugging
 	//

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -1534,6 +1534,7 @@ void LEM::SystemsTimestep(double simt, double simdt)
 	optics.Timestep(simdt);
 	LR.Timestep(simdt);
 	RR.Timestep(simdt);
+	agc.RadarRead();
 	RadarTape.Timestep(simdt);
 	crossPointerLeft.Timestep(simdt);
 	crossPointerRight.Timestep(simdt);
@@ -2448,6 +2449,50 @@ bool LEM_LR::IsPowered()
 	return true;
 }
 
+void LEM_LR::GetRangeLGC()
+{
+	if (!IsPowered()) return;
+
+	// High range is 5.395 feet per count
+	// Low range is 1.079 feet per count
+	if (range >= 2500.0) {
+		// Hi Range
+		lem->agc.vagc.Erasable[0][RegRNRAD] = (int16_t)(range / 5.395);
+	}
+	else {
+		// Lo Range
+		lem->agc.vagc.Erasable[0][RegRNRAD] = (int16_t)(range / 1.079);
+	}
+}
+
+void LEM_LR::GetVelocityXLGC()
+{
+	if (!IsPowered()) return;
+
+	// 12288 COUNTS = -000000 F/S
+	// SIGN REVERSED
+	// 0.643966 F/S PER COUNT
+	lem->agc.vagc.Erasable[0][RegRNRAD] = (int16_t)(12288.0 - (rate[0] / 0.643966));
+}
+
+void LEM_LR::GetVelocityYLGC()
+{
+	if (!IsPowered()) return;
+
+	// 12288 COUNTS = +000000 F/S
+	// 1.211975 F/S PER COUNT
+	lem->agc.vagc.Erasable[0][RegRNRAD] = (int16_t)(12288.0 + (rate[1] / 1.211975));
+}
+
+void LEM_LR::GetVelocityZLGC()
+{
+	if (!IsPowered()) return;
+
+	// 12288 COUNTS = +00000 F/S
+	// 0.866807 F/S PER COUNT
+	lem->agc.vagc.Erasable[0][RegRNRAD] = (int16_t)(12288.0 + (rate[2] / 0.866807));
+}
+
 double LEM_LR::GetAltTransmitterPower()
 {
 	if (!IsPowered())
@@ -2472,10 +2517,8 @@ void LEM_LR::Timestep(double simdt){
 	if(lem == NULL){ return; }
 	// char debugmsg[256];
 	ChannelValue val12;
-	ChannelValue val13;
 	ChannelValue val33;
 	val12 = lem->agc.GetInputChannel(012);
-	val13 = lem->agc.GetInputChannel(013);
 	val33 = lem->agc.GetInputChannel(033);
 
 	if (IsPowered())
@@ -2499,21 +2542,6 @@ void LEM_LR::Timestep(double simdt){
 		if(clobber == TRUE){ lem->agc.SetInputChannel(033, val33); }
 		rangeGood = 0;
 		velocityGood = 0;
-		if (val13[RadarActivity] == 1) {
-			int radarBits = 0;
-			if (val13[RadarA] == 1) { radarBits |= 1; }
-			if (val13[RadarB] == 1) { radarBits |= 2; }
-			if (val13[RadarC] == 1) { radarBits |= 4; }
-			switch (radarBits) {
-			case 1:
-			case 3:
-			case 5:
-			case 7:
-				lem->agc.SetInputChannelBit(013, RadarActivity, 0);
-				lem->agc.RaiseInterrupt(ApolloGuidance::Interrupt::RADARUPT);
-				break;
-			}
-		}
 		return;
 	}	
 
@@ -2722,80 +2750,6 @@ void LEM_LR::Timestep(double simdt){
 	if(velocityGood == 1 && val33[LRVelocityDataGood] == 0){ val33[LRVelocityDataGood] = 1; lem->agc.SetInputChannel(033, val33);	}
 	if(velocityGood == 0 && val33[LRVelocityDataGood] == 1){ val33[LRVelocityDataGood] = 0; lem->agc.SetInputChannel(033, val33);	}
 
-	// The computer wants something from the radar.
-	if(val13[RadarActivity] == 1){
-		int radarBits = 0;
-		if(val13[RadarA] == 1){ radarBits |= 1; }
-		if(val13[RadarB] == 1){ radarBits |= 2; }
-		if(val13[RadarC] == 1){ radarBits |= 4; }
-		switch(radarBits){
-		case 1: 
-			// LR (LR VEL X)
-			// 12288 COUNTS = -000000 F/S
-			// SIGN REVERSED				
-			// 0.643966 F/S PER COUNT
-			lem->agc.vagc.Erasable[0][RegRNRAD] = (int16_t)(12288.0 - (rate[0] / 0.643966));
-			lem->agc.SetInputChannelBit(013, RadarActivity, 0);
-			lem->agc.RaiseInterrupt(ApolloGuidance::Interrupt::RADARUPT);
-			ruptSent = 1;
-
-			break;
-		case 2:
-			// RR RANGE RATE
-			// Not our problem
-			break;
-		case 3:
-			// LR (LR VEL Z)
-			// 12288 COUNTS = +00000 F/S
-			// 0.866807 F/S PER COUNT
-			lem->agc.vagc.Erasable[0][RegRNRAD] = (int16_t)(12288.0 + (rate[2] / 0.866807));
-			lem->agc.SetInputChannelBit(013, RadarActivity, 0);
-			lem->agc.RaiseInterrupt(ApolloGuidance::Interrupt::RADARUPT);
-			ruptSent = 3;
-
-			break;
-		case 4:
-			// RR RANGE
-			// Not our problem
-			break;
-		case 5:
-			// LR (LR VEL Y)
-			// 12288 COUNTS = +000000 F/S
-			// 1.211975 F/S PER COUNT
-			lem->agc.vagc.Erasable[0][RegRNRAD] = (int16_t)(12288.0 + (rate[1] / 1.211975));
-			lem->agc.SetInputChannelBit(013, RadarActivity, 0);
-			lem->agc.RaiseInterrupt(ApolloGuidance::Interrupt::RADARUPT);
-			ruptSent = 5;
-
-			break;
-		case 7: 
-			// LR (LR RANGE)
-			// High range is 5.395 feet per count
-			// Low range is 1.079 feet per count
-			if (val33[LRRangeLowScale] == 0) {
-				// Hi Range
-				lem->agc.vagc.Erasable[0][RegRNRAD] = (int16_t)(range / 5.395);
-			}
-			else {
-				// Lo Range
-				lem->agc.vagc.Erasable[0][RegRNRAD] = (int16_t)(range / 1.079);
-			}
-			lem->agc.SetInputChannelBit(013, RadarActivity, 0);
-			lem->agc.RaiseInterrupt(ApolloGuidance::Interrupt::RADARUPT);
-			ruptSent = 7;
-
-			break;
-			/*
-		default:
-			sprintf(oapiDebugString(),"%s BADBITS",debugmsg);
-			*/
-		}
-
-	}else{
-		ruptSent = 0;
-	}
-
-
 	//sprintf(oapiDebugString(), "rangeGood: %d velocityGood: %d ruptSent: %d  RadarActivity: %d Position %f° Range: %f", rangeGood, velocityGood, ruptSent, val13[RadarActivity] == 1, antennaAngle, range);
 }
 
@@ -2811,7 +2765,6 @@ void LEM_LR::SaveState(FILEHANDLE scn,char *start_str,char *end_str){
 	oapiWriteLine(scn, start_str);
 	papiWriteScenario_double(scn, "RANGE", range);
 	papiWriteScenario_double(scn, "ANTENNAANGLE", antennaAngle);
-	oapiWriteScenario_int(scn, "RUPTSEND", ruptSent);
 	oapiWriteScenario_int(scn, "RANGEGOOD", rangeGood);
 	oapiWriteScenario_int(scn, "VELOCITYGOOD", velocityGood);
 	papiWriteScenario_vec(scn, "RATE", _V(rate[0], rate[1], rate[2]));
@@ -2833,9 +2786,6 @@ void LEM_LR::LoadState(FILEHANDLE scn,char *end_str){
 		if (!strnicmp(line, "ANTENNAANGLE", 12)) {
 			sscanf(line + 12, "%lf", &dec);
 			antennaAngle = dec;
-		}
-		if (!strnicmp(line, "RUPTSEND", 8)) {
-			sscanf(line + 8, "%d", &ruptSent);
 		}
 		if (!strnicmp(line, "RANGEGOOD", 9)) {
 			sscanf(line + 9, "%d", &rangeGood);

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_rr.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_rr.h
@@ -53,6 +53,8 @@ public:
 	double GetTrunnionCos() { return cos_trunnion; }
 	double dBm2SignalStrength(double RecvdRRPower_dBm);
 	void SetRCVDrfProp(double freq, double pow, double gain, double phase) { RCVDfreq = freq; RCVDpow = pow; RCVDgain = gain; RCVDPhase = phase; };
+	void GetRadarRangeLGC();
+	void GetRadarRateLGC();
 
 	bool IsPowered();
 	bool IsDCPowered();
@@ -83,7 +85,6 @@ private:
 	double rate;
 	double internalrange;
 	double internalrangerate;
-	int ruptSent;				// Rupt sent
 	int scratch[2];             // Scratch data
 	int mode;					//Mode I = false, Mode II = true
 	double hpbw_factor;			//Beamwidth factor

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
@@ -783,6 +783,23 @@ void ApolloGuidance::SetOutputChannel(int channel, ChannelValue val)
 	}
 }
 
+void ApolloGuidance::RadarRead()
+{
+	ChannelValue val13 = GetInputChannel(013);
+
+	if (val13[RangeUnitActivity] == 1) {
+		int radarBits = 0;
+		if (val13[RangeUnitSelectA] == 1) { radarBits |= 1; }
+		if (val13[RangeUnitSelectB] == 1) { radarBits |= 2; }
+		if (val13[RangeUnitSelectC] == 1) { radarBits |= 4; }
+
+		GetRadarData(radarBits);
+
+		SetInputChannelBit(013, RangeUnitActivity, 0);
+		RaiseInterrupt(ApolloGuidance::Interrupt::RADARUPT);
+	}
+}
+
 //
 // By default, do nothing for the RCS channels.
 //

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
@@ -262,6 +262,9 @@ public:
 
 	virtual void ProcessIMUCDUReadCount(int channel, int val);
 
+	/// Resets the radar activity bit, reads radar data and causes the RADARUPT. Should be called after the radar timesteps
+	void RadarRead();
+
 	///
 	/// \brief Triggers Virtual AGC core dump
 	///
@@ -355,6 +358,9 @@ protected:
 	virtual void ProcessChannel143(ChannelValue val);
 	virtual void ProcessChannel163(ChannelValue val);
 	virtual void ProcessIMUCDUErrorCount(int channel, ChannelValue val);
+
+	/// Vehicle specific function
+	virtual void GetRadarData(int radarBits) = 0;
 
 public:
 


### PR DESCRIPTION
Instead of the RR, LR and VHF ranging system having to reset the radar activity bit and cause a RADARUPT, it is now done in one central place in the ApolloGuidance class, in a function that is called after the radar timesteps. That also removes a bunch of ugly code in the case the radar is not powered. This update should fix any remaining radar interface issues where the AGC wants data from a radar but is never getting an interrupt, usually causing some program alarm. This will fix a case with Luminary 99 where you are in V63, which reads RR data every second, and switch from RR mode LGC to Slew, causing a 1210 alarm.

As this update changes how all radar data is being read, a bit of additional testing should be done. Some lunar descent and rendezvous would be best.