### PR TITLE
Reload cue cards at CM/SM sep. Move probe mesh code to AddCMMeshes function

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnmesh.cpp
@@ -1076,18 +1076,7 @@ void Saturn::SetCSMStage (VECTOR3 cg_ofs)
 	meshidx = AddMesh(hCMInt, &mesh_dir);
 	SetMeshVisibilityMode(meshidx, MESHVIS_EXTERNAL);
 
-	// Docking probe
-	if (HasProbe) {
-		dockringidx = AddMesh(hdockring, &mesh_dir);
-		probeidx = AddMesh(hprobe, &mesh_dir);
-		probeextidx = AddMesh(hprobeext, &mesh_dir);
-		SetDockingProbeMesh();
-	} else {
-		dockringidx = -1;
-		probeidx = -1;
-		probeextidx = -1;
-	}
-
+	//Add CM meshes. More to be added here...
 	AddCMMeshes(mesh_dir);
 
 	// Docking port
@@ -1592,22 +1581,8 @@ void Saturn::SetReentryMeshes() {
 	coascdridx = AddMesh(hcmCOAScdr, &mesh_dir);
 	SetCOASMesh();
 
-	//
-	// Docking probe
-	//
-
-	if (HasProbe)
-	{
-		dockringidx = AddMesh(hdockring, &mesh_dir);
-		probeidx = AddMesh(hprobe, &mesh_dir);
-		probeextidx = AddMesh(hprobeext, &mesh_dir);
-		SetDockingProbeMesh();
-	} else
-	{
-		dockringidx = -1;
-		probeidx = -1;
-		probeextidx = -1;
-	}
+	//Add CM meshes. More to be added here...
+	AddCMMeshes(mesh_dir);
 }
 
 void Saturn::StageSeven(double simt)
@@ -2260,9 +2235,23 @@ void Saturn::ResetDynamicMeshIndizes()
 
 void Saturn::AddCMMeshes(const VECTOR3 &mesh_dir)
 {
+	// Docking probe
+	if (HasProbe) {
+		dockringidx = AddMesh(hdockring, &mesh_dir);
+		probeidx = AddMesh(hprobe, &mesh_dir);
+		probeextidx = AddMesh(hprobeext, &mesh_dir);
+		SetDockingProbeMesh();
+	}
+	else {
+		dockringidx = -1;
+		probeidx = -1;
+		probeextidx = -1;
+	}
+
 	// Optics Cover
 	opticscoveridx = AddMesh(hopticscover, &mesh_dir);
 	SetOpticsCoverMesh();
 
+	//Reload cue cards, if required
 	CueCards.ResetCueCards();
 }


### PR DESCRIPTION
During the initial cue cards work I added a function called AddCMMeshes, where in the long run all the meshes related code should go that are always required in the Saturn class, so the barebones CM. A lot more can be moved there, but as part of the fix for cue cards vanishing at CM/SM sep, I am starting to do that. So this PR does:

-AddCMMeshes now handles docking probe, optics cover and cue card meshes (docking probe is new)
-AddCMMeshes is called in SetReentryMeshes, so that the cue cards are still loaded at CM/SM sep
-Duplicate code removed from SetCSMStage and SetReentryMeshes, so that it is now only done in AddCMMeshes 

In terms of changed behavior, the cue cards bug should be fixed and the optics cover can now be loaded on the CM, if it is still attached