### PR TITLE
Remove duplicate code for LM hover stage (after gear deployment) as much as possible

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemmesh.cpp
@@ -208,10 +208,6 @@ void LEM::SetLmVesselDockStage()
 
 void LEM::SetLmVesselHoverStage()
 {
-	ClearThrusterDefinitions();
-
-	SetEmptyMass(AscentFuelMassKg + AscentEmptyMassKg + DescentEmptyMassKg);
-
 	SetSize (7);
 	SetVisibilityLimit(1e-3, 5.4135e-4);
 	SetPMI(_V(2.5428, 2.2871, 2.7566));
@@ -221,54 +217,11 @@ void LEM::SetLmVesselHoverStage()
 	SetPitchMomentScale (0);
 	SetYawMomentScale (0);
 	SetLiftCoeffFunc (0);
-	ClearBeacons();
-	ClearExhaustRefs();
-	ClearAttExhaustRefs();
 
 	DefineTouchdownPoints(1);
 
-	if (!ph_Dsc){  
-		ph_Dsc  = CreatePropellantResource(DescentFuelMassKg); //2nd stage Propellant
-	}
-	else
-	{
-		SetPropellantMaxMass(ph_Dsc, DescentFuelMassKg);
-	}
-
-	SetDefaultPropellantResource (ph_Dsc); // display 2nd stage propellant level in generic HUD
-
-	if (!ph_RCSA){
-		ph_RCSA = CreatePropellantResource(LM_RCS_FUEL_PER_TANK);
-	}
-	if (!ph_RCSB){
-		ph_RCSB = CreatePropellantResource(LM_RCS_FUEL_PER_TANK);
-	}
-	
-	// orbiter main thrusters
-	//Ascent stage mesh has RCS plane as reference, but it's shifted by 0.99 m up for center of full LM mesh
-	//RCS plane is at 254 inches in LM coordinates. DPS gimbal plane is at 154 inches in LM coordinates
-	//Therefore: 3.9116 m - (6.4516 m - 0.99 m) = -1.55 m for the DPS reference position
-	th_hover[0] = CreateThruster(_V(0.0, -1.55, 0.0), _V(0, 1, 0), 46706.3, ph_Dsc, 3107);
-	thg_hover = CreateThrusterGroup(th_hover, 1, THGROUP_USER);
-
-	EXHAUSTSPEC es_hover[1] = {
-		{ th_hover[0], NULL, NULL, NULL, 10.0, 1.5, 1.16, 0.1, exhaustTex, EXHAUST_CONSTANTPOS }
-	};
-
-	AddExhaust(es_hover);
-
-	AddDust();
-
 	status = 1;
 	stage = 1;
-	SetView();
-	AddRCS_LMH(-5.4616); //254 inches minus the 0.99m offset from mesh_asc = 5.4616 m
-
-	InitNavRadios (4);
-
-	// Exterior lights
-	SetTrackLight();
-	SetDockingLights();
 }
 
 void LEM::SetLmAscentHoverStage()


### PR DESCRIPTION
The LM in NASSP is simulated as having three separate phases:

Stage 0: "Docked" stage, full LM before gear deployment
Stage 1: "Hover" stage, full LM after gear deployment
Stage 2: Ascent stage

Originally the gear deployment was simulated as a mesh change (now it is an animation) and the only way to accomplish this was to reload all meshes. So the function that sets up the LM hover stage (SetLmVesselHoverStage) had to create the LM entirely from scratch, in the same way as the LM dock stage function (SetLmVesselDockStage) does it.

Presently SetLmVesselHoverStage still contains a lot of duplicate code compared to SetLmVesselDockStage. This pull request removes as much as possible of this. Note that on scenario loading the function SetLmVesselDockStage is always called, no matter the stage (even ascent stage). So SetLmVesselHoverStage only needs to have configuration changes that actually come from the gear deployment.

Issue #1016 is caused by reloading the RCS thruster locations without taking the shifted CG into account. They are created in the wrong place on gear deployment, so it's not just a visual bug. Removing the duplicate code should also fix this issue.

This PR changes for the gear deployment:

-LM thrusters and thruster groups aren't deleted and then created from scratch
-Empty mass isn't re-calculated (gear deployment should have no mass change, maybe a tiny bit from the pyro)
-Beacons (docking and tracking lights) aren't deleted and created from scratch
-DPS and RCS propellants aren't created (in case they had not been created before)
-View position isn't reset

The function still contains:
-SetSize and SetVisibilityLimit. Has an influence on how visible the vessel is from long distances. The dock and hover configurations of the LM use different values right now and that is probably realistic, as the gear deployment causes a physical change and appears slightly larger
-Moments of inertia (SetPMI) call. Right now we don't simulate a difference for this before vs. after gear deployment, but it could be done to get a slightly more realistic value
-Several aerodynamic functions (SetCrossSections, CreateAirfoils, SetRotDrag, SetPitchMomentScale, SetYawMomentScale, SetLiftCoeffFunc). Like the moments of inertia no difference is currently being simulated, but the gear deployment would have an influence on aerodynamics, so this is being retained.
-Touchdown points, they are obviously a main difference between pre and post gear deployment
-Status/stage flags for all kinds of purposes

So to fully test that this pull request doesn't break anything, one should test a gear deployment, for example with the Apollo 9 Before Gear Deployment scenario:

-That the DPS and RCS are working properly after gear deployment and also is visually correct (fix for #1016)
-Mass doesn't change
-Docking and tracking lights still work
-Propellants are the same
-View doesn't jump in 2D or VC