### PR TITLE
Upgraded S-IVB lunar impact targeting

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -742,7 +742,7 @@ ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
 
 	LUNTAR_lat = 0.0;
 	LUNTAR_lng = 0.0;
-	LUNTAR_bt_guess = 10.0;
+	LUNTAR_bt_guess = 0.0;
 	LUNTAR_pitch_guess = 0.0;
 	LUNTAR_yaw_guess = 0.0;
 	LUNTAR_TIG = 0.0;
@@ -4603,7 +4603,7 @@ int ARCore::subThread()
 		in.bt_guess = LUNTAR_bt_guess;
 		in.pitch_guess = LUNTAR_pitch_guess;
 		in.yaw_guess = LUNTAR_yaw_guess;
-		in.tig_guess = GC->rtcc->GMTfromGET(LUNTAR_TIG);
+		in.tig_guess = LUNTAR_TIG;
 		in.TB8 = lvdc->TB8;
 
 		LunarTargetingProgram luntar(GC->rtcc);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -1297,7 +1297,7 @@ void ApolloRTCCMFD::menuLWPLiftoffTime()
 
 void ApolloRTCCMFD::LUNTAR_TIGInput()
 {
-	GenericGETInput(&G->LUNTAR_TIG, "Enter GET (Format: HH:MM:SS)");
+	GenericGETInput(&G->LUNTAR_TIG, "Enter GET (Format: HH:MM:SS). Enter zero for trajectory evaluation (no maneuver):");
 }
 
 void ApolloRTCCMFD::menuLWP_RINS()

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -9516,23 +9516,37 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		skp->Text(1 * W / 2, 3 * H / 32, "LUNAR TARGETING PROGRAM", 33);
 		skp->SetTextAlign(oapi::Sketchpad::LEFT);
 
-		GET_Display(Buffer, G->LUNTAR_TIG, false);
-		skp->Text(1 * W / 16, 2 * H / 14, Buffer, strlen(Buffer));
+		if (G->LUNTAR_TIG)
+		{
+			GET_Display(Buffer, G->LUNTAR_TIG, false);
+			skp->Text(1 * W / 16, 2 * H / 14, Buffer, strlen(Buffer));
 
-		sprintf_s(Buffer, "%.1lf s", G->LUNTAR_bt_guess);
-		skp->Text(1 * W / 16, 4 * H / 14, Buffer, strlen(Buffer));
+			sprintf_s(Buffer, "%.2lf°", G->LUNTAR_lat*DEG);
+			skp->Text(1 * W / 16, 10 * H / 14, Buffer, strlen(Buffer));
 
-		sprintf_s(Buffer, "%.2lf°", G->LUNTAR_pitch_guess*DEG);
-		skp->Text(1 * W / 16, 6 * H / 14, Buffer, strlen(Buffer));
+			sprintf_s(Buffer, "%.2lf°", G->LUNTAR_lng*DEG);
+			skp->Text(1 * W / 16, 12 * H / 14, Buffer, strlen(Buffer));
 
-		sprintf_s(Buffer, "%.2lf°", G->LUNTAR_yaw_guess*DEG);
-		skp->Text(1 * W / 16, 8 * H / 14, Buffer, strlen(Buffer));
+			if (G->LUNTAR_bt_guess)
+			{
+				sprintf_s(Buffer, "%.1lf s", G->LUNTAR_bt_guess);
+				skp->Text(1 * W / 16, 4 * H / 14, Buffer, strlen(Buffer));
 
-		sprintf_s(Buffer, "%.2lf°", G->LUNTAR_lat*DEG);
-		skp->Text(1 * W / 16, 10 * H / 14, Buffer, strlen(Buffer));
+				sprintf_s(Buffer, "%.2lf°", G->LUNTAR_pitch_guess*DEG);
+				skp->Text(1 * W / 16, 6 * H / 14, Buffer, strlen(Buffer));
 
-		sprintf_s(Buffer, "%.2lf°", G->LUNTAR_lng*DEG);
-		skp->Text(1 * W / 16, 12 * H / 14, Buffer, strlen(Buffer));
+				sprintf_s(Buffer, "%.2lf°", G->LUNTAR_yaw_guess*DEG);
+				skp->Text(1 * W / 16, 8 * H / 14, Buffer, strlen(Buffer));
+			}
+			else
+			{
+				skp->Text(1 * W / 16, 4 * H / 14, "No initial guess", 16);
+			}
+		}
+		else
+		{
+			skp->Text(1 * W / 16, 2 * H / 14, "Trajectory Evaluation", 21);
+		}
 
 		if (G->target != NULL)
 		{
@@ -9566,17 +9580,17 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			if (G->LUNTAR_Output.err == 1)
 			{
-				sprintf_s(Buffer, "INITIAL GUESS DID NOT IMPACT");
+				sprintf_s(Buffer, "Initial guess did not impact. PC Alt: %.0lf NM", G->LUNTAR_Output.FlybyAlt);
 			}
 			else if (G->LUNTAR_Output.err == 2)
 			{
-				sprintf_s(Buffer, "SOLUTION DID NOT CONVERGE");
+				sprintf_s(Buffer, "Solution did not converge");
 			}
 			else if (G->LUNTAR_Output.err == 3)
 			{
-				sprintf_s(Buffer, "TIMEBASE 8 NOT STARTED");
+				sprintf_s(Buffer, "Timebase 8 not started");
 			}
-			skp->Text(4 * W / 16, 26 * H / 28, Buffer, strlen(Buffer));
+			skp->Text(1 * W / 16, 26 * H / 28, Buffer, strlen(Buffer));
 		}
 	}
 	else if (screen == 116)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LunarTargetingProgram.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LunarTargetingProgram.cpp
@@ -37,48 +37,152 @@ void LunarTargetingProgram::Call(const LunarTargetingProgramInput &in, LunarTarg
 	mass = in.mass;
 	out.err = 0;
 
-	//Propagate to TIG
-	EphemerisData sv_imp, sv_tig_apo;
-	double mass_f;
+	//Calculate impact site coordinates
+	RLS = OrbMech::r_from_latlong(in.lat_tgt, in.lng_tgt, pRTCC->SystemParameters.MCSMLR);
+
+	EphemerisData sv_tig_apo, sv_imp;
 	int ITS;
 
-	pRTCC->PMMCEN(in.sv_in, 0.0, 0.0, 1, in.tig_guess - in.sv_in.GMT, 1.0, sv_tig, ITS);
+	//Propagate to TIG, if applicable
+	if (in.tig_guess != 0.0)
+	{
+		double mass_f;
 
-	//Simulate maneuver
-	double dv_guess, bt;
+		pRTCC->PMMCEN(in.sv_in, 0.0, 0.0, 1, pRTCC->GMTfromGET(in.tig_guess) - in.sv_in.GMT, 1.0, sv_tig, ITS);
 
-	dv_guess = F / mass * in.bt_guess;
-	sv_tig_apo = SimulateBurn(in.pitch_guess, in.yaw_guess, dv_guess, mass_f, bt);
+		//Simulate maneuver, if applicable
+		if (in.bt_guess != 0.0)
+		{
+			double dv_guess, bt;
 
+			dv_guess = F / mass * in.bt_guess;
+			sv_tig_apo = SimulateBurn(in.pitch_guess, in.yaw_guess, dv_guess, mass_f, bt);
+		}
+		else
+		{
+			sv_tig_apo = sv_tig;
+		}
+	}
+	else
+	{
+		sv_tig_apo = in.sv_in;
+	}
 	//Propagate to impact
-	pRTCC->PMMCEN(sv_tig_apo, 0.0, 10.0*24.0*3600.0, 3, pRTCC->SystemParameters.MCSMLR, 1.0, sv_imp, ITS);
+	pRTCC->PMMCEN(sv_tig_apo, 0.0, 5.0*24.0*3600.0, 3, pRTCC->SystemParameters.MCSMLR, 1.0, sv_imp, ITS);
 	
-	if (ITS != 3)
+	if (ITS != 3 || sv_imp.RBI != BODY_MOON)
 	{
 		//Initial guess didn't impact
 		out.err = 1;
+		//Find closest approach
+		pRTCC->PMMCEN(sv_tig_apo, 0.0, 5.0*24.0*3600.0, 2, 0.0, 1.0, sv_imp, ITS);
+		out.FlybyAlt = (length(sv_imp.R) - pRTCC->SystemParameters.MCSMLR) / 1852.0;
 		return;
 	}
 
-	bool err = ConvergeOnImpact(in.pitch_guess, in.yaw_guess, dv_guess, in.lat_tgt, in.lng_tgt);
+	if (in.tig_guess == 0.0)
+	{
+		//Impact evaluation
+		double alt;
+		pRTCC->GLSSAT(sv_imp.R, sv_imp.GMT, sv_imp.RBI, out.lat_imp, out.lng_imp, alt);
+		out.get_imp = pRTCC->GETfromGMT(sv_imp.GMT);
+		out.tig = 0.0;
+		out.pitch = 0.0;
+		out.yaw = 0.0;
+		out.bt = 0.0;
+		return;
+	}
+
+	//Get initial guess for spherical coordinates
+	double r, v1, v2, gamma1, gamma2, psi1, psi2, theta, phi, dv_mcc, dgamma_mcc, dpsi_mcc;
+
+	RVIO(true, sv_tig.R, sv_tig.V, r, v1, theta, phi, gamma1, psi1);
+	RVIO(true, sv_tig_apo.R, sv_tig_apo.V, r, v2, theta, phi, gamma2, psi2);
+
+	dv_mcc = v2 - v1;
+	dgamma_mcc = gamma2 - gamma1;
+	dpsi_mcc = psi2 - psi1;
+
+	//Converge on impact in STR coordinates
+	bool err = ConvergeOnImpactSTR(dv_mcc, dgamma_mcc, dpsi_mcc, in.lat_tgt, in.lng_tgt);
 	if (err)
 	{
 		out.err = 2;
 		return;
 	}
 
+	//Converge and optimize lat/lng
+	err = ConvergeOnImpact(outarray.dv, outarray.dgamma, outarray.dpsi, in.lat_tgt, in.lng_tgt);
+	if (err)
+	{
+		out.err = 2;
+		return;
+	}
+
+	//Calculate output values
+	MATRIX3 Mat;
+	VECTOR3 DV, BurnVec, BurnVec_LVLH;
+	DV = outarray.sv_tig_apo.V - sv_tig.V;
+	BurnVec = unit(DV);
+	Mat = OrbMech::LVLH_Matrix(sv_tig.R, sv_tig.V);
+	BurnVec_LVLH = mul(Mat, BurnVec);
+
+	out.pitch = atan2(-BurnVec_LVLH.z, BurnVec_LVLH.x);
+	out.yaw = asin(BurnVec_LVLH.y);
+	out.bt = length(DV) / (F / mass);
+
+	//Just for debugging
+	//EphemerisData sv_tig_apo2 = SimulateBurn(out.pitch, out.yaw, length(DV), mass_f, out.bt);
+
 	double temp = sv_tig.GMT - pRTCC->GetIUClockZero();
 	out.tig = temp - in.TB8;
-
-	out.pitch = outarray.pitch;
-	out.yaw = outarray.yaw;
-	out.bt = outarray.bt;
 	out.lat_imp = outarray.lat;
 	out.lng_imp = outarray.lng;
 	out.get_imp = pRTCC->GETfromGMT(outarray.gmt_imp);
 }
 
-bool LunarTargetingProgram::ConvergeOnImpact(double pitch, double yaw, double dv, double lat, double lng)
+bool LunarTargetingProgram::ConvergeOnImpactSTR(double dv, double dgamma, double dpsi, double lat, double lng)
+{
+	void *constPtr;
+
+	constPtr = &outarray;
+
+	bool LunarTargetingProgramTrajectoryComputerSTRPointer(void *data, std::vector<double> &var, void *varPtr, std::vector<double>& arr, bool mode);
+	bool(*fptr)(void *, std::vector<double>&, void*, std::vector<double>&, bool) = &LunarTargetingProgramTrajectoryComputerSTRPointer;
+
+	GenIterator::GeneralizedIteratorBlock block;
+
+	block.IndVarSwitch[0] = true;
+	block.IndVarSwitch[1] = true;
+	block.IndVarSwitch[2] = true;
+	block.IndVarGuess[0] = dv;
+	block.IndVarGuess[1] = dgamma;
+	block.IndVarGuess[2] = dpsi;
+	block.IndVarStep[0] = 0.001;
+	block.IndVarStep[1] = pow(2, -19);
+	block.IndVarStep[2] = pow(2, -19);
+	block.IndVarWeight[0] = 512.0;
+	block.IndVarWeight[1] = 512.0;
+	block.IndVarWeight[2] = 512.0;
+	block.DepVarSwitch[0] = true;
+	block.DepVarSwitch[1] = true;
+	block.DepVarSwitch[2] = true;
+	block.DepVarLowerLimit[0] = -10000.0;
+	block.DepVarLowerLimit[1] = -10000.0;
+	block.DepVarLowerLimit[2] = -10000.0;
+	block.DepVarUpperLimit[0] = 10000.0;
+	block.DepVarUpperLimit[1] = 10000.0;
+	block.DepVarUpperLimit[2] = 10000.0;
+	block.DepVarClass[0] = 1;
+	block.DepVarClass[1] = 1;
+	block.DepVarClass[2] = 1;
+
+	std::vector<double> result;
+	std::vector<double> y_vals;
+	return GenIterator::GeneralizedIterator(fptr, block, constPtr, (void*)this, result, y_vals);
+}
+
+bool LunarTargetingProgram::ConvergeOnImpact(double dv, double dgamma, double dpsi, double lat, double lng)
 {
 	void *constPtr;
 
@@ -92,12 +196,12 @@ bool LunarTargetingProgram::ConvergeOnImpact(double pitch, double yaw, double dv
 	block.IndVarSwitch[0] = true;
 	block.IndVarSwitch[1] = true;
 	block.IndVarSwitch[2] = true;
-	block.IndVarGuess[0] = pitch;
-	block.IndVarGuess[1] = yaw;
-	block.IndVarGuess[2] = dv;
-	block.IndVarStep[0] = pow(2, -19);
+	block.IndVarGuess[0] = dv;
+	block.IndVarGuess[1] = dgamma;
+	block.IndVarGuess[2] = dpsi;
+	block.IndVarStep[0] = 0.001;
 	block.IndVarStep[1] = pow(2, -19);
-	block.IndVarStep[2] = 0.001;
+	block.IndVarStep[2] = pow(2, -19);
 	block.IndVarWeight[0] = 512.0;
 	block.IndVarWeight[1] = 512.0;
 	block.IndVarWeight[2] = 512.0;
@@ -145,6 +249,123 @@ VECTOR3 LunarTargetingProgram::BurnAttitude(double pitch, double yaw)
 	return tmul(Mat, _V(CPITCH*CYAW, SYAW, -SPITCH * CYAW));
 }
 
+void LunarTargetingProgram::BURN(VECTOR3 R, VECTOR3 V, double dv, double dgamma, double dpsi, double &dv_R, double &mfm0, VECTOR3 &RF, VECTOR3 &VF)
+{
+	double r, v;
+	RF = R;
+
+	r = length(R);
+	v = length(V);
+
+	VECTOR3 Rdot1, Rdot2;
+	double d, h;
+
+	d = dotp(R, V);
+	h = length(crossp(R, V));
+	Rdot1 = V * cos(dgamma) + (R*v*v - V * d) / h * sin(dgamma);
+	Rdot2 = R * 2.0*dotp(R, Rdot1) / r / r * pow(sin(dpsi / 2.0), 2) + Rdot1 * cos(dpsi) - crossp(R, Rdot1) / r * sin(dpsi);
+	VF = Rdot2 * (1.0 + dv / v);
+	dv_R = sqrt(dv*dv + 4.0*v*(v + dv)*(pow(sin(dgamma / 2.0), 2) + (h*h*cos(dgamma) - h * d*sin(dgamma)) / (r*r*v*v)*pow(sin(dpsi / 2.0), 2)));
+	mfm0 = exp(-dv_R / isp);
+}
+
+void LunarTargetingProgram::RVIO(bool vecinp, VECTOR3 &R, VECTOR3 &V, double &r, double &v, double &theta, double &phi, double &gamma, double&psi)
+{
+	if (vecinp)
+	{
+		r = length(R);
+		v = length(V);
+		phi = asin(R.z / r);
+		theta = atan2(R.y, R.x);
+		if (theta < 0)
+		{
+			theta += PI2;
+		}
+		gamma = asin(dotp(R, V) / r / v);
+		psi = atan2(R.x*V.y - R.y*V.x, V.z*r - R.z*dotp(R, V) / r);
+		//if (psi < 0)
+		//{
+		//	psi += PI2;
+		//}
+	}
+	else
+	{
+		R = _V(cos(phi)*cos(theta), cos(phi)*sin(theta), sin(phi))*r;
+		V = mul(_M(cos(phi)*cos(theta), -sin(theta), -sin(phi)*cos(theta), cos(phi)*sin(theta), cos(theta), -sin(phi)*sin(theta), sin(phi), 0, cos(phi)), _V(sin(gamma), cos(gamma)*sin(psi), cos(gamma)*cos(psi))*v);
+	}
+}
+
+bool LunarTargetingProgramTrajectoryComputerSTRPointer(void *data, std::vector<double> &var, void *varPtr, std::vector<double>& arr, bool mode)
+{
+	return ((LunarTargetingProgram*)data)->TrajectoryComputerSTR(var, varPtr, arr, mode);
+}
+
+bool LunarTargetingProgram::TrajectoryComputerSTR(std::vector<double> &var, void *varPtr, std::vector<double>& arr, bool mode)
+{
+	//Independent variables:
+	//0: MCC delta velocity in m/s
+	//1: MCC delta flight-path angle in rad
+	//2: MCC delta azimuth in rad
+	//Dependent variables:
+	//0: X-axis error in impact coordinates, meters
+	//1: Y-axis error in impact coordinates, meters
+	//2: Z-axis error in impact coordinates, meters
+
+	LUNTARGeneralizedIteratorArray *vars;
+	vars = static_cast<LUNTARGeneralizedIteratorArray*>(varPtr);
+
+	EphemerisData sv_imp;
+	double mfm0;
+	int ITS;
+
+	vars->dv = var[0];
+	vars->dgamma = var[1];
+	vars->dpsi = var[2];
+
+	//Simulate burn
+	BURN(sv_tig.R, sv_tig.V, vars->dv, vars->dgamma, vars->dpsi, vars->dv_R, mfm0, vars->sv_tig_apo.R, vars->sv_tig_apo.V);
+	vars->sv_tig_apo.RBI = sv_tig.RBI;
+	vars->sv_tig_apo.GMT = sv_tig.GMT;
+	vars->mass_f = mass * mfm0;
+
+	//Propagate to impact
+	pRTCC->PMMCEN(vars->sv_tig_apo, 0.0, 5.0*24.0*3600.0, 3, pRTCC->SystemParameters.MCSMLR, 1.0, sv_imp, ITS);
+
+	if (ITS != 3 || sv_imp.RBI != BODY_MOON)
+	{
+		//Didn't impact
+		return true;
+	}
+
+	MATRIX3 M_MCI_MCT, M_STR;
+	VECTOR3 R_EM, V_EM,  N, E, S, T, R, R_STR_imp, R_STR_des, DR_STR;
+	double r, v, e, beta;
+
+	pRTCC->PLEFEM(3, sv_imp.GMT / 3600.0, 0, &R_EM, &V_EM, NULL, &M_MCI_MCT);
+	N = unit(crossp(R_EM, V_EM));
+
+	r = length(sv_imp.R);
+	v = length(sv_imp.V);
+	E = (sv_imp.R*(v*v - OrbMech::mu_Moon / r) - sv_imp.V*dotp(sv_imp.R, sv_imp.V)) / OrbMech::mu_Moon;
+	e = length(E);
+	beta = acos(1.0 / e);
+	S = unit(E)*cos(beta) + unit(crossp(N, E))*sin(beta);
+	T = unit(crossp(S, N));
+	R = crossp(S, T);
+
+	M_STR = _M(R.x, R.y, R.z, S.x, S.y, S.z, T.x, T.y, T.z);
+
+	R_STR_imp = mul(M_STR, sv_imp.R);
+	R_STR_des = mul(M_STR, tmul(M_MCI_MCT, RLS));
+
+	DR_STR = R_STR_des - R_STR_imp;
+
+	arr[0] = DR_STR.x;
+	arr[1] = DR_STR.y;
+	arr[2] = DR_STR.z;
+	return false;
+}
+
 bool LunarTargetingProgramTrajectoryComputerPointer(void *data, std::vector<double> &var, void *varPtr, std::vector<double>& arr, bool mode)
 {
 	return ((LunarTargetingProgram*)data)->TrajectoryComputer(var, varPtr, arr, mode);
@@ -152,29 +373,34 @@ bool LunarTargetingProgramTrajectoryComputerPointer(void *data, std::vector<doub
 
 bool LunarTargetingProgram::TrajectoryComputer(std::vector<double> &var, void *varPtr, std::vector<double>& arr, bool mode)
 {
+	//Independent variables:
+	//0: MCC delta velocity in m/s
+	//1: MCC delta flight-path angle in rad
+	//2: MCC delta azimuth in rad
+	//Dependent variables:
+	//0: Impact latitude in rad
+	//1: Impact longitude in rad
+	//2: Burnout mass in kg
+
 	LUNTARGeneralizedIteratorArray *vars;
 	vars = static_cast<LUNTARGeneralizedIteratorArray*>(varPtr);
 
 	EphemerisData sv_imp;
-	double alt;
+	double mfm0, alt;
 	int ITS;
 
-	vars->pitch = var[0];
-	vars->yaw = var[1];
-	vars->dv = var[2];
+	vars->dv = var[0];
+	vars->dgamma = var[1];
+	vars->dpsi = var[2];
 
-	if (vars->dv < 0)
-	{
-		//Not allowed
-		return true;
-	}
-
-	vars->sv_tig_apo = SimulateBurn(vars->pitch, vars->yaw, vars->dv, vars->mass_f, vars->bt);
+	//Simulate burn
+	BURN(sv_tig.R, sv_tig.V, vars->dv, vars->dgamma, vars->dpsi, vars->dv_R, mfm0, vars->sv_tig_apo.R, vars->sv_tig_apo.V);
+	vars->mass_f = mass * mfm0;
 
 	//Propagate to impact
-	pRTCC->PMMCEN(vars->sv_tig_apo, 0.0, 10.0*24.0*3600.0, 3, pRTCC->SystemParameters.MCSMLR, 1.0, sv_imp, ITS);
+	pRTCC->PMMCEN(vars->sv_tig_apo, 0.0, 5.0*24.0*3600.0, 3, pRTCC->SystemParameters.MCSMLR, 1.0, sv_imp, ITS);
 
-	if (ITS != 3)
+	if (ITS != 3 || sv_imp.RBI != BODY_MOON)
 	{
 		//Didn't impact
 		return true;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LunarTargetingProgram.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LunarTargetingProgram.h
@@ -34,7 +34,7 @@ struct LunarTargetingProgramInput
 	double pitch_guess;
 	double yaw_guess;
 	double bt_guess;
-	double tig_guess;
+	double tig_guess; //In GET
 
 	double lat_tgt;
 	double lng_tgt;
@@ -53,19 +53,21 @@ struct LunarTargetingProgramOutput
 	double get_imp = 0.0;
 
 	int err = 0;
+	double FlybyAlt = 0.0; //Nautical miles, only in case of no impact
 };
 
 struct LUNTARGeneralizedIteratorArray
 {
-	double pitch;
-	double yaw;
-	double dv;
+	//Stored inputs
+	double dv, dgamma, dpsi;
+
+	//Outputs
 	EphemerisData sv_tig_apo;
-	double bt;
 	double mass_f;
 	double lat;
 	double lng;
 	double gmt_imp;
+	double dv_R;
 };
 
 class LunarTargetingProgram : public RTCCModule
@@ -73,15 +75,21 @@ class LunarTargetingProgram : public RTCCModule
 public:
 	LunarTargetingProgram(RTCC *r);
 	void Call(const LunarTargetingProgramInput &in, LunarTargetingProgramOutput &out);
+	bool TrajectoryComputerSTR(std::vector<double> &var, void *varPtr, std::vector<double>& arr, bool mode);
 	bool TrajectoryComputer(std::vector<double> &var, void *varPtr, std::vector<double>& arr, bool mode);
 
 	LUNTARGeneralizedIteratorArray outarray;
 protected:
-	bool ConvergeOnImpact(double pitch, double yaw, double dv, double lat, double lng);
+	bool ConvergeOnImpactSTR(double dv, double dgamma, double dpsi, double lat, double lng);
+	bool ConvergeOnImpact(double dv, double dgamma, double dpsi, double lat, double lng);
 	EphemerisData SimulateBurn(double pitch, double yaw, double dv, double &mass_f, double &bt);
 	VECTOR3 BurnAttitude(double pitch, double yaw);
 
+	void RVIO(bool vecinp, VECTOR3 &R, VECTOR3 &V, double &r, double &v, double &theta, double &phi, double &gamma, double&psi);
+	void BURN(VECTOR3 R, VECTOR3 V, double dv, double dgamma, double dpsi, double &dv_R, double &mfm0, VECTOR3 &RF, VECTOR3 &VF);
+
 	EphemerisData sv_tig;
+	VECTOR3 RLS;
 	double mass;
 	double F, isp;
 };

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
@@ -1156,7 +1156,7 @@ int RTCC::GLSSAT(VECTOR3 R, double GMT, int RBI, double &lat, double &lng, doubl
 	{
 		return 1;
 	}
-	u = unit(R);
+	u = unit(R_out);
 	lat = atan2(u.z, sqrt(u.x*u.x + u.y*u.y));
 	lng = atan2(u.y, u.x) - OrbMech::w_Earth*K*GMT;
 	OrbMech::normalizeAngle(lng, false);


### PR DESCRIPTION
Improvements are:

-Add trajectory evaluation option, where the impact location of the current trajectory can be determined. If there is no impact the flyby altitude is given
-Change iteration variables so that the targeting doesn't depend on a good initial guess and converges much better
-Simplify display so that no initial guess has to be input, as long as the current trajectory impacts the Moon
-Earth impact cannot be falsely detected as a good impact
-Fix coordinate system bug in common RTCC function

Scenario I used for testing. Apollo 13 at 5h GET:

[Apollo 13 - Before TLI 0008.scn.txt](https://github.com/orbiternassp/NASSP/files/12352510/Apollo.13.-.Before.TLI.0008.scn.txt)
