### PR TITLE
Remove as much CMC initialization code as possible

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_aux/Mission.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_aux/Mission.cpp
@@ -101,6 +101,7 @@ namespace mission {
 		bCSMHasHGA = true;
 		bCSMHasVHFRanging = true;
 		strCMCVersion = "Artemis072";
+		dTEPHEM0 = 41133.;
 		strLGCVersion = "Luminary210";
 		strAEAVersion = "FP8";
 		bInvertLMStageBit = false;
@@ -226,6 +227,7 @@ namespace mission {
 			else if (!_strnicmp(line, "CMCVersion=", 11)) {
 				strncpy(buffer, line + 11, 255);
 				strCMCVersion.assign(buffer);
+				UpdateTEPHEM0();
 			}
 			else if (!_strnicmp(line, "LGCVersion=", 11)) {
 				strncpy(buffer, line + 11, 255);
@@ -267,6 +269,9 @@ namespace mission {
 			else if (!_strnicmp(line, "CrossPointerReversePolarity=", 28)) {
 				strncpy(buffer, line + 28, 255);
 				bCrossPointerReversePolarity = !_strnicmp(buffer, "TRUE", 4);
+			}
+			else if (!_strnicmp(line, "TEPHEM0=", 8)) {
+				sscanf(line + 8, "%lf", &dTEPHEM0);
 			}
 			else if (!_strnicmp(line, "CDRVesselName=", 14)) {
 				strncpy(buffer, line + 14, 255);
@@ -419,6 +424,11 @@ namespace mission {
 		return bCrossPointerReversePolarity;
 	}
 
+	double Mission::GetTEPHEM0() const
+	{
+		return dTEPHEM0;
+	}
+
 	void Mission::ReadCueCardLine(char *line, int vehicle)
 	{
 		char buffer[128];
@@ -482,6 +492,26 @@ namespace mission {
 	void Mission::AddLMCueCard(unsigned location, std::string meshname, VECTOR3 ofs)
 	{
 		AddCueCard(1, location, meshname, ofs);
+	}
+
+	void Mission::UpdateTEPHEM0()
+	{
+		if (strCMCVersion == "Colossus237" || strCMCVersion == "Colossus249" || strCMCVersion == "Manche45R2")
+		{
+			dTEPHEM0 = 40038.;
+		}
+		else if (strCMCVersion == "Comanche055")
+		{
+			dTEPHEM0 = 40403.;
+		}
+		else if (strCMCVersion == "Artemis072NBY71")
+		{
+			dTEPHEM0 = 40768.;
+		}
+		else if (strCMCVersion == "Artemis072")
+		{
+			dTEPHEM0 = 41133.;
+		}
 	}
 
 	const std::string& Mission::GetCDRName() const

--- a/Orbitersdk/samples/ProjectApollo/src_aux/Mission.h
+++ b/Orbitersdk/samples/ProjectApollo/src_aux/Mission.h
@@ -91,6 +91,8 @@ namespace mission
 		int GetLMCWEAVersion() const;
 		//false = Normal polarity (Apollo 14 and earlier), Lateral axis for PGNS and LR input has switched polarity (Apollo 15 and later)
 		bool GetCrossPointerReversePolarity() const;
+		//Get time reference of AGC for CMC clock initialization. The value is usually the MJD of midnight July 1st that preceeds the launch
+		double GetTEPHEM0() const;
 		//Get cue cards
 		bool GetCSMCueCards(unsigned &counter, unsigned &loc, std::string &meshname, VECTOR3 &ofs);
 		//Name of CDR
@@ -115,6 +117,7 @@ namespace mission
 
 		void ReadCueCardLine(char *line, int vehicle);
 
+		void UpdateTEPHEM0();
 
 		std::string strFileName;
 		std::string strMissionName;
@@ -151,6 +154,7 @@ namespace mission
 		bool bCrossPointerReversePolarity;
 		std::vector<CueCardConfig> CSMCueCards;
 		std::vector<CueCardConfig> LMCueCards;
+		double dTEPHEM0;
 
 		void SetDefaultValues();
 	};

--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -208,77 +208,24 @@ void CSMcomputer::Timestep(double simt, double simdt)
 		//
 		if(!PadLoaded) {
 
-			double latitude, longitude, radius, heading, TEPHEM0;
-
-			// init pad load
-			OurVessel->GetEquPos(longitude, latitude, radius);
-			oapiGetHeading(OurVessel->GetHandle(), &heading);
-
-			// set launch pad latitude
-			vagc.Erasable[5][2] = ConvertDecimalToAGCOctal(latitude / TWO_PI, true);
-			vagc.Erasable[5][3] = ConvertDecimalToAGCOctal(latitude / TWO_PI, false);
-
-			if (ProgramName == "Colossus237" || ProgramName == "Colossus249" || ProgramName == "Manche45R2")
-			{
-				// set launch pad longitude
-				if (longitude < 0) { longitude += TWO_PI; }
-				vagc.Erasable[2][0263] = ConvertDecimalToAGCOctal(longitude / TWO_PI, true);
-				vagc.Erasable[2][0264] = ConvertDecimalToAGCOctal(longitude / TWO_PI, false);
-
-				// set launch pad altitude
-				//vagc.Erasable[2][0272] = 01;	// 17.7 nmi
-				vagc.Erasable[2][0272] = 0;
-				vagc.Erasable[2][0273] = (int16_t)(0.5 * OurVessel->GetAltitude());
-
-				TEPHEM0 = 40038.;
-			}
-			else if (ProgramName == "Comanche055")	// Comanche 055
-			{
-				// set launch pad longitude
-				if (longitude < 0) { longitude += TWO_PI; }
-				vagc.Erasable[2][0263] = ConvertDecimalToAGCOctal(longitude / TWO_PI, true);
-				vagc.Erasable[2][0264] = ConvertDecimalToAGCOctal(longitude / TWO_PI, false);
-
-				// set launch pad altitude
-				//vagc.Erasable[2][0272] = 01;	// 17.7 nmi
-				vagc.Erasable[2][0272] = 0;
-				vagc.Erasable[2][0273] = (int16_t)(0.5 * OurVessel->GetAltitude());
-
-				TEPHEM0 = 40403.;
-			}
-			else if (ProgramName == "Artemis072NBY71")	//Artemis 072 for Apollo 14
-			{
-				// set launch pad longitude
-				if (longitude < 0) longitude += TWO_PI;
-				vagc.Erasable[2][0135] = ConvertDecimalToAGCOctal(longitude / TWO_PI, true);
-				vagc.Erasable[2][0136] = ConvertDecimalToAGCOctal(longitude / TWO_PI, false);
-
-				// set launch pad altitude
-				//vagc.Erasable[2][0133] = 01;	// 17.7 nmi
-				vagc.Erasable[2][0133] = 0;
-				vagc.Erasable[2][0134] = (int16_t)(0.5 * OurVessel->GetAltitude());
-
-				TEPHEM0 = 40768.;
-			}
-			else	//Artemis 072
-			{
-				// set launch pad longitude
-				if (longitude < 0) longitude += TWO_PI;
-				vagc.Erasable[2][0135] = ConvertDecimalToAGCOctal(longitude / TWO_PI, true);
-				vagc.Erasable[2][0136] = ConvertDecimalToAGCOctal(longitude / TWO_PI, false);
-
-				// set launch pad altitude
-				//vagc.Erasable[2][0133] = 01;	// 17.7 nmi
-				vagc.Erasable[2][0133] = 0;
-				vagc.Erasable[2][0134] = (int16_t)(0.5 * OurVessel->GetAltitude());
-
-				TEPHEM0 = 41133.;
-			}
+			//Get time reference for TEPHEM
+			double TEPHEM0 = sat->pMission->GetTEPHEM0();
 
 			// Synchronize clock with launch time (TEPHEM)
-			double tephem = vagc.Erasable[AGC_BANK(01710)][AGC_ADDR(01710)] +
-				vagc.Erasable[AGC_BANK(01707)][AGC_ADDR(01707)] * pow((double) 2., (double) 14.) +
-				vagc.Erasable[AGC_BANK(01706)][AGC_ADDR(01706)] * pow((double) 2., (double) 28.);
+			double tephem;
+			if (ProgramName == "Skylark048") //Only Skylark has a different address
+			{
+				tephem = vagc.Erasable[AGC_BANK(01702)][AGC_ADDR(01702)] +
+					vagc.Erasable[AGC_BANK(01701)][AGC_ADDR(01701)] * pow((double) 2., (double) 14.) +
+					vagc.Erasable[AGC_BANK(01700)][AGC_ADDR(01700)] * pow((double) 2., (double) 28.);
+			}
+			else
+			{
+				tephem = vagc.Erasable[AGC_BANK(01710)][AGC_ADDR(01710)] +
+					vagc.Erasable[AGC_BANK(01707)][AGC_ADDR(01707)] * pow((double) 2., (double) 14.) +
+					vagc.Erasable[AGC_BANK(01706)][AGC_ADDR(01706)] * pow((double) 2., (double) 28.);
+			}
+
 			tephem = (tephem / 8640000.) + TEPHEM0;
 			double clock = (oapiGetSimMJD() - tephem) * 8640000. * pow((double) 2., (double)-28.);
 			vagc.Erasable[AGC_BANK(024)][AGC_ADDR(024)] = ConvertDecimalToAGCOctal(clock, true);


### PR DESCRIPTION
Before this update, when the CMC gets first powered up, several things are being loaded into the CMC erasable memory: The launchpad latitude, longitude and altitude and also the initial value of the CMC clock, aligned to whatever launch time reference (TEPHEM) was loaded as part of the padload.

The addresses for the launchpad coordinates are CMC version specific and so is the base time for the time reference (TEPHEM0 in our code). So custom ropes might not get initialized properly. And to be able to support Skylark, which has a variable time reference (midnight July 1st before launch), the clock initialization code needed to be changed as well.

So this pull request changes:

-Launchpad coordinates are no longer loaded in code, but have to be part of the padload, as it was in reality
-The TEPHEM0 variable has been moved to the mission class, where all the normal ropes that NASSP uses have default parameters
-A custom TEPHEM0 can be loaded in the mission file for custom rope and if Skylark is being used. It doesn't have to be done for the nominally supported ropes
-Skylark specific clock initialization code, as TEPHEM has a different address. So this still depends on the rope name, but only Skylark is special

To test this PR any launch scenario could be loaded, after CMC powerup the CMC clock can be checked and after launch the REFSMMAT and state vector (which use the launchpad coordinate) need to be still good. I have checked this for Apollo 7 and 17