### PR TITLE
Fix lunar occultation logic in RTCC station contact generator

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_aux/Mission.h
+++ b/Orbitersdk/samples/ProjectApollo/src_aux/Mission.h
@@ -45,7 +45,7 @@ namespace mission
 		virtual bool LoadMission(const int iMission);
 		virtual bool LoadMission(const std::string& strMission);
 
-		//1 = Block I and pre Apollo 12, 2 = Apollo 12 and later
+		//1 = Block I and pre Apollo 13, 2 = Apollo 13 and later
 		virtual int GetSMJCVersion() const;
 		//false = any other CSM, true = J-type mission CSM (for all systems and panels common to CSM-112 to 114)
 		virtual bool IsJMission() const;
@@ -81,7 +81,7 @@ namespace mission
 		double GetATCA_PRM_Factor() const;
 		//Get matrix with coefficients for calculating the LM center of gravity as a quadratic function of mass
 		MATRIX3 GetLMCGCoefficients() const;
-		//CM to LM power connection version. 0 = connection doesn't work with LM staged, 1 = LM has a CB to bypass circuit to descent stage, 2 = circuit bypassed automatically at stating
+		//CM to LM power connection version. 0 = connection doesn't work with LM staged, 1 = LM has a CB to bypass circuit to descent stage, 2 = circuit bypassed automatically at staging
 		int GetCMtoLMPowerConnectionVersion() const;
 		//Get CG of the empty SM (but including SM RCS) in inches
 		VECTOR3 GetCGOfEmptySM() const;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -4823,7 +4823,7 @@ private:
 	//Generalized Contact Generator
 	void EMGENGEN(EphemerisDataTable2 &ephemeris, ManeuverTimesTable &MANTIMES, const StationTable &stationlist, int body, OrbitStationContactsTable &res, LunarStayTimesTable *LUNSTAY = NULL);
 	//Horizon Crossing Subprogram
-	bool EMXING(EphemerisDataTable2 &ephemeris, ManeuverTimesTable &MANTIMES, const StationData & station, int body, std::vector<StationContact> &acquisitions, LunarStayTimesTable *LUNSTAY);
+	int EMXING(EphemerisDataTable2 &ephemeris, ManeuverTimesTable &MANTIMES, const StationData & station, int body, std::vector<StationContact> &acquisitions, LunarStayTimesTable *LUNSTAY);
 	bool EMXINGLunarOccultation(EphemerisDataTable2 &ephemeris, ManeuverTimesTable &MANTIMES, double gmt, VECTOR3 R_S_equ, double &g_func, LunarStayTimesTable *LUNSTAY);
 	int CapeCrossingRev(int L, double GMT);
 	double CapeCrossingGMT(int L, int rev);


### PR DESCRIPTION
and fix two typos in comments in Mission.h

The horizon crossing subprogram EMXING first generates AOS/LOS times based on coming in to view without taking occultation by the Moon into account. Then, if the trajectory is in lunar orbit, it splits up or limits the acquisition times based on coming into view over the Moon horizon. If these two types of AOS events (Earth rotating or the Moon is in the way) happen very close to each other some logic is skipped that causes the while loop that searches for the precise AOS time to use uninitialized variables.

This PR fixes that bug by initializing the variables and also prevents the logic from getting stuck in the while loop by adding a maximum number of iterations and error conditions, as well as the appropiate error message for the online monitor.

This Apollo 15 scenario doesn't even load because it gets stuck in a while loop with those uninitialized variables. With the fix it should load fine and AOS/LOS are calculated properly (see Next Station Contacts or Predicted Site Acquisition displays).

[Apollo_15_-_Load_Loop.scn.txt](https://github.com/orbiternassp/NASSP/files/12430353/Apollo_15_-_Load_Loop.scn.txt)
