### PR TITLE
Add VHF Ranging to Skylab

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Skylab.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Skylab.vcxproj
@@ -20,6 +20,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src_skylab\skylab.h" />
+    <ClInclude Include="..\..\src_skylab\SkylabConnector.h" />
+    <ClInclude Include="..\..\src_skylab\skylab_telecom.h" />
     <ClInclude Include="..\..\src_sys\connector.h" />
     <ClInclude Include="..\..\src_sys\nasspdefs.h" />
     <ClInclude Include="..\..\src_sys\powersource.h" />
@@ -27,6 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src_skylab\skylab.cpp" />
+    <ClCompile Include="..\..\src_skylab\SkylabConnector.cpp" />
     <ClCompile Include="..\..\src_sys\connector.cpp" />
     <ClCompile Include="..\..\src_sys\powersource.cpp" />
     <ClCompile Include="..\..\src_sys\soundlib.cpp" />

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Skylab.vcxproj
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Skylab.vcxproj
@@ -45,8 +45,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -88,6 +87,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
+    <OutDir>../../../../../Modules/ProjectApollo/</OutDir>
+    <IntDir>.\Debug\Skylab\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
@@ -103,16 +104,28 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;SKYLAB_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <SDLCheck>
+      </SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_USRDLL;LEM_EXPORTS;DIRECTSOUNDENABLED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>false</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>../../src_aux;../../src_sys;../../src_mfd;../../src_lm;../../src_moon;../../src_csm;../../src_launch;../../src_landing;../../src_saturn;../../../../include;../../../../../Sound/OrbiterSound_SDK/VESSELSOUND_SDK/ShuttlePB_project;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <MinimalRebuild>true</MinimalRebuild>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeaderOutputFile>.\Debug\LEM/LEM.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug\Skylab/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug\Skylab/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug\Skylab/</ProgramDataBaseFileName>
+      <BrowseInformation>true</BrowseInformation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
+      <OutputFile>../../../../../Modules/ProjectApollo/Skylab.dll</OutputFile>
+      <AdditionalLibraryDirectories>;../../../../lib/Lua;.\Debug\PanelSDK;../../../../lib;../../../../../Sound/OrbiterSound_SDK/VESSELSOUND_SDK/ShuttlePB_project;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>PanelSDK.lib;orbiter.lib;orbitersdk.lib;opengl32.lib;glu32.lib;lua5.1.lib;User32.lib;Gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Orbitersdk/samples/ProjectApollo/Build/VC2017/Skylab.vcxproj.filters
+++ b/Orbitersdk/samples/ProjectApollo/Build/VC2017/Skylab.vcxproj.filters
@@ -30,6 +30,12 @@
     <ClInclude Include="..\..\src_sys\soundlib.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src_skylab\SkylabConnector.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src_skylab\skylab_telecom.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src_skylab\skylab.cpp">
@@ -42,6 +48,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src_sys\soundlib.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src_skylab\SkylabConnector.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
@@ -1583,22 +1583,24 @@ void VHFAMTransceiver::Timestep()
 	//send RF properties to the connector
 	if (lem && activeAntenna)
 	{
+		VECTOR3 CSMGlobalPosition;
+		lem->GetGlobalPos(CSMGlobalPosition);
 		if (transmitA)
 		{
-			sat->csm_vhfto_lm_vhfconnector.SendRF(freqXCVR_A, xmitPower, activeAntenna->getPolarGain(U_R_LOCAL), 0.0, false); //XCVR A
+			sat->csm_vhfto_lm_vhfconnector.SendRF(freqXCVR_A, xmitPower, activeAntenna->getPolarGain(U_R_LOCAL), 0.0, false, CSMGlobalPosition); //XCVR A
 		}
 		else
 		{
-			sat->csm_vhfto_lm_vhfconnector.SendRF(freqXCVR_B, 0.0, 0.0, 0.0, false);
+			sat->csm_vhfto_lm_vhfconnector.SendRF(freqXCVR_B, 0.0, 0.0, 0.0, false, CSMGlobalPosition);
 		}
 
 		if (transmitB)
 		{
-			sat->csm_vhfto_lm_vhfconnector.SendRF(freqXCVR_B, xmitPower, activeAntenna->getPolarGain(U_R_LOCAL), 0.0, XMITRangeTone); //XCVR B
+			sat->csm_vhfto_lm_vhfconnector.SendRF(freqXCVR_B, xmitPower, activeAntenna->getPolarGain(U_R_LOCAL), 0.0, XMITRangeTone, CSMGlobalPosition); //XCVR B
 		}
 		else
 		{
-			sat->csm_vhfto_lm_vhfconnector.SendRF(freqXCVR_B, 0.0, 0.0, 0.0, false);
+			sat->csm_vhfto_lm_vhfconnector.SendRF(freqXCVR_B, 0.0, 0.0, 0.0, false, CSMGlobalPosition);
 		}
 
 		//sprintf(oapiDebugString(), "VHF ANTENNA GAIN = %lf dBi", activeAntenna->getPolarGain(U_R_LOCAL));
@@ -1718,6 +1720,7 @@ void VHFRangingSystem::TimeStep(double simdt)
 	if (resetswitch->IsUp())
 	{
 		isRanging = true;
+		phaseLockTimer = 0.0;
 	}
 
 	if (isRanging && transceiver->IsVHFRangingConfig())

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.cpp
@@ -1416,7 +1416,7 @@ void VHFAMTransceiver::Init(Saturn *vessel, ThreePosSwitch *vhfASw, ThreePosSwit
 	if (!lem) {
 		VESSEL *lm = sat->agc.GetLM(); // Replace me with multi-lem code
 		if (lm) {
-			lem = (static_cast<LEM*>(lm));
+			lem = lm;
 			sat->csm_vhfto_lm_vhfconnector.ConnectTo(GetVesselConnector(lem, VIRTUAL_CONNECTOR_PORT, VHF_RNG));
 		}
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.h
@@ -584,7 +584,7 @@ protected:
 	VHFAntenna *rightAntenna;
 	VHFAntenna *activeAntenna;
 	Saturn *sat;
-	LEM *lem;
+	VESSEL *lem;
 };
 
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.h
@@ -544,12 +544,14 @@ public:
 	double RCVDpowRCVR_A; //power radiated at rcvr A MEASURED AT THE TRANSMITTER
 	double RCVDgainRCVR_A; //gain of the transmitter senting to rcvr A
 	double RCVDPhaseRCVR_A; //phase of the signal sending to rcvr A
+	VECTOR3 RCVDGlobalPosition_A; //global position of the signal sending ti rcvr A
 	//
 	double RCVDfreqRCVR_B; //Frequency received by rcvr B
 	double RCVDpowRCVR_B; //Power radiated at B MEASURED AT THE TRANSMITTER
 	double RCVDgainRCVR_B; //Gain of the transmitter senting to rcvr B
 	double RCVDPhaseRCVR_B; //Phase of the signal sending to rcvr B
 	bool RCVDRangeTone; // Receiving a ranging tone from the CSM?
+	VECTOR3 RCVDGlobalPosition_B; //global position of the signal sending ti rcvr B
 
 	double RCVDinputPowRCVR_A; //Power received by transcever A in dBm
 	double RCVDinputPowRCVR_B;//Power received by transcever B in dBm

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csm_telecom.h
@@ -586,7 +586,6 @@ protected:
 	VHFAntenna *rightAntenna;
 	VHFAntenna *activeAntenna;
 	Saturn *sat;
-	VESSEL *lem;
 };
 
 
@@ -604,6 +603,7 @@ public:
 	double GetRange() { return range / 185.20; }
 	void RangingReturnSignal(); // ################# DELETE ME #######################
 	void GetRangeCMC();
+	void SetCSMPosForRanging();
 protected:
 
 	bool RangingOffLogic();
@@ -611,14 +611,15 @@ protected:
 	bool dataGood;
 	double internalrange;
 	double range;
+	double newrange;
 	bool isRanging;
 	double phaseLockTimer;
 	int hasLock;
 
 	bool rangeTone;
+	VECTOR3 CSMGlobalPosForRanging;
 
 	Saturn *sat;
-	VESSEL *lem;
 	VHFAMTransceiver *transceiver;
 	CircuitBrakerSwitch *powercb;
 	ToggleSwitch *powerswitch;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csmconnector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csmconnector.cpp
@@ -930,7 +930,7 @@ CSM_VHFto_LM_VHFConnector::~CSM_VHFto_LM_VHFConnector()
 {
 }
 
-void CSM_VHFto_LM_VHFConnector::SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone)
+void CSM_VHFto_LM_VHFConnector::SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone, VECTOR3 Position)
 {
 	ConnectorMessage cm;
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csmconnector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csmconnector.cpp
@@ -957,6 +957,7 @@ bool CSM_VHFto_LM_VHFConnector::ReceiveMessage(Connector * from, ConnectorMessag
 	//in actuality it should be something more like a resonance responce centered around the tuned receiver frequency, but this waaay more simple
 	//and easy to compute every timestep
 
+	//sprintf(oapiDebugString(), "%lf %lf %lf", m.val5.vValue.x, m.val5.vValue.y, m.val5.vValue.z);
 
 	if (m.val1.dValue > pVHFxcvr->freqXCVR_A*0.99f && m.val1.dValue < pVHFxcvr->freqXCVR_A*1.01f && m.messageType == VHF_RNG_SIGNAL_LM)
 	{

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csmconnector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csmconnector.cpp
@@ -957,27 +957,46 @@ bool CSM_VHFto_LM_VHFConnector::ReceiveMessage(Connector * from, ConnectorMessag
 	//in actuality it should be something more like a resonance responce centered around the tuned receiver frequency, but this waaay more simple
 	//and easy to compute every timestep
 
-	if (m.val1.dValue > pVHFxcvr->freqXCVR_A*0.99f && m.val1.dValue < pVHFxcvr->freqXCVR_A*1.01f)
+
+	if (m.val1.dValue > pVHFxcvr->freqXCVR_A*0.99f && m.val1.dValue < pVHFxcvr->freqXCVR_A*1.01f && m.messageType == VHF_RNG_SIGNAL_LM)
 	{
 		//sprintf(oapiDebugString(), "A");
 		pVHFxcvr->RCVDfreqRCVR_A = m.val1.dValue;
 		pVHFxcvr->RCVDpowRCVR_A = m.val2.dValue;
 		pVHFxcvr->RCVDgainRCVR_A = m.val3.dValue;
 		pVHFxcvr->RCVDPhaseRCVR_A = m.val4.dValue;
+		pVHFxcvr->RCVDGlobalPosition_A = m.val5.vValue;
 		pVHFxcvr->RCVDRangeTone = m.val1.bValue;
+		pVHFRngSys->SetCSMPosForRanging();
 		return true;
 	}
-	else if (m.val1.dValue > pVHFxcvr->freqXCVR_B*0.99f && m.val1.dValue < pVHFxcvr->freqXCVR_B*1.01f)
+	else if (m.val1.dValue > pVHFxcvr->freqXCVR_B*0.99f && m.val1.dValue < pVHFxcvr->freqXCVR_B*1.01f && m.messageType == VHF_RNG_SIGNAL_LM)
 	{
-		//sprintf(oapiDebugString(), "B");
 		pVHFxcvr->RCVDfreqRCVR_B = m.val1.dValue;
 		pVHFxcvr->RCVDpowRCVR_B = m.val2.dValue;
 		pVHFxcvr->RCVDgainRCVR_B = m.val3.dValue;
 		pVHFxcvr->RCVDPhaseRCVR_B = m.val4.dValue;
+		pVHFxcvr->RCVDGlobalPosition_B = m.val5.vValue;
 		return true;
 	}
 	else
 	{
+		//Zero Inputs
+		pVHFxcvr->RCVDfreqRCVR_A = 0.0;
+		pVHFxcvr->RCVDpowRCVR_A = 0.0;
+		pVHFxcvr->RCVDgainRCVR_A = 0.0;
+		pVHFxcvr->RCVDPhaseRCVR_A = 0.0;
+
+		pVHFxcvr->RCVDfreqRCVR_B = 0.0;
+		pVHFxcvr->RCVDpowRCVR_B = 0.0;
+		pVHFxcvr->RCVDgainRCVR_B = 0.0;
+		pVHFxcvr->RCVDPhaseRCVR_B = 0.0;
+
+		pVHFxcvr->RCVDinputPowRCVR_A = 0.0;
+		pVHFxcvr->RCVDinputPowRCVR_B = 0.0;
+
+		pVHFxcvr->RCVDGlobalPosition_A = _V(0.0, 0.0, 0.0);
+		pVHFxcvr->RCVDGlobalPosition_B = _V(0.0, 0.0, 0.0);
 		return false;
 	}
 }

--- a/Orbitersdk/samples/ProjectApollo/src_csm/csmconnector.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/csmconnector.h
@@ -133,7 +133,7 @@ public:
 	CSM_VHFto_LM_VHFConnector(Saturn *s, VHFAMTransceiver *VHFxcvr, VHFRangingSystem *vhf_system);
 	~CSM_VHFto_LM_VHFConnector();
 
-	void SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone);
+	void SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone, VECTOR3 Position);
 	bool ReceiveMessage(Connector *from, ConnectorMessage &m);
 protected:
 	VHFRangingSystem *pVHFRngSys;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemconnector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemconnector.cpp
@@ -306,7 +306,8 @@ void LM_VHFtoCSM_VHF_Connector::SendRF(double freq, double XMITpow, double XMITg
 	cm.val2.dValue = XMITpow; //W
 	cm.val3.dValue = XMITgain; //dBi
 	cm.val4.dValue = XMITphase;
-	cm.val1.bValue = RangeTone; 
+	cm.val1.bValue = RangeTone;
+	cm.val5.vValue = Position;
 
 	SendMessage(cm);
 }

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemconnector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemconnector.cpp
@@ -295,7 +295,7 @@ LM_VHFtoCSM_VHF_Connector::~LM_VHFtoCSM_VHF_Connector()
 
 }
 
-void LM_VHFtoCSM_VHF_Connector::SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone)
+void LM_VHFtoCSM_VHF_Connector::SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone, VECTOR3 Position)
 {
 	ConnectorMessage cm;
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemconnector.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemconnector.h
@@ -111,7 +111,7 @@ public:
 	LM_VHFtoCSM_VHF_Connector(LEM *l, LM_VHF *VHFsys);
 	~LM_VHFtoCSM_VHF_Connector();
 
-	void SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone);
+	void SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone, VECTOR3 Position);
 	bool ReceiveMessage(Connector *from, ConnectorMessage &m);
 protected:
 	LM_VHF *pLM_VHFs;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
@@ -316,22 +316,24 @@ void LM_VHF::Timestep(double simt)
 
 	if (lem->lm_vhf_to_csm_csm_connector.connectedTo)
 	{
+		VECTOR3 LEMGlobalPosition;
+		lem->GetGlobalPos(LEMGlobalPosition);
 		if (transmitA)
 		{
-			lem->lm_vhf_to_csm_csm_connector.SendRF(freqXCVR_A, xmitPower, activeAntenna->getPolarGain(U_R_LOCAL), 0.0, (isRanging && !transmitB && RCVDRangeTone && (RCVDinputPowRCVR_B > minimumRCVDPower)));
+			lem->lm_vhf_to_csm_csm_connector.SendRF(freqXCVR_A, xmitPower, activeAntenna->getPolarGain(U_R_LOCAL), 0.0, (isRanging && !transmitB && RCVDRangeTone && (RCVDinputPowRCVR_B > minimumRCVDPower)), LEMGlobalPosition);
 		}
 		else
 		{
-			lem->lm_vhf_to_csm_csm_connector.SendRF(freqXCVR_A, 0.0, 0.0, 0.0, false);
+			lem->lm_vhf_to_csm_csm_connector.SendRF(freqXCVR_A, 0.0, 0.0, 0.0, false, LEMGlobalPosition);
 		}
 
 		if (transmitB)
 		{
-			lem->lm_vhf_to_csm_csm_connector.SendRF(freqXCVR_B, xmitPower, activeAntenna->getPolarGain(U_R_LOCAL), 0.0, false);
+			lem->lm_vhf_to_csm_csm_connector.SendRF(freqXCVR_B, xmitPower, activeAntenna->getPolarGain(U_R_LOCAL), 0.0, false, LEMGlobalPosition);
 		}
 		else
 		{
-			lem->lm_vhf_to_csm_csm_connector.SendRF(freqXCVR_B, 0.0, 0.0, 0.0, false);
+			lem->lm_vhf_to_csm_csm_connector.SendRF(freqXCVR_B, 0.0, 0.0, 0.0, false, LEMGlobalPosition);
 		}
 
 		//sprintf(oapiDebugString(), "VHF ANTENNA GAIN = %lf", activeAntenna->getPolarGain(U_R_LOCAL));

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
@@ -318,6 +318,7 @@ void LM_VHF::Timestep(double simt)
 	{
 		VECTOR3 LEMGlobalPosition;
 		lem->GetGlobalPos(LEMGlobalPosition);
+		//sprintf(oapiDebugString(), "%lf %lf %lf", LEMGlobalPosition.x, LEMGlobalPosition.y, LEMGlobalPosition.z);
 		if (transmitA)
 		{
 			lem->lm_vhf_to_csm_csm_connector.SendRF(freqXCVR_A, xmitPower, activeAntenna->getPolarGain(U_R_LOCAL), 0.0, (isRanging && !transmitB && RCVDRangeTone && (RCVDinputPowRCVR_B > minimumRCVDPower)), LEMGlobalPosition);

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.h
@@ -226,12 +226,14 @@ public:
 	double RCVDpowRCVR_A; //power radiated at rcvr A MEASURED AT THE TRANSMITTER
 	double RCVDgainRCVR_A; //gain of the transmitter senting to rcvr A
 	double RCVDPhaseRCVR_A; //phase of the signal sending to rcvr A
+	VECTOR3 RCVDGlobalPosition_A; //global position of the signal sending ti rcvr A
 	//
 	double RCVDfreqRCVR_B; //Frequency received by rcvr B
 	double RCVDpowRCVR_B; //Power radiated at B MEASURED AT THE TRANSMITTER
 	double RCVDgainRCVR_B; //Gain of the transmitter senting to rcvr B
 	double RCVDPhaseRCVR_B; //Phase of the signal sending to rcvr B
 	bool RCVDRangeTone; // Receiving a ranging tone from the CSM?
+	VECTOR3 RCVDGlobalPosition_B; //global position of the signal sending ti rcvr B
 
 	double RCVDinputPowRCVR_A; //Power received by transcever A in dBm
 	double RCVDinputPowRCVR_B;//Power received by transcever B in dBm

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/SkylabConnector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/SkylabConnector.cpp
@@ -48,7 +48,7 @@ Skylab_VHFtoCSM_VHF_Connector::~Skylab_VHFtoCSM_VHF_Connector()
 
 }
 
-void Skylab_VHFtoCSM_VHF_Connector::SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone)
+void Skylab_VHFtoCSM_VHF_Connector::SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone, VECTOR3 Position)
 {
 	ConnectorMessage cm;
 
@@ -60,42 +60,13 @@ void Skylab_VHFtoCSM_VHF_Connector::SendRF(double freq, double XMITpow, double X
 	cm.val3.dValue = XMITgain; //dBi
 	cm.val4.dValue = XMITphase;
 	cm.val1.bValue = RangeTone;
+	cm.val5.vValue = Position;
 
 	SendMessage(cm);
 }
 
 bool Skylab_VHFtoCSM_VHF_Connector::ReceiveMessage(Connector* from, ConnectorMessage& m)
 {
-	if (!pSkylab_VHFs) //No more segfaults
-	{
-		return false;
-	}
 
-	//this checks that the incoming frequencies from the csm connector are within 1% of the tuned frequencies of the receivers
-	//in actuality it should be something more like a resonance responce centered around the tuned receiver frequency, but this waaay more simple
-	//and easy to compute every timestep
-
-	//if (m.val1.dValue > pSkylab_VHFs->freqXCVR_A * 0.99f && m.val1.dValue < pSkylab_VHFs->freqXCVR_A * 1.01f)
-	//{
-	//	//sprintf(oapiDebugString(), "A");
-	//	pLM_VHFs->RCVDfreqRCVR_A = m.val1.dValue;
-	//	pLM_VHFs->RCVDpowRCVR_A = m.val2.dValue;
-	//	pLM_VHFs->RCVDgainRCVR_A = m.val3.dValue;
-	//	pLM_VHFs->RCVDPhaseRCVR_A = m.val4.dValue;
-	//	return true;
-	//}
-	//else if (m.val1.dValue > pLM_VHFs->freqXCVR_B * 0.99f && m.val1.dValue < pLM_VHFs->freqXCVR_B * 1.01f)
-	//{
-	//	//sprintf(oapiDebugString(), "B");
-	//	pLM_VHFs->RCVDfreqRCVR_B = m.val1.dValue;
-	//	pLM_VHFs->RCVDpowRCVR_B = m.val2.dValue;
-	//	pLM_VHFs->RCVDgainRCVR_B = m.val3.dValue;
-	//	pLM_VHFs->RCVDPhaseRCVR_B = m.val4.dValue;
-	//	pLM_VHFs->RCVDRangeTone = m.val1.bValue;
-	//	return true;
-	//}
-	//else
-	//{
-	//	return false;
-	//}
+	return true;
 }

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/SkylabConnector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/SkylabConnector.cpp
@@ -27,14 +27,13 @@ See http://nassp.sourceforge.net/license/ for more details.
 #include "SkylabConnector.h"
 
 SkylabConnector::SkylabConnector(Skylab* s)
-
 {
 	OurVessel = s;
 }
 
 SkylabConnector::~SkylabConnector()
-
 {
+
 }
 
 
@@ -67,6 +66,6 @@ void Skylab_VHFtoCSM_VHF_Connector::SendRF(double freq, double XMITpow, double X
 
 bool Skylab_VHFtoCSM_VHF_Connector::ReceiveMessage(Connector* from, ConnectorMessage& m)
 {
-
+	//sprintf(oapiDebugString(), "%lf %lf %lf", m.val5.vValue.x, m.val5.vValue.y, m.val5.vValue.z);
 	return true;
 }

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/SkylabConnector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/SkylabConnector.cpp
@@ -1,0 +1,101 @@
+/***************************************************************************
+This file is part of Project Apollo - NASSP
+Copyright 2017
+
+Skylab Connector Classes
+
+Project Apollo is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+Project Apollo is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Project Apollo; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+See http://nassp.sourceforge.net/license/ for more details.
+
+**************************************************************************/
+
+#include "Orbitersdk.h"
+#include "Skylab.h"
+#include "SkylabConnector.h"
+
+SkylabConnector::SkylabConnector(Skylab* s)
+
+{
+	OurVessel = s;
+}
+
+SkylabConnector::~SkylabConnector()
+
+{
+}
+
+
+Skylab_VHFtoCSM_VHF_Connector::Skylab_VHFtoCSM_VHF_Connector(Skylab* s) : SkylabConnector(s)
+{
+	type = VHF_RNG;
+}
+
+Skylab_VHFtoCSM_VHF_Connector::~Skylab_VHFtoCSM_VHF_Connector()
+{
+
+}
+
+void Skylab_VHFtoCSM_VHF_Connector::SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone)
+{
+	ConnectorMessage cm;
+
+	cm.destination = VHF_RNG;
+	cm.messageType = VHF_RNG_SIGNAL_LM;
+
+	cm.val1.dValue = freq; //MHz
+	cm.val2.dValue = XMITpow; //W
+	cm.val3.dValue = XMITgain; //dBi
+	cm.val4.dValue = XMITphase;
+	cm.val1.bValue = RangeTone;
+
+	SendMessage(cm);
+}
+
+bool Skylab_VHFtoCSM_VHF_Connector::ReceiveMessage(Connector* from, ConnectorMessage& m)
+{
+	if (!pSkylab_VHFs) //No more segfaults
+	{
+		return false;
+	}
+
+	//this checks that the incoming frequencies from the csm connector are within 1% of the tuned frequencies of the receivers
+	//in actuality it should be something more like a resonance responce centered around the tuned receiver frequency, but this waaay more simple
+	//and easy to compute every timestep
+
+	//if (m.val1.dValue > pSkylab_VHFs->freqXCVR_A * 0.99f && m.val1.dValue < pSkylab_VHFs->freqXCVR_A * 1.01f)
+	//{
+	//	//sprintf(oapiDebugString(), "A");
+	//	pLM_VHFs->RCVDfreqRCVR_A = m.val1.dValue;
+	//	pLM_VHFs->RCVDpowRCVR_A = m.val2.dValue;
+	//	pLM_VHFs->RCVDgainRCVR_A = m.val3.dValue;
+	//	pLM_VHFs->RCVDPhaseRCVR_A = m.val4.dValue;
+	//	return true;
+	//}
+	//else if (m.val1.dValue > pLM_VHFs->freqXCVR_B * 0.99f && m.val1.dValue < pLM_VHFs->freqXCVR_B * 1.01f)
+	//{
+	//	//sprintf(oapiDebugString(), "B");
+	//	pLM_VHFs->RCVDfreqRCVR_B = m.val1.dValue;
+	//	pLM_VHFs->RCVDpowRCVR_B = m.val2.dValue;
+	//	pLM_VHFs->RCVDgainRCVR_B = m.val3.dValue;
+	//	pLM_VHFs->RCVDPhaseRCVR_B = m.val4.dValue;
+	//	pLM_VHFs->RCVDRangeTone = m.val1.bValue;
+	//	return true;
+	//}
+	//else
+	//{
+	//	return false;
+	//}
+}

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/SkylabConnector.h
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/SkylabConnector.h
@@ -49,7 +49,7 @@ public:
 	Skylab_VHFtoCSM_VHF_Connector(Skylab* s);
 	~Skylab_VHFtoCSM_VHF_Connector();
 
-	void SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone);
+	void SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone, VECTOR3 Position);
 	bool ReceiveMessage(Connector* from, ConnectorMessage& m);
 protected:
 	Skylab* pSkylab_VHFs;

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/SkylabConnector.h
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/SkylabConnector.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+This file is part of Project Apollo - NASSP
+Copyright 2017
+
+LM connector classes (Header)
+
+Project Apollo is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+Project Apollo is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Project Apollo; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+See http://nassp.sourceforge.net/license/ for more details.
+
+**************************************************************************/
+
+#if !defined(_SKYLAB_CONNECTOR_H)
+#define _SKYLAB_CONNECTOR_H
+
+#include "Orbitersdk.h"
+#include "connector.h"
+
+
+class Skylab;
+
+class SkylabConnector : public Connector
+{
+public:
+	SkylabConnector(Skylab* s);
+	~SkylabConnector();
+
+	void SetSkylab(Skylab* skylab) { OurVessel = skylab; };
+
+protected:
+	Skylab* OurVessel;
+};
+
+class Skylab_VHFtoCSM_VHF_Connector : public SkylabConnector
+{
+public:
+	Skylab_VHFtoCSM_VHF_Connector(Skylab* s);
+	~Skylab_VHFtoCSM_VHF_Connector();
+
+	void SendRF(double freq, double XMITpow, double XMITgain, double XMITphase, bool RangeTone);
+	bool ReceiveMessage(Connector* from, ConnectorMessage& m);
+protected:
+	Skylab* pSkylab_VHFs;
+};
+
+#endif

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.cpp
@@ -25,14 +25,13 @@
 #include "skylab.h"
 
 
-Skylab::Skylab(OBJHANDLE hObj, int fmodel): ProjectApolloConnectorVessel(hObj, fmodel)
+Skylab::Skylab(OBJHANDLE hObj, int fmodel): ProjectApolloConnectorVessel(hObj, fmodel),
+skylab_vhf2csm_vhf_connector(this)
 {
-	skylab_vhf2csm_vhf_connector = new Skylab_VHFtoCSM_VHF_Connector(nullptr);
-	skylab_vhf2csm_vhf_connector->ConnectTo(nullptr);
+	skylab_vhf2csm_vhf_connector.ConnectTo(nullptr);
 }
 
 Skylab::~Skylab() {
-	delete skylab_vhf2csm_vhf_connector;
 }
 
 void Skylab::InitSkylab() {
@@ -45,7 +44,7 @@ void Skylab::InitSkylab() {
 	SetMeshVisibilityMode(meshidx, MESHVIS_ALWAYS);
 	//*****************************************************
 
-	RegisterConnector(VIRTUAL_CONNECTOR_PORT, skylab_vhf2csm_vhf_connector);
+	RegisterConnector(VIRTUAL_CONNECTOR_PORT, &skylab_vhf2csm_vhf_connector);
 }
 
 void Skylab::clbkPostCreation() {
@@ -55,40 +54,18 @@ void Skylab::clbkPostCreation() {
 
 void Skylab::clbkPreStep(double simt, double simdt, double mjd)
 {
-	if (skylab_vhf2csm_vhf_connector->connectedTo) {
+	if (skylab_vhf2csm_vhf_connector.connectedTo) {
 
 		VECTOR3 OurGlobalPosition;
 		this->GetGlobalPos(OurGlobalPosition);
 
-		skylab_vhf2csm_vhf_connector->SendRF(296.8E6, 5, 10, 0, true, OurGlobalPosition);
-		/*sprintf(oapiDebugString(), "%lf", oapiGetSimMJD());*/
+		skylab_vhf2csm_vhf_connector.SendRF(296.8E6, 5, 10, 0, true, OurGlobalPosition);
+		sprintf(oapiDebugString(), "%lf", oapiGetSimMJD());
 
-		
 	}
 	else
 	{
-		OBJHANDLE objToConnect = oapiGetVesselByName("AS-206");
-		VESSEL* vesselToConnect = oapiGetVesselInterface(objToConnect);
-
-		skylab_vhf2csm_vhf_connector->ConnectTo(GetVesselConnector(vesselToConnect, VIRTUAL_CONNECTOR_PORT, VHF_RNG));
-
-		/*int vesselsCount = oapiGetVesselCount();
-		for (int ii = 0; ii < vesselsCount; ++ii) {
-			OBJHANDLE objToConnect = oapiGetVesselByIndex(ii);
-			VESSEL* vesselToConnect = oapiGetVesselInterface(objToConnect);
-
-			ProjectApolloConnectorVessel* pv = nullptr;
-
-			if (vesselToConnect->Version() > 2) {
-				pv = dynamic_cast<ProjectApolloConnectorVessel*>((VESSEL4*)vesselToConnect);
-			}
-			sprintf(oapiDebugString(), "%d", ii);
-
-			if (pv) {
-				if (skylab_vhf2csm_vhf_connector->ConnectTo(GetVesselConnector(vesselToConnect, VIRTUAL_CONNECTOR_PORT, VHF_RNG))) { break; };
-			}
-
-		}*/
+		skylab_vhf2csm_vhf_connector.ConnectTo(skylab_vhf2csm_vhf_connector.GetConnectorFromList(VHF_RNG));
 	}
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.cpp
@@ -54,6 +54,7 @@ void Skylab::clbkPostCreation() {
 
 void Skylab::clbkPreStep(double simt, double simdt, double mjd)
 {
+	skylab_vhf2csm_vhf_connector->SendRF(296.8E6, 5, 1000, 0, true);
 }
 
 void Skylab::clbkSetClassCaps(FILEHANDLE cfg)

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.cpp
@@ -28,6 +28,7 @@
 Skylab::Skylab(OBJHANDLE hObj, int fmodel): ProjectApolloConnectorVessel(hObj, fmodel)
 {
 	skylab_vhf2csm_vhf_connector = new Skylab_VHFtoCSM_VHF_Connector(nullptr);
+	skylab_vhf2csm_vhf_connector->ConnectTo(nullptr);
 }
 
 Skylab::~Skylab() {
@@ -37,7 +38,7 @@ Skylab::~Skylab() {
 void Skylab::InitSkylab() {
 
 	//load meshes (turn me into a function soon 8/28/2023)
-	SkylabMesh = oapiLoadMeshGlobal("ProjectApollo/sat5skylab");
+	SkylabMesh = oapiLoadMeshGlobal("Skylab1973/Skylab I");
 	UINT meshidx;
 	VECTOR3 mesh_dir = _V(0, 0, .93); //fix mesh scaling and geometry
 	meshidx = AddMesh(SkylabMesh, &mesh_dir);
@@ -54,7 +55,41 @@ void Skylab::clbkPostCreation() {
 
 void Skylab::clbkPreStep(double simt, double simdt, double mjd)
 {
-	skylab_vhf2csm_vhf_connector->SendRF(296.8E6, 5, 1000, 0, true);
+	if (skylab_vhf2csm_vhf_connector->connectedTo) {
+
+		VECTOR3 OurGlobalPosition;
+		this->GetGlobalPos(OurGlobalPosition);
+
+		skylab_vhf2csm_vhf_connector->SendRF(296.8E6, 5, 10, 0, true, OurGlobalPosition);
+		/*sprintf(oapiDebugString(), "%lf", oapiGetSimMJD());*/
+
+		
+	}
+	else
+	{
+		OBJHANDLE objToConnect = oapiGetVesselByName("AS-206");
+		VESSEL* vesselToConnect = oapiGetVesselInterface(objToConnect);
+
+		skylab_vhf2csm_vhf_connector->ConnectTo(GetVesselConnector(vesselToConnect, VIRTUAL_CONNECTOR_PORT, VHF_RNG));
+
+		/*int vesselsCount = oapiGetVesselCount();
+		for (int ii = 0; ii < vesselsCount; ++ii) {
+			OBJHANDLE objToConnect = oapiGetVesselByIndex(ii);
+			VESSEL* vesselToConnect = oapiGetVesselInterface(objToConnect);
+
+			ProjectApolloConnectorVessel* pv = nullptr;
+
+			if (vesselToConnect->Version() > 2) {
+				pv = dynamic_cast<ProjectApolloConnectorVessel*>((VESSEL4*)vesselToConnect);
+			}
+			sprintf(oapiDebugString(), "%d", ii);
+
+			if (pv) {
+				if (skylab_vhf2csm_vhf_connector->ConnectTo(GetVesselConnector(vesselToConnect, VIRTUAL_CONNECTOR_PORT, VHF_RNG))) { break; };
+			}
+
+		}*/
+	}
 }
 
 void Skylab::clbkSetClassCaps(FILEHANDLE cfg)

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.cpp
@@ -27,19 +27,24 @@
 
 Skylab::Skylab(OBJHANDLE hObj, int fmodel): ProjectApolloConnectorVessel(hObj, fmodel)
 {
-	
+	skylab_vhf2csm_vhf_connector = new Skylab_VHFtoCSM_VHF_Connector(nullptr);
 }
 
 Skylab::~Skylab() {
-
+	delete skylab_vhf2csm_vhf_connector;
 }
 
 void Skylab::InitSkylab() {
+
+	//load meshes (turn me into a function soon 8/28/2023)
 	SkylabMesh = oapiLoadMeshGlobal("ProjectApollo/sat5skylab");
 	UINT meshidx;
 	VECTOR3 mesh_dir = _V(0, 0, .93); //fix mesh scaling and geometry
 	meshidx = AddMesh(SkylabMesh, &mesh_dir);
 	SetMeshVisibilityMode(meshidx, MESHVIS_ALWAYS);
+	//*****************************************************
+
+	RegisterConnector(VIRTUAL_CONNECTOR_PORT, skylab_vhf2csm_vhf_connector);
 }
 
 void Skylab::clbkPostCreation() {

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.h
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.h
@@ -44,7 +44,7 @@ public:
 	void clbkSaveState(FILEHANDLE scn);
 	void clbkLoadState(FILEHANDLE scn);
 private:
-	Skylab_VHFtoCSM_VHF_Connector *skylab_vhf2csm_vhf_connector;
+	Skylab_VHFtoCSM_VHF_Connector skylab_vhf2csm_vhf_connector;
 	MESHHANDLE SkylabMesh;
 };
 

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.h
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.h
@@ -29,9 +29,8 @@
 #include "PanelSDK/PanelSDK.h"
 #include "powersource.h"
 #include "soundlib.h"
-#include "connector.h"
+#include "SkylabConnector.h"
 #include "nasspdefs.h"
-
 
 
 class Skylab: public ProjectApolloConnectorVessel{
@@ -45,6 +44,7 @@ public:
 	void clbkSaveState(FILEHANDLE scn);
 	void clbkLoadState(FILEHANDLE scn);
 private:
+	Skylab_VHFtoCSM_VHF_Connector *skylab_vhf2csm_vhf_connector;
 	MESHHANDLE SkylabMesh;
 };
 

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/skylab_telecom.h
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/skylab_telecom.h
@@ -1,0 +1,28 @@
+/***************************************************************************
+  This file is part of Project Apollo - NASSP
+  Copyright 2004-2005
+
+  LM Telecommunications Implementation
+
+  Project Apollo is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  Project Apollo is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Project Apollo; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  See http://nassp.sourceforge.net/license/ for more details.
+
+  **************************************************************************/
+
+#if !defined(_SKYLAB_TELECOM_H)
+#define _SKYLAB_TELECOM_H
+
+#endif

--- a/Orbitersdk/samples/ProjectApollo/src_sys/connector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/connector.cpp
@@ -36,26 +36,35 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <vector>
+
+std::vector<Connector*> Connector::AllConnectorList;
 
 Connector::Connector()
-
 {
 	type = NO_CONNECTION;
-	connectedTo = 0;
+	connectedTo = nullptr;
+
+	// give the connector an ID and push a pointer onto the static list of connector pointers
+	AllConnectorList.push_back(this);
+	Connector_ID = AllConnectorList.size() - 1;
 }
 
 Connector::~Connector()
-
 {
 	//
 	// We have to be sure to disconnect before deletion so the other end doesn't try to send
 	// us any more data.
 	//
 	Disconnect();
+
+	// delete us from the list of all connectors
+	// note that this doesn't change the size of the list.
+	// When connectors are deleted they will just fail: if(AllConnectorList(ID that was deleted))
+	AllConnectorList[Connector_ID] = nullptr;
 }
 
 void Connector::Disconnect()
-
 {
 	if (connectedTo)
 	{
@@ -70,6 +79,16 @@ void Connector::Disconnected()
 	//
 	// Do nothing by default.
 	//
+}
+
+Connector* Connector::GetConnectorFromList(ConnectorType t)
+{
+	for (auto connectorIter : AllConnectorList) {
+		if (connectorIter->type == t && connectorIter->Connector_ID != this->Connector_ID) {
+			return connectorIter;
+		}
+	}
+	return nullptr;
 }
 
 bool Connector::ConnectTo(Connector *other)

--- a/Orbitersdk/samples/ProjectApollo/src_sys/connector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/connector.cpp
@@ -48,6 +48,9 @@ Connector::Connector()
 	// give the connector an ID and push a pointer onto the static list of connector pointers
 	AllConnectorList.push_back(this);
 	Connector_ID = AllConnectorList.size() - 1;
+	char buff[255];
+	sprintf(buff, "Connector Created %d %d\n", Connector_ID, type);
+	oapiWriteLog(buff);
 }
 
 Connector::~Connector()

--- a/Orbitersdk/samples/ProjectApollo/src_sys/connector.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/connector.h
@@ -45,6 +45,7 @@ enum ConnectorType
 	SII_SIC_COMMAND,			///< Docking connector between S-II and S-IC
 	RADAR_RF_SIGNAL,			///< Radar connector betwen LM rendezvous radar amd CSM rendezvous radar transponder
 	VHF_RNG,
+	VHF_RNG_RTTA
 };
 
 #define VIRTUAL_CONNECTOR_PORT	(0xffff)		///< Port ID for 'virtual' connectors which don't physically exist.
@@ -100,6 +101,11 @@ struct ConnectorMessage
 	/// \brief Message value 4.
 	///
 	ConnectorMessageValue val4;
+
+	///
+	/// \brief Message value 5.
+	///
+	ConnectorMessageValue val5;
 };
 
 ///

--- a/Orbitersdk/samples/ProjectApollo/src_sys/connector.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/connector.h
@@ -22,8 +22,10 @@
 
   **************************************************************************/
 
+
 #if !defined(_PA_CONNECTOR_H)
 #define _PA_CONNECTOR_H
+
 
 ///
 /// \ingroup Connectors
@@ -137,6 +139,11 @@ public:
 	void SetType(ConnectorType t) { type = t; };
 
 	///
+	/// \brief Return the first instance in the global connector list of another connector that is not this connector.
+	/// \param t Connector type.
+	///
+	Connector* GetConnectorFromList(ConnectorType t);
+
 	/// \brief Connect to another connector.
 	/// \param other Other end of the connection.
 	/// \return True if the connector is the correct type and we connected.
@@ -188,6 +195,17 @@ protected:
 	/// \brief Type of connection.
 	///
 	ConnectorType type;
+
+	///
+	/// \brief A vector of all connectors.
+	///
+
+	static std::vector<Connector*> AllConnectorList;
+
+	///
+	/// \brief The ID of this connector.
+	///
+	unsigned int Connector_ID;
 };
 
 ///


### PR DESCRIPTION
This will also clean up the CSM code a bit, and add functionality for connectors to look for each other independently of vessel-pointers (no more isLem(), etc).