### PR TITLE
LM tape recorder talkback working in the VC

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
@@ -1163,7 +1163,7 @@ void LEM::RegisterActiveAreas()
 		oapiVCSetAreaClickmode_Spherical(AID_VC_TW_P12_01 + i, P12_TW_POS[i] + ofs, 0.02);
 	}
 
-	//oapiVCRegisterArea(AID_VC_RECORDER_TALKBACK, _R(806, 1460, 829, 1483), PANEL_REDRAW_ALWAYS, PANEL_MOUSE_IGNORE, PANEL_MAP_BACKGROUND, MainPanelTex2);
+	oapiVCRegisterArea(AID_VC_RECORDER_TALKBACK, _R(601*TexMul, 1435*TexMul, 829*TexMul, 1483*TexMul), PANEL_REDRAW_ALWAYS, PANEL_MOUSE_IGNORE, PANEL_MAP_BACKGROUND, MainPanelTex2);
 
 	// Panel 14
 
@@ -1396,7 +1396,7 @@ void LEM::RegisterActiveAreas()
 	EDDesOxidVentTB.InitVC(srf[SRF_INDICATORVC]);
 	EDLGTB.InitVC(srf[SRF_INDICATORVC]);
 
-	//TapeRecorderTB.InitVC(srf[SRF_INDICATORVC]);
+	TapeRecorderTB.InitVC(srf[SRF_INDICATORVC]);
 
 	DSCBattery1TB.InitVC(srf[SRF_INDICATORVC]);
 	DSCBattery2TB.InitVC(srf[SRF_INDICATORVC]);
@@ -1826,10 +1826,6 @@ bool LEM::clbkVCRedrawEvent(int id, int event, SURFHANDLE surf)
 	case AID_VC_START_BUTTON_RED:
 		ManualEngineStart.DoDrawSwitchVC(surf, srf[SRF_ENGSTARTSTOP_VC], TexMul);
 		return true;
-
-	/*case AID_VC_RECORDER_TALKBACK:
-		TapeRecorderTB.DrawSwitchVC(surf, srf[SRF_INDICATORVC]);
-		return true;*/
 	}
 
 	return MainPanelVC.VCRedrawEvent(id, event, surf);
@@ -2790,7 +2786,7 @@ void LEM::DefineVCAnimations()
 	Panel12SignalStrengthMeter.SetReference(P12_NEEDLE_POS[2], P12_ROT_AXIS);
 	Panel12SignalStrengthMeter.DefineMeshGroup(VC_GRP_Needle_P12_03);
 
-	//MainPanelVC.AddSwitch(&TapeRecorderTB, AID_VC_RECORDER_TALKBACK);
+	MainPanelVC.AddSwitch(&TapeRecorderTB, AID_VC_RECORDER_TALKBACK);
 
 	//Panel 14
 


### PR DESCRIPTION
The talkback is voice activated, so in NASSP it would always stay barberpole. The best way to test this PR is to temporarily make the function LM_DSEA::LMPVoiceXmit() in lm_telecom.cpp always return true.