### PR TITLE
Use oapiGetVesselByName instead of oapiGetObjectByName for vessels

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_D.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_D.cpp
@@ -63,7 +63,7 @@ void MCC::MissionSequence_D()
 				{
 					VESSEL *v;
 					OBJHANDLE hLV;
-					hLV = oapiGetObjectByName(LVName);
+					hLV = oapiGetVesselByName(LVName);
 					if (hLV != NULL)
 					{
 						v = oapiGetVesselInterface(hLV);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_F.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_F.cpp
@@ -111,7 +111,7 @@ void MCC::MissionSequence_F()
 			{
 				VESSEL *v;
 				OBJHANDLE hLV;
-				hLV = oapiGetObjectByName(LVName);
+				hLV = oapiGetVesselByName(LVName);
 				if (hLV != NULL)
 				{
 					v = oapiGetVesselInterface(hLV);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_G.cpp
@@ -103,7 +103,7 @@ void MCC::MissionSequence_G()
 			{
 				VESSEL *v;
 				OBJHANDLE hLV;
-				hLV = oapiGetObjectByName(LVName);
+				hLV = oapiGetVesselByName(LVName);
 				if (hLV != NULL)
 				{
 					v = oapiGetVesselInterface(hLV);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_H1.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_H1.cpp
@@ -100,7 +100,7 @@ void MCC::MissionSequence_H1()
 			{
 				VESSEL *v;
 				OBJHANDLE hLV;
-				hLV = oapiGetObjectByName(LVName);
+				hLV = oapiGetVesselByName(LVName);
 				if (hLV != NULL)
 				{
 					v = oapiGetVesselInterface(hLV);
@@ -148,7 +148,7 @@ void MCC::MissionSequence_H1()
 			{
 				VESSEL *v;
 				OBJHANDLE hLV;
-				hLV = oapiGetObjectByName(LVName);
+				hLV = oapiGetVesselByName(LVName);
 				if (hLV != NULL)
 				{
 					v = oapiGetVesselInterface(hLV);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
@@ -4454,7 +4454,7 @@ void MCC::SetCSM(char *csmname)
 
 	strncat(CSMName, csmname, 64);
 
-	hVessel = oapiGetObjectByName(csmname);
+	hVessel = oapiGetVesselByName(csmname);
 	if (hVessel != NULL)
 	{
 		v = oapiGetVesselInterface(hVessel);
@@ -4472,7 +4472,7 @@ void MCC::SetLM(char *lemname)
 
 	strncat(LEMName, lemname, 64);
 
-	hVessel = oapiGetObjectByName(lemname);
+	hVessel = oapiGetVesselByName(lemname);
 	if (hVessel != NULL)
 	{
 		v = oapiGetVesselInterface(hVessel);
@@ -4491,7 +4491,7 @@ void MCC::SetLV(char *lvname)
 
 	strncat(LVName, lvname, 64);
 
-	hVessel = oapiGetObjectByName(lvname);
+	hVessel = oapiGetVesselByName(lvname);
 	if (hVessel != NULL)
 	{
 		v = oapiGetVesselInterface(hVessel);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -213,7 +213,7 @@ void ApolloRTCCMFD::ReadStatus(FILEHANDLE scn)
 		if (istarget)
 		{
 			OBJHANDLE obj;
-			obj = oapiGetObjectByName(Buffer2);
+			obj = oapiGetVesselByName(Buffer2);
 			if (obj)
 			{
 				G->target = oapiGetVesselInterface(obj);

--- a/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_skylab/skylab.cpp
@@ -130,7 +130,7 @@ void Skylab::clbkLoadStateEx(FILEHANDLE scn, void *vstatus)
 			char temp[64];
 			strncpy(temp, line + 6, 64);
 
-			OBJHANDLE hVessel = oapiGetObjectByName(temp);
+			OBJHANDLE hVessel = oapiGetVesselByName(temp);
 			if (hVessel != NULL) csm = oapiGetVesselInterface(hVessel);
 		}
 		else if (!strnicmp(line, ATMDC_START_STRING, sizeof(ATMDC_START_STRING)))


### PR DESCRIPTION
Prevents a body (e.g. Triton) to be found instead of a vessel with the same name.