### PR TITLE
Checklist MFD Improvements

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_mfd/MFDconnector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/MFDconnector.cpp
@@ -299,6 +299,20 @@ bool MFDConnector::completeChecklistItem(ChecklistItem* in)
 
 	return false;
 }
+bool MFDConnector::skipToChecklistItem(ChecklistItem* in) {
+	ConnectorMessage cm;
+
+	cm.destination = type;
+	cm.messageType = PanelConnector::MFD_PANEL_SKIP_TO_CHECKLIST_ITEM;
+	cm.val1.pValue = in;
+
+	if (SendMessage(cm))
+	{
+		return cm.val2.bValue;
+	}
+
+	return false;
+}
 char *MFDConnector::checklistName()
 {
 	ConnectorMessage cm;

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/MFDconnector.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/MFDconnector.cpp
@@ -299,16 +299,28 @@ bool MFDConnector::completeChecklistItem(ChecklistItem* in)
 
 	return false;
 }
-bool MFDConnector::skipToChecklistItem(ChecklistItem* in) {
+bool MFDConnector::gotoChecklistItem(ChecklistItem* in) {
 	ConnectorMessage cm;
 
 	cm.destination = type;
-	cm.messageType = PanelConnector::MFD_PANEL_SKIP_TO_CHECKLIST_ITEM;
+	cm.messageType = PanelConnector::MFD_PANEL_GOTO_CHECKLIST_ITEM;
 	cm.val1.pValue = in;
 
 	if (SendMessage(cm))
 	{
 		return cm.val2.bValue;
+	}
+
+	return false;
+}
+bool MFDConnector::undoChecklistItem() {
+	ConnectorMessage cm;
+
+	cm.destination = type;
+	cm.messageType = PanelConnector::MFD_PANEL_UNDO_CHECKLIST_ITEM;
+
+	if (SendMessage(cm)) {
+		return cm.val1.bValue;
 	}
 
 	return false;

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/MFDconnector.h
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/MFDconnector.h
@@ -132,6 +132,13 @@ public:
 	bool completeChecklistItem(ChecklistItem* in);
 
 	///
+	/// Skip to an item in a checklist.
+	/// 
+	/// \param in ChecklistItem that is skipped to.
+	/// \return true if checklist successfully skipped.  False otherwise.
+	bool skipToChecklistItem(ChecklistItem* in);
+
+	///
 	/// Get the autoComplete status.
 	///
 	/// \return autoComplete status.

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/MFDconnector.h
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/MFDconnector.h
@@ -132,11 +132,17 @@ public:
 	bool completeChecklistItem(ChecklistItem* in);
 
 	///
-	/// Skip to an item in a checklist.
+	/// Go to an item in a checklist.
 	/// 
 	/// \param in ChecklistItem that is skipped to.
-	/// \return true if checklist successfully skipped.  False otherwise.
-	bool skipToChecklistItem(ChecklistItem* in);
+	/// \return true if checklist successfully skipped. False otherwise.
+	bool gotoChecklistItem(ChecklistItem* in);
+
+	///
+	/// Undo the last completed item in a checklist.
+	/// 
+	/// \return true if item was successfully undone. False otherwise.
+	bool undoChecklistItem();
 
 	///
 	/// Get the autoComplete status.

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
@@ -154,7 +154,7 @@ ProjectApolloChecklistMFD::~ProjectApolloChecklistMFD ()
 char *ProjectApolloChecklistMFD::ButtonLabel (int bt)
 {
 	// 2nd was "MET", disabled for now, MET is shown by default
-	static char *labelCHKLST[12] = {"NAV","","INFO","EXEC","FLSH","AUTO","PgUP","UP","","GOTO","DN","PgDN"};
+	static char *labelCHKLST[12] = {"NAV","","INFO","EXEC","FLSH","AUTO","PgUP","UP","BCK","GOTO","DN","PgDN"};
 	static char *labelCHKLSTActiveItem[12] = {"NAV","UNDO","INFO","EXEC","FLSH","AUTO","PgUP","UP","PRO","FAIL","DN","PgDN"};
 	static char *labelCHKLSTNAV[12] = {"BCK","","INFO","EXEC","FLSH","AUTO","PgUP","UP","SEL","REV","DN","PgDN"};
 	static char *labelCHKLSTREV[12] = {"NAV","","INFO","","","AUTO","PgUP","UP","","","DN","PgDN"};
@@ -191,7 +191,7 @@ int ProjectApolloChecklistMFD::ButtonMenu (const MFDBUTTONMENU **menu) const
 		{"Toggle AutoComplete",0,'A'},
 		{"Scroll Up","One Page",'<'},
 		{"Scroll Up","One Line",'U'},
-		{0,0,0},
+		{"Back To", "Active Item", 'B'},
 		{"Go To","Highlighted Step",'R'},
 		{"Scroll Down","One Line",'D'},
 		{"Scroll Down","One Page",'>'}
@@ -286,7 +286,7 @@ bool ProjectApolloChecklistMFD::ConsumeButton (int bt, int event)
 {
 	if (!(event & PANEL_MOUSE_LBDOWN)) return false;
 
-	static const DWORD btkeyCHKLST[12] = { OAPI_KEY_C,0,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_A,OAPI_KEY_PRIOR,OAPI_KEY_U,0,OAPI_KEY_R,OAPI_KEY_D,OAPI_KEY_NEXT };
+	static const DWORD btkeyCHKLST[12] = { OAPI_KEY_C,0,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_A,OAPI_KEY_PRIOR,OAPI_KEY_U,OAPI_KEY_B,OAPI_KEY_R,OAPI_KEY_D,OAPI_KEY_NEXT };
 	static const DWORD btkeyCHKLSTActiveItem[12] = { OAPI_KEY_C,OAPI_KEY_B,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_A,OAPI_KEY_PRIOR,OAPI_KEY_U,OAPI_KEY_S,OAPI_KEY_F,OAPI_KEY_D,OAPI_KEY_NEXT};
 	static const DWORD btkeyCHKLSTNAV[12] = { OAPI_KEY_C,OAPI_KEY_M,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_A,OAPI_KEY_PRIOR,OAPI_KEY_U,OAPI_KEY_S,OAPI_KEY_R,OAPI_KEY_D,OAPI_KEY_NEXT};
 	static const DWORD btkeyCHKLSTREV[12] = { OAPI_KEY_C,OAPI_KEY_M,OAPI_KEY_N,0,0,OAPI_KEY_A,OAPI_KEY_PRIOR,OAPI_KEY_U,0,0,OAPI_KEY_D,OAPI_KEY_NEXT};
@@ -412,18 +412,26 @@ bool ProjectApolloChecklistMFD::ConsumeKeyBuffered (DWORD key)
 			InvalidateButtons();
 			return true;
 		}
-		if (key == OAPI_KEY_B) {
+		if (key == OAPI_KEY_B && CurrentStep == 0) {
 			// Ensure we have a current item
 			if (conn.GetChecklistItem(-1, 0)) {
 				conn.undoChecklistItem();
 				// Let's reset our cursor, just so the user knows we actually did something.
 				CurrentStep = 0;
 			}
+			
+			InvalidateDisplay();
+			InvalidateButtons();
+			return true;
+		}
+		if (key == OAPI_KEY_B && CurrentStep != 0) {
+			CurrentStep = 0;
 
 			InvalidateDisplay();
 			InvalidateButtons();
 			return true;
 		}
+		
 		if (key == OAPI_KEY_D)
 		{
 			CurrentStep++;

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloChecklistMFD.cpp
@@ -154,8 +154,8 @@ ProjectApolloChecklistMFD::~ProjectApolloChecklistMFD ()
 char *ProjectApolloChecklistMFD::ButtonLabel (int bt)
 {
 	// 2nd was "MET", disabled for now, MET is shown by default
-	static char *labelCHKLST[12] = {"NAV","","INFO","EXEC","FLSH","AUTO","PgUP","UP","","SKIP","DN","PgDN"};
-	static char *labelCHKLSTActiveItem[12] = {"NAV","","INFO","EXEC","FLSH","AUTO","PgUP","UP","PRO","FAIL","DN","PgDN"};
+	static char *labelCHKLST[12] = {"NAV","","INFO","EXEC","FLSH","AUTO","PgUP","UP","","GOTO","DN","PgDN"};
+	static char *labelCHKLSTActiveItem[12] = {"NAV","UNDO","INFO","EXEC","FLSH","AUTO","PgUP","UP","PRO","FAIL","DN","PgDN"};
 	static char *labelCHKLSTNAV[12] = {"BCK","","INFO","EXEC","FLSH","AUTO","PgUP","UP","SEL","REV","DN","PgDN"};
 	static char *labelCHKLSTREV[12] = {"NAV","","INFO","","","AUTO","PgUP","UP","","","DN","PgDN"};
 	static char *labelCHKLSTINFO[12] = {"BCK","","","","","","","","","","",""};
@@ -192,14 +192,14 @@ int ProjectApolloChecklistMFD::ButtonMenu (const MFDBUTTONMENU **menu) const
 		{"Scroll Up","One Page",'<'},
 		{"Scroll Up","One Line",'U'},
 		{0,0,0},
-		{"Skip To","Highlighted Step",'R'},
+		{"Go To","Highlighted Step",'R'},
 		{"Scroll Down","One Line",'D'},
 		{"Scroll Down","One Page",'>'}
 	};
 	static const MFDBUTTONMENU mnuCHKLSTActiveItem[12] = {
 		{"Go to","Checklist Navigation",'N'},
 		// {"Toggle Display","Mission Elapsed Time",'M'},
-		{0,0,0},
+		{"Undo","Last Step",'B'},
 		{"More Information","About This Step",'N'},
 		{"Toggle Automatic", "Checklist execution", 'E'},
 		{"Toggle Flashing",0,'L'},
@@ -286,8 +286,8 @@ bool ProjectApolloChecklistMFD::ConsumeButton (int bt, int event)
 {
 	if (!(event & PANEL_MOUSE_LBDOWN)) return false;
 
-	static const DWORD btkeyCHKLST[12] = { OAPI_KEY_C,OAPI_KEY_M,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_A,OAPI_KEY_PRIOR,OAPI_KEY_U,0,OAPI_KEY_R,OAPI_KEY_D,OAPI_KEY_NEXT };
-	static const DWORD btkeyCHKLSTActiveItem[12] = { OAPI_KEY_C,OAPI_KEY_M,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_A,OAPI_KEY_PRIOR,OAPI_KEY_U,OAPI_KEY_S,OAPI_KEY_F,OAPI_KEY_D,OAPI_KEY_NEXT};
+	static const DWORD btkeyCHKLST[12] = { OAPI_KEY_C,0,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_A,OAPI_KEY_PRIOR,OAPI_KEY_U,0,OAPI_KEY_R,OAPI_KEY_D,OAPI_KEY_NEXT };
+	static const DWORD btkeyCHKLSTActiveItem[12] = { OAPI_KEY_C,OAPI_KEY_B,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_A,OAPI_KEY_PRIOR,OAPI_KEY_U,OAPI_KEY_S,OAPI_KEY_F,OAPI_KEY_D,OAPI_KEY_NEXT};
 	static const DWORD btkeyCHKLSTNAV[12] = { OAPI_KEY_C,OAPI_KEY_M,OAPI_KEY_N,OAPI_KEY_E,OAPI_KEY_L,OAPI_KEY_A,OAPI_KEY_PRIOR,OAPI_KEY_U,OAPI_KEY_S,OAPI_KEY_R,OAPI_KEY_D,OAPI_KEY_NEXT};
 	static const DWORD btkeyCHKLSTREV[12] = { OAPI_KEY_C,OAPI_KEY_M,OAPI_KEY_N,0,0,OAPI_KEY_A,OAPI_KEY_PRIOR,OAPI_KEY_U,0,0,OAPI_KEY_D,OAPI_KEY_NEXT};
 	static const DWORD btkeyCHKLSTINFO[12] = { OAPI_KEY_B,OAPI_KEY_M,0,0,0,0,0,0,0,0,0,0};
@@ -402,14 +402,21 @@ bool ProjectApolloChecklistMFD::ConsumeKeyBuffered (DWORD key)
 			return true;
 		}
 		if (key == OAPI_KEY_R) {
-			// If step is in the past, we can't skip back (at the moment).
-			// Do nothing, invalidation not required; no action was taken
-			if (CurrentStep < 0) {
-				return true;
-			}
 			item = conn.GetChecklistItem(-1, CurrentStep);
 			if (item) {
-				conn.skipToChecklistItem(item);
+				conn.gotoChecklistItem(item);
+				CurrentStep = 0;
+			}
+
+			InvalidateDisplay();
+			InvalidateButtons();
+			return true;
+		}
+		if (key == OAPI_KEY_B) {
+			// Ensure we have a current item
+			if (conn.GetChecklistItem(-1, 0)) {
+				conn.undoChecklistItem();
+				// Let's reset our cursor, just so the user knows we actually did something.
 				CurrentStep = 0;
 			}
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.cpp
@@ -263,7 +263,7 @@ bool ChecklistController::completeChecklistItem(ChecklistItem* input)
 	return true;
 }
 // Todo: Verify
-bool ChecklistController::skipToChecklistItem(ChecklistItem* input)
+bool ChecklistController::gotoChecklistItem(ChecklistItem* input)
 {
 	if (input->index >= active.set.size())
 		return false;
@@ -272,16 +272,61 @@ bool ChecklistController::skipToChecklistItem(ChecklistItem* input)
 	if (!currentItem)
 		return false;
 
-	for (int i = currentItem->index; i < input->index; i++) {
-		active.set[i].status = COMPLETE;
-		active.set[i].setFlashing(&conn, false);
-		lastItemTime = lastMissionTime;
-		iterate();
+	if (currentItem->index > input->index) {
+		for (int i = currentItem->index; i > input->index; i--) {
+			active.set[i].status = PENDING;
+			active.set[i].setFlashing(&conn, false);
+			active.sequence--;
+		}
 
-		if (active.set[i].callGroup != -1) {
-			return spawnCheck(active.set[i].callGroup, false);
+		autoexecuteSlowDelay = active.sequence->getAutoexecuteSlowDelay(&conn);
+	}
+	else {
+		for (int i = currentItem->index; i < input->index; i++) {
+			active.set[i].status = COMPLETE;
+			active.set[i].setFlashing(&conn, false);
+			iterate();
+			// We don't want to perform a spawn check; that will perform call groups.
 		}
 	}
+
+	lastItemTime = lastMissionTime;
+	return true;
+}
+bool ChecklistController::undoChecklistItem() {
+	ChecklistItem* lastItem = getChecklistItem(-1, -1);
+
+	// No last item, i.e. this checklist has just begun.
+	if (!lastItem) {
+		// Special case: this is the "root" checklist. Here be dragons, leave now!
+		if (action.empty()) {
+			active = ChecklistContainer();
+			return true;
+		}
+		// Exit it and "pop" it from the stack.
+		active = action[0];
+		action.pop_front();
+		
+		// Make sure we return to where we were last
+		if (active.sequence->index > 0) {
+			active.sequence--;
+			// Unmark the current item (that called the group we were just in) as completed
+			ChecklistItem* curItem = getChecklistItem(-1, 0);
+			// N.B. We (probably) don't need to guard on curItem here as,
+			// excepting odd race conditions, we should have a current item.
+			active.set[curItem->index].status = PENDING;
+		}
+	}
+	else {
+		// Unmark the last item as completed and decrement iterator.
+		active.set[lastItem->index].status = PENDING;
+		active.set[lastItem->index].setFlashing(&conn, true);
+		// N.B. we have a last item, so no index check is necessary
+		active.sequence--;
+	}
+
+	lastItemTime = lastMissionTime;
+	autoexecuteSlowDelay = active.sequence->getAutoexecuteSlowDelay(&conn);
 	return true;
 }
 // Todo: Verify

--- a/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.cpp
@@ -263,6 +263,28 @@ bool ChecklistController::completeChecklistItem(ChecklistItem* input)
 	return true;
 }
 // Todo: Verify
+bool ChecklistController::skipToChecklistItem(ChecklistItem* input)
+{
+	if (input->index >= active.set.size())
+		return false;
+
+	ChecklistItem* currentItem = getChecklistItem(-1, 0);
+	if (!currentItem)
+		return false;
+
+	for (int i = currentItem->index; i < input->index; i++) {
+		active.set[i].status = COMPLETE;
+		active.set[i].setFlashing(&conn, false);
+		lastItemTime = lastMissionTime;
+		iterate();
+
+		if (active.set[i].callGroup != -1) {
+			return spawnCheck(active.set[i].callGroup, false);
+		}
+	}
+	return true;
+}
+// Todo: Verify
 bool ChecklistController::autoComplete(bool input)
 {
 	bool temp = complete;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.h
@@ -519,10 +519,16 @@ public:
 /// -------------------------------------------------------------
 	bool completeChecklistItem(ChecklistItem*);
 /// -------------------------------------------------------------
-/// Skip ahead in the checklist to the provided item.  All items
-/// between the current and provided item will be marked as complete.
+/// Set the active item in the checklist to the provided item. All
+/// items between the current and provided item will be marked as
+/// complete.
 /// -------------------------------------------------------------
-	bool skipToChecklistItem(ChecklistItem*);
+	bool gotoChecklistItem(ChecklistItem*);
+/// -------------------------------------------------------------
+/// Undo the last checklist item. The last item will be marked as
+/// pending and the cursor will return to the last item.
+/// -------------------------------------------------------------
+	bool undoChecklistItem();
 /// -------------------------------------------------------------
 /// This allows setting of the autoComplete function which 
 /// automatically detects if a step is already complete and marks

--- a/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.h
@@ -519,6 +519,11 @@ public:
 /// -------------------------------------------------------------
 	bool completeChecklistItem(ChecklistItem*);
 /// -------------------------------------------------------------
+/// Skip ahead in the checklist to the provided item.  All items
+/// between the current and provided item will be marked as complete.
+/// -------------------------------------------------------------
+	bool skipToChecklistItem(ChecklistItem*);
+/// -------------------------------------------------------------
 /// This allows setting of the autoComplete function which 
 /// automatically detects if a step is already complete and marks
 /// it as such, hiding it if it's already at the top of the list.

--- a/Orbitersdk/samples/ProjectApollo/src_sys/connector.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/connector.h
@@ -244,7 +244,8 @@ public:
 		MFD_PANEL_GET_ITEM_FLASHING,			///< Get the item's current flashing.
 		MFD_PANEL_GET_CHECKLIST_AUTOEXECUTE,	///< Get automatic checklist execution.
 		MFD_PANEL_SET_CHECKLIST_AUTOEXECUTE,    ///< Set automatic checklist execution.
-		MFD_PANEL_SKIP_TO_CHECKLIST_ITEM        ///< Skip to checklist item
+		MFD_PANEL_GOTO_CHECKLIST_ITEM,          ///< Go to checklist item
+		MFD_PANEL_UNDO_CHECKLIST_ITEM           ///< Undo last item   
 	};
 
 	PanelConnector(PanelSwitches &p, ChecklistController &c);

--- a/Orbitersdk/samples/ProjectApollo/src_sys/connector.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/connector.h
@@ -243,7 +243,8 @@ public:
 		MFD_PANEL_CHECKLIST_FLASHING_QUERY,		///< Checklist item flashing.
 		MFD_PANEL_GET_ITEM_FLASHING,			///< Get the item's current flashing.
 		MFD_PANEL_GET_CHECKLIST_AUTOEXECUTE,	///< Get automatic checklist execution.
-		MFD_PANEL_SET_CHECKLIST_AUTOEXECUTE		///< Set automatic checklist execution.
+		MFD_PANEL_SET_CHECKLIST_AUTOEXECUTE,    ///< Set automatic checklist execution.
+		MFD_PANEL_SKIP_TO_CHECKLIST_ITEM        ///< Skip to checklist item
 	};
 
 	PanelConnector(PanelSwitches &p, ChecklistController &c);

--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
@@ -5381,8 +5381,11 @@ bool PanelConnector::ReceiveMessage(Connector *from, ConnectorMessage &m)
 	case MFD_PANEL_SET_CHECKLIST_AUTOEXECUTE:
 		checklist.autoExecute(m.val1.bValue);
 		return true;
-	case MFD_PANEL_SKIP_TO_CHECKLIST_ITEM:
-		m.val2.bValue = checklist.skipToChecklistItem(static_cast<ChecklistItem*>(m.val1.pValue));
+	case MFD_PANEL_GOTO_CHECKLIST_ITEM:
+		m.val2.bValue = checklist.gotoChecklistItem(static_cast<ChecklistItem*>(m.val1.pValue));
+		return true;
+	case MFD_PANEL_UNDO_CHECKLIST_ITEM:
+		m.val1.bValue = checklist.undoChecklistItem();
 		return true;
 	}
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
@@ -5381,6 +5381,9 @@ bool PanelConnector::ReceiveMessage(Connector *from, ConnectorMessage &m)
 	case MFD_PANEL_SET_CHECKLIST_AUTOEXECUTE:
 		checklist.autoExecute(m.val1.bValue);
 		return true;
+	case MFD_PANEL_SKIP_TO_CHECKLIST_ITEM:
+		m.val2.bValue = checklist.skipToChecklistItem(static_cast<ChecklistItem*>(m.val1.pValue));
+		return true;
 	}
 
 	return false;


### PR DESCRIPTION
This PR adds a few helpful features to the Checklist MFD (N.B. cursor here refers to the currently selected step, but not necessarily the active step):
- When in a checklist, and the cursor is at the active step, an "UNDO" button is present which will undo the last completed step. If the active step is the first in the group, it will return to the previous checklist or to the "no active checklist" screen. No actions will be executed even if EXEC is enabled.
- When in a checklist, and the cursor is *not* at the active step, a "GOTO" button is present which will allow the user to skip forward or back to the step under the cursor, skipping any steps in between and not executing any actions.
- When in a checklist, and the cursor is *not* at the active step, a "BCK" button is present which will allow the user to sync the cursor with the active step. This is useful when perusing a checklist using PgDn and PgUp quite a bit.