### PR TITLE
Fix AEA cycles after an AEA power down without reloading the scenario

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_ags.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_ags.cpp
@@ -345,7 +345,12 @@ void LEM_AEA::Timestep(double simt, double simdt) {
 
 	//Determine if the AEA has power
 	powered = DeterminePowerState();
-	if (!IsPowered()) return;
+	if (!IsPowered())
+	{
+		// Reset last cycling time
+		LastCycled = 0;
+		return;
+	}
 
 	int Delta, CycleCount = 0;
 


### PR DESCRIPTION
The number of cycles the AEA does in a timestep is calculated by:

`long cycles = (long)((simt - LastCycled) / 0.0000009765625);`

Where simt is the current mission time and LastCycled is the time when AEA cycles were last done. On the first timestep of an Orbiter session, the LastCycled variable is initialized as follows:

```
if (LastCycled == 0)
{
  // Use simdt as difference if new run
  LastCycled = (simt - simdt);
}
```

When the AEA is powered down, simt of course continues to go up, but LastCycled currently stays at its last value. This causes two types of wrong behavior in the first line of code above:

-If the AEA has been off for less than 2097.2 seconds, the AEA will catch up the cycles it has missed since power down. So a lot of cycles will be (falsely) done during the timestep of powering up.
-If the AEA has been off for more than 2097.2 seconds, the calculation has integer overflow and the variable cycles becomes negative. That causes no further AEA cycles to be done at all, unless the scenario is reloaded.

The fix for this bug is the same as the Virtual AGC handles the LastCycled variable. It is being kept at zero with the AEA unpowered, so that it uses the special first timestep logic from above. Both types of the bug are fixed by that.

Method to trigger the bug:

In the LEM_AEA constructor, initialize LastCycled like this

`LastCycled = 104.0*3600.0;`

to the time of Apollo 11 powerdown. Load the scenario (powerup for ascent) below, switch the AGS to operate and no DEDA readouts or enter are possible due to the integer overflow. With this pull request the problem does not occur.

[Apollo_11_-_Launch_0132.zip](https://github.com/orbiternassp/NASSP/files/13417837/Apollo_11_-_Launch_0132.zip)

