### PR TITLE
Implement AEA bootup sequence by setting initial values when AEA is unpowered

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_ags.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_ags.cpp
@@ -349,6 +349,12 @@ void LEM_AEA::Timestep(double simt, double simdt) {
 	{
 		// Reset last cycling time
 		LastCycled = 0;
+		// Reset program counter to 6000 for power up
+		vags.ProgramCounter = 06000;
+		// Also reset overflow
+		vags.Overflow = 0;
+		// And inhibit engine on
+		OutputPorts[IO_ODISCRETES] |= 02000;
 		return;
 	}
 


### PR DESCRIPTION
When booting up correctly after having been powered down, the AEA now causes a AGS warning light. Fix for issue #1111 