### PR TITLE
Slight adjustment of RTCC MFD font sizes

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -52,11 +52,11 @@ ApolloRTCCMFD::ApolloRTCCMFD (DWORD w, DWORD h, VESSEL *vessel, UINT im)
 
 	//font = oapiCreateFont(w / 20, true, "Arial", FONT_NORMAL, 0);
 	font = oapiCreateFont(w / 20, true, "Courier", FONT_NORMAL, 0);
-	font2 = oapiCreateFont(w / 24, true, "Courier", FONT_NORMAL, 0);
+	font2 = oapiCreateFont(w * 2 / 51, true, "Courier", FONT_NORMAL, 0);
 	font2vert = oapiCreateFont(w / 24, true, "Courier", FONT_NORMAL, 900);
 	fonttest = oapiCreateFont(w / 32, false, "Courier New", FONT_NORMAL, 0);
-	font3 = oapiCreateFont(w / 22, true, "Courier", FONT_NORMAL, 0);
-	font4 = oapiCreateFont(w / 27, true, "Courier", FONT_NORMAL, 0);
+	font3 = oapiCreateFont(w / 24, true, "Courier", FONT_NORMAL, 0);
+	font4 = oapiCreateFont(w / 31, true, "Courier", FONT_NORMAL, 0);
 	pen = oapiCreatePen(1, 1, 0x00FFFF);
 	pen2 = oapiCreatePen(1, 1, 0x00FFFFFF);
 	bool found = false;


### PR DESCRIPTION
Slightly improves the problem of overlapping text in the RTCC MFD when used with the External MFD, without making the font too small to read on the 2D panel.

2D panel:
![image](https://github.com/orbiternassp/NASSP/assets/13571607/075ccdd1-7cdf-4809-9e54-599d57831034)

Previous worst case in the External MFD:
![image](https://github.com/orbiternassp/NASSP/assets/13571607/0fed3896-81fc-4839-a204-f744a025b7a1)

New worst case in the External MFD:
![image](https://github.com/orbiternassp/NASSP/assets/13571607/c6be19d6-1e06-4e02-a689-b7bb62d5d9ae)

Similar results with MFD pages that use other adjusted font sizes.