### PR TITLE
MCC and RTCC use one common set of functions converting time to hours…

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C.cpp
@@ -62,7 +62,7 @@ bool RTCC::CalculationMTP_C(int fcn, LPVOID &pad, char * upString, char * upDesc
 		int hh, mm;
 		double ss;
 
-		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss);
+		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss, 0.01);
 
 		sprintf_s(Buff, "P10,CSM,%d:%d:%.2lf;", hh, mm, ss);
 		GMGMED(Buff);
@@ -81,7 +81,7 @@ bool RTCC::CalculationMTP_C(int fcn, LPVOID &pad, char * upString, char * upDesc
 		GMGMED(Buff);
 
 		//P12: IU GRR and Azimuth
-		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss);
+		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss, 0.01);
 		sprintf_s(Buff, "P12,IU1,%d:%d:%.2lf,%.2lf;", hh, mm, ss, Azi);
 		GMGMED(Buff);
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C_PRIME.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C_PRIME.cpp
@@ -65,7 +65,7 @@ bool RTCC::CalculationMTP_C_PRIME(int fcn, LPVOID &pad, char * upString, char * 
 		int hh, mm;
 		double ss;
 
-		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss);
+		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss, 0.01);
 
 		sprintf_s(Buff, "P10,CSM,%d:%d:%.2lf;", hh, mm, ss);
 		GMGMED(Buff);
@@ -84,7 +84,7 @@ bool RTCC::CalculationMTP_C_PRIME(int fcn, LPVOID &pad, char * upString, char * 
 		GMGMED(Buff);
 
 		//P12: IU GRR and Azimuth
-		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss);
+		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss, 0.01);
 		sprintf_s(Buff, "P12,IU1,%d:%d:%.2lf,%.2lf;", hh, mm, ss, Azi);
 		GMGMED(Buff);
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_D.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_D.cpp
@@ -156,7 +156,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 		int hh, mm;
 		double ss;
 
-		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss);
+		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss, 0.01);
 
 		sprintf_s(Buff, "P10,CSM,%d:%d:%.2lf;", hh, mm, ss);
 		GMGMED(Buff);
@@ -178,7 +178,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 		GMGMED("P15,AGS,,40:00:00;");
 
 		//P12: IU GRR and Azimuth
-		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss);
+		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss, 0.01);
 		sprintf_s(Buff, "P12,IU1,%d:%d:%.2lf,%.2lf;", hh, mm, ss, Azi);
 		GMGMED(Buff);
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
@@ -65,7 +65,7 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 		int hh, mm;
 		double ss;
 
-		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss);
+		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss, 0.01);
 
 		sprintf_s(Buff, "P10,CSM,%d:%d:%.2lf;", hh, mm, ss);
 		GMGMED(Buff);
@@ -87,7 +87,7 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 		GMGMED("P15,AGS,,90:00:00;");
 
 		//P12: IU GRR and Azimuth
-		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss);
+		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss, 0.01);
 		sprintf_s(Buff, "P12,IU1,%d:%d:%.2lf,%.2lf;", hh, mm, ss, Azi);
 		GMGMED(Buff);
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
@@ -116,7 +116,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		int hh, mm;
 		double ss;
 
-		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss);
+		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss, 0.01);
 
 		sprintf_s(Buff, "P10,CSM,%d:%d:%.2lf;", hh, mm, ss);
 		GMGMED(Buff);
@@ -138,7 +138,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		GMGMED("P15,AGS,,90:00:00;");
 
 		//P12: IU GRR and Azimuth
-		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss);
+		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss, 0.01);
 		sprintf_s(Buff, "P12,IU1,%d:%d:%.2lf,%.2lf;", hh, mm, ss, Azi);
 		GMGMED(Buff);
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
@@ -202,7 +202,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 		int hh, mm;
 		double ss;
 
-		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss);
+		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss, 0.01);
 
 		sprintf_s(Buff, "P10,CSM,%d:%d:%.2lf;", hh, mm, ss);
 		GMGMED(Buff);
@@ -224,7 +224,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 		GMGMED("P15,AGS,,100:00:00;");
 
 		//P12: IU GRR and Azimuth
-		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss);
+		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss, 0.01);
 		sprintf_s(Buff, "P12,IU1,%d:%d:%.2lf,%.2lf;", hh, mm, ss, Azi);
 		GMGMED(Buff);
 
@@ -577,7 +577,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 			F23time = LOIFP - 11.0*60.0;
 			while (PZMCCDIS.data[0].GET_LOI < LOIFP - 5.0 || init)
 			{
-				OrbMech::SStoHHMMSS(F23time, hh, mm, ss);
+				OrbMech::SStoHHMMSS(F23time, hh, mm, ss, 0.01);
 				sprintf_s(Buff, "F23,%d:%d:%.2lf,%d:%d:%.2lf;", hh, mm, ss, hh, mm + 10, ss);
 				GMGMED(Buff);
 				TranslunarMidcourseCorrectionProcessor(sv, CSMmass, LMmass);
@@ -607,7 +607,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 					F23time = LOIFP - 11.0*60.0;
 					while (PZMCCDIS.data[0].GET_LOI < LOIFP - 5.0 || init)
 					{
-						OrbMech::SStoHHMMSS(F23time, hh, mm, ss);
+						OrbMech::SStoHHMMSS(F23time, hh, mm, ss, 0.01);
 						sprintf_s(Buff, "F23,%d:%d:%.2lf,%d:%d:%.2lf;", hh, mm, ss, hh, mm + 10, ss);
 						GMGMED(Buff);
 						TranslunarMidcourseCorrectionProcessor(sv, CSMmass, LMmass);
@@ -2769,7 +2769,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 			SystemParameters.MCGZSS = SystemParameters.MCGZSL + KFactor / 3600.0;
 		}
 
-		OrbMech::SStoHHMMSS(GETfromGMT(GetAGSClockZero()), hh, mm, ss);
+		OrbMech::SStoHHMMSS(GETfromGMT(GetAGSClockZero()), hh, mm, ss, 0.01);
 
 		AP11LMASCPAD pad2;
 
@@ -2844,7 +2844,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 
 		AP11ManeuverPAD(&opt, *form);
 		sprintf(form->purpose, "SEP BURN");
-		OrbMech::SStoHHMMSS(form->GETI - 5.0*60.0, hh, mm, ss);
+		OrbMech::SStoHHMMSS(form->GETI - 5.0*60.0, hh, mm, ss, 0.01);
 		sprintf(form->remarks, "Jettison PAD: GET %d:%d:%.2lf R 219 P 358 Y 342\nSep burn is Z-axis, retrograde", hh, mm, ss);
 		form->type = 2;
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_SL.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_SL.cpp
@@ -53,7 +53,7 @@ bool RTCC::CalculationMTP_SL(int fcn, LPVOID &pad, char * upString, char * upDes
 		int hh, mm;
 		gmt = modf(oapiGetSimMJD(), &iptr)*24.0*3600.0 + 4.0*3600.0; //TBD: Not sure this is good
 
-		OrbMech::SStoHHMMSS(gmt, hh, mm, ss);
+		OrbMech::SStoHHMMSS(gmt, hh, mm, ss, 0.01);
 
 		sprintf_s(Buff, "P10,CSM,%d:%d:%.2lf;", hh, mm, ss);
 		GMGMED(Buff);
@@ -94,7 +94,7 @@ bool RTCC::CalculationMTP_SL(int fcn, LPVOID &pad, char * upString, char * upDes
 		int hh, mm;
 		double ss;
 
-		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss);
+		OrbMech::SStoHHMMSS(LaunchMJD*3600.0, hh, mm, ss, 0.01);
 
 		sprintf_s(Buff, "P10,CSM,%d:%d:%.2lf;", hh, mm, ss);
 		GMGMED(Buff);
@@ -113,7 +113,7 @@ bool RTCC::CalculationMTP_SL(int fcn, LPVOID &pad, char * upString, char * upDes
 		GMGMED(Buff);
 
 		//P12: IU GRR and Azimuth
-		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss);
+		OrbMech::SStoHHMMSS(T_GRR, hh, mm, ss, 0.01);
 		sprintf_s(Buff, "P12,IU1,%d:%d:%.2lf,%.2lf;", hh, mm, ss, Azi);
 		GMGMED(Buff);
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
@@ -2567,38 +2567,6 @@ void MCC::LoadState(FILEHANDLE scn) {
 	return;
 }
 
-// PAD Utility: Format time.
-void format_time(char *buf, double time) {
-	buf[0] = 0; // Clobber
-	int hours, minutes, seconds;
-	if (time < 0) { return;  } // don't do that
-	hours = (int)(time / 3600);
-	minutes = (int)((time / 60) - (hours * 60));
-	seconds = (int)((time - (hours * 3600)) - (minutes * 60));
-	sprintf(buf, "%03d:%02d:%02d", hours, minutes, seconds);
-}
-
-// PAD Utility: Format precise time.
-void format_time_prec(char *buf, double time) {
-	buf[0] = 0; // Clobber
-	int hours, minutes;
-	double seconds;
-	if (time < 0) { return; } // don't do that
-	hours = (int)(time / 3600);
-	minutes = (int)((time / 60) - (hours * 60));
-	seconds = ((time - (hours * 3600)) - (minutes * 60));
-	sprintf(buf, "HRS XXX%03d\nMIN XXXX%02d\nSEC XX%05.2f", hours, minutes, seconds);
-}
-
-void SStoHHMMSS(double time, int &hours, int &minutes, double &seconds)
-{
-	double mins;
-	hours = (int)trunc(time / 3600.0);
-	mins = fmod(time / 60.0, 60.0);
-	minutes = (int)trunc(mins);
-	seconds = (mins - minutes) * 60.0;
-}
-
 // Draw PAD display
 void MCC::drawPad(bool writetofile){
 	char buffer[1024];
@@ -2621,8 +2589,8 @@ void MCC::drawPad(bool writetofile){
 
 			for (int i = 0;i < 4;i++)
 			{
-				format_time(tmpbuf, form->GETI[i]);
-				format_time(tmpbuf2, form->GETI[i + 4]);
+				OrbMech::format_time(tmpbuf, form->GETI[i]);
+				OrbMech::format_time(tmpbuf2, form->GETI[i + 4]);
 				length += sprintf(buffer + length, "\nXX%s XX%s AREA\nXXX%+05.1f XXX%+05.1f LAT\nXX%+06.1f XX%+06.1f LONG\n%s %s GETI\nXXX%4.1f XXX%4.1f DVC\n%s %s WX", form->Area[i], form->Area[i + 4], form->Lat[i], form->Lat[i + 4], form->Lng[i], form->Lng[i + 4], tmpbuf, tmpbuf2, form->dVC[i], form->dVC[i + 4], form->Wx[i], form->Wx[i + 4]);
 			}
 			oapiAnnotationSetText(NHpad, buffer);
@@ -2631,13 +2599,13 @@ void MCC::drawPad(bool writetofile){
 	case PT_P27PAD:
 		{
 			P27PAD * form = (P27PAD *)padForm;
-			format_time(tmpbuf, form->GET[0]);
+			OrbMech::format_time(tmpbuf, form->GET[0]);
 			sprintf(buffer, "P27 UPDATE\nPURP V%d\nGET %s\n304 01 INDEX %d\n", form->Verb[0], tmpbuf, form->Index[0]);
 			for (int i = 0;i < 16;i++)
 			{
 				sprintf(buffer, "%s %02o %05d\n", buffer,i+2, form->Data[0][i]);
 			}
-			format_time_prec(tmpbuf, form->NavChk);
+			OrbMech::format_time_prec(tmpbuf, form->NavChk);
 			sprintf(buffer, "%sNAV CHECK (N34)\n%s\nLAT %+07.2f\nLONG %+07.2f\nALT %+07.1f\n", buffer, tmpbuf, form->lat, form->lng, form->alt);
 			oapiAnnotationSetText(NHpad, buffer);
 		}
@@ -2645,7 +2613,7 @@ void MCC::drawPad(bool writetofile){
 	case PT_AP7NAV:
 		{
 			AP7NAV * form = (AP7NAV *)padForm;
-			format_time_prec(tmpbuf, form->NavChk[0]);
+			OrbMech::format_time_prec(tmpbuf, form->NavChk[0]);
 			sprintf(buffer, "NAV CHECK\nGET (N34):\n%s\n %+07.2f LAT\n %+07.2f LNG\n %+07.1f ALT\n", tmpbuf, form->lat[0], form->lng[0], form->alt[0]);
 			oapiAnnotationSetText(NHpad, buffer);
 		}
@@ -2668,7 +2636,7 @@ void MCC::drawPad(bool writetofile){
 				fullString = "MANEUVER\n";
 			}
 
-			SStoHHMMSS(form->GETI, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->GETI, hh, mm, ss, 0.01);
 			snprintf(tempString, 1024, "%s PURPOSE\n%+06d HRS GETI N33\n%+06d MIN\n%+07.2f SEC\n%+07.1f DVX\n%+07.1f DVY\n%+07.1f DVZ\n", form->purpose, hh, mm, ss, form->dV.x, form->dV.y, form->dV.z);
 			fullString.append(tempString);
 
@@ -2685,13 +2653,14 @@ void MCC::drawPad(bool writetofile){
 			snprintf(tempString, 1024, "%+07.1f DVC\n", form->Vc);
 			fullString.append(tempString);
 
-			SStoHHMMSS(form->burntime, hh, mm, ss);
 			if (MissionType == MTP_D)
 			{
+				OrbMech::SStoHHMMSS(form->burntime, hh, mm, ss, 0.1);
 				snprintf(tempString, 1024, "XX%d:%04.1f BT\n%+06.0f CSM WT\n%+07.2f PTRM\n%+07.2f YTRM\n", mm, ss, form->Weight, form->pTrim, form->yTrim);
 			}
 			else
 			{
+				OrbMech::SStoHHMMSS(form->burntime, hh, mm, ss);
 				snprintf(tempString, 1024, "%+06.0f WGT\n%+07.2f PTRM\n%+07.2f YTRM\nXXX%d:%02.0f BT (MIN:SEC)\n", form->Weight, form->pTrim, form->yTrim, mm, ss);
 			}
 			fullString.append(tempString);
@@ -2705,7 +2674,7 @@ void MCC::drawPad(bool writetofile){
 			}
 			else
 			{
-				SStoHHMMSS(form->NavChk, hh, mm, ss);
+				OrbMech::SStoHHMMSS(form->NavChk, hh, mm, ss, 0.01);
 				snprintf(tempString, 1024, "%+06d HRS\n%+06d MIN TLAT, LONG\n%+07.2f SEC\n%+07.2f LAT\n%+07.2f LONG\n%+07.1f ALT\n", hh, mm, ss, form->lat, form->lng, form->alt);
 			}
 			fullString.append(tempString);
@@ -2720,7 +2689,7 @@ void MCC::drawPad(bool writetofile){
 	case PT_AP7TPI:
 		{
 			AP7TPI * form = (AP7TPI *)padForm;
-			format_time_prec(tmpbuf, form->GETI);
+			OrbMech::format_time_prec(tmpbuf, form->GETI);
 			sprintf(buffer, "TERMINAL PHASE INITIATE\nGETI\n%s\n%+07.1f Vgx\n%+07.1f Vgy\n%+07.1f Vgz\n", tmpbuf, form->Vg.x, form->Vg.y, form->Vg.z);
 			if (form->Backup_dV.x > 0)
 			{
@@ -2767,36 +2736,36 @@ void MCC::drawPad(bool writetofile){
 			buffer3.append(buffer2);
 			sprintf_s(buffer2, "%+07.1f RTGO .05G\n%+06.0f VIO .05G\n", form->RTGO[0], form->VIO[0]);
 			buffer3.append(buffer2);
-			SStoHHMMSS(form->Ret05[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->Ret05[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%0d:%02.0f RET .05G\n%+07.2f LAT\n%+07.2f LONG\n", mm, ss, form->Lat[0], form->Lng[0]);
 			buffer3.append(buffer2);
-			SStoHHMMSS(form->Ret2[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->Ret2[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%0d:%02.0f RET .2G\n%+07.1lf DRE (55°) N66\n", mm, ss, form->DRE[0]);
 			buffer3.append(buffer2);
-			SStoHHMMSS(form->RetBBO[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->RetBBO[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%0d:%02.0f RETBBO\n", mm, ss);
 			buffer3.append(buffer2);
-			SStoHHMMSS(form->RetEBO[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->RetEBO[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%0d:%02.0f RETEBO\n", mm, ss);
 			buffer3.append(buffer2);
-			SStoHHMMSS(form->RetDrog[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->RetDrog[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%0d:%02.0f RETDROG\n", mm, ss);
 			buffer3.append(buffer2);
 			sprintf_s(buffer2, "POSTBURN\nXXX%03.0f R400K\n%+07.1f RTGO .05G\n%+06.0f VIO .05G\n", form->PB_R400K[0], form->PB_RTGO[0], form->PB_VIO[0]);
 			buffer3.append(buffer2);
-			SStoHHMMSS(form->PB_Ret05[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->PB_Ret05[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%0d:%02.0f RET .05G\n", mm, ss);
 			buffer3.append(buffer2);
-			SStoHHMMSS(form->PB_Ret2[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->PB_Ret2[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%0d:%02.0f RET .2G\n%+07.1lf DRE +/-100nm N66\n", mm, ss, form->PB_DRE[0]);
 			buffer3.append(buffer2);
-			SStoHHMMSS(form->PB_RetBBO[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->PB_RetBBO[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%0d:%02.0f RETBBO\n", mm, ss);
 			buffer3.append(buffer2);
-			SStoHHMMSS(form->PB_RetEBO[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->PB_RetEBO[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%0d:%02.0f RETEBO\n", mm, ss);
 			buffer3.append(buffer2);
-			SStoHHMMSS(form->PB_RetDrog[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->PB_RetDrog[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%0d:%02.0f RETDROG\n", mm, ss);
 			buffer3.append(buffer2);
 
@@ -2811,8 +2780,8 @@ void MCC::drawPad(bool writetofile){
 
 			for (int i = 0;i < 4;i++)
 			{
-				format_time(tmpbuf, form->GETI[i]);
-				format_time(tmpbuf2, form->GET400K[i]);
+				OrbMech::format_time(tmpbuf, form->GETI[i]);
+				OrbMech::format_time(tmpbuf2, form->GET400K[i]);
 				sprintf(buffer, "%s-------------------------\n%s GETI\nX%+04.0f DVT\nX%+5.1f LONG\n%s GET 400K\n", buffer, tmpbuf, form->dVT[i], form->lng[i], tmpbuf2);
 			}
 			oapiAnnotationSetText(NHpad, buffer);
@@ -2826,10 +2795,10 @@ void MCC::drawPad(bool writetofile){
 		double ss, ss2;
 
 		sprintf(buffer, "P30 MANEUVER");
-		SStoHHMMSS(form->GETI, hh, mm, ss);
-		SStoHHMMSS(form->burntime, hh2, mm2, ss2);
+		OrbMech::SStoHHMMSS(form->GETI, hh, mm, ss, 0.01);
+		OrbMech::SStoHHMMSS(form->burntime, hh2, mm2, ss2);
 
-		format_time(tmpbuf, form->GET05G);
+		OrbMech::format_time(tmpbuf, form->GET05G);
 
 		sprintf(buffer, "%s\n%s PURPOSE\n%s PROP/GUID\n%+05.0f WT N47\n%+07.2f PTRIM N48\n%+07.2f YTRIM\n%+06d HRS GETI\n%+06d MIN N33\n%+07.2f SEC\n%+07.1f DVX N81\n%+07.1f DVY\n%+07.1f DVZ\nXXX%03.0f R\nXXX%03.0f P\nXXX%03.0f Y\n",
 			buffer, form->purpose, form->PropGuid, form->Weight, form->pTrim, form->yTrim, hh, mm, ss, form->dV.x, form->dV.y, form->dV.z, form->Att.x, form->Att.y, form->Att.z);
@@ -2858,34 +2827,34 @@ void MCC::drawPad(bool writetofile){
 
 			buffer3 = "LUNAR ENTRY\n";
 
-			format_time(tmpbuf, form->GETHorCheck[0]);
+			OrbMech::format_time(tmpbuf, form->GETHorCheck[0]);
 			sprintf_s(buffer2, "%s AREA\nXXX%03.0f R 0.05G\nXXX%03.0f P 0.05G\nXXX%03.0f Y 0.05G\n%s GET HOR CHK\n", form->Area[0], form->Att05[0].x, form->Att05[0].y, form->Att05[0].z, tmpbuf);
 			buffer3.append(buffer2);
 
 			sprintf_s(buffer2, "XXX%03.0f P\n%+07.2f LAT N61\n%+07.2f LONG\nXXX%04.1f MAX G\n", form->PitchHorCheck[0], form->Lat[0], form->Lng[0], form->MaxG[0]);
 			buffer3.append(buffer2);
 
-			format_time(tmpbuf, form->RRT[0]);
+			OrbMech::format_time(tmpbuf, form->RRT[0]);
 			sprintf_s(buffer2, "%+06.0f V400K N60\n%+07.2f y400K\n%+07.1f RTGO EMS\n%+06.0f VI0\n%s RRT\n", form->V400K[0], form->Gamma400K[0], form->RTGO[0], form->VIO[0], tmpbuf);
 			buffer3.append(buffer2);
 
-			SStoHHMMSS(form->RET05[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->RET05[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%02d:%02.0f RET 0.05G\nXXX%04.2f DO\n", mm, ss, form->DO[0]);
 			buffer3.append(buffer2);
 
-			SStoHHMMSS(form->RETVCirc[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->RETVCirc[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%02d:%02.0f RET V CIRC\n", mm, ss);
 			buffer3.append(buffer2);
 
-			SStoHHMMSS(form->RETBBO[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->RETBBO[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%02d:%02.0f RETBBO\n", mm, ss);
 			buffer3.append(buffer2);
 
-			SStoHHMMSS(form->RETEBO[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->RETEBO[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%02d:%02.0f RETEBO\n", mm, ss);
 			buffer3.append(buffer2);
 
-			SStoHHMMSS(form->RETDRO[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->RETDRO[0], hh, mm, ss);
 			sprintf_s(buffer2, "XX%02d:%02.0f RETDRO\n", mm, ss);
 			buffer3.append(buffer2);
 
@@ -2909,8 +2878,8 @@ void MCC::drawPad(bool writetofile){
 			double ss;
 
 			buffer3 = "TLI\n";
-			format_time(tmpbuf, form->TB6P);
-			SStoHHMMSS(form->BurnTime, hh, mm, ss);
+			OrbMech::format_time(tmpbuf, form->TB6P);
+			OrbMech::SStoHHMMSS(form->BurnTime, hh, mm, ss);
 
 			sprintf_s(buffer2, "%s TB6p\nXXX%03.0f R\nXXX%03.0f P TLI\nXXX%03.0f Y\nXXX%d:%02.0f BT\n%07.1f DVC\n%+05.0f VI\nXXX%03.0f R\nXXX%03.0f P SEP\nXXX%03.0f Y\n", tmpbuf, form->IgnATT.x, form->IgnATT.y, form->IgnATT.z, mm, ss, form->dVC, form->VI, form->SepATT.x, form->SepATT.y, form->SepATT.z);
 			buffer3.append(buffer2);
@@ -2936,8 +2905,8 @@ void MCC::drawPad(bool writetofile){
 		double ss, ss2;
 
 		sprintf(buffer, "CSM STAR CHECK UPDATE");
-		SStoHHMMSS(form->GET[0], hh, mm, ss);
-		SStoHHMMSS(form->TAlign[0], hh2, mm2, ss2);
+		OrbMech::SStoHHMMSS(form->GET[0], hh, mm, ss, 0.01);
+		OrbMech::SStoHHMMSS(form->TAlign[0], hh2, mm2, ss2, 0.01);
 
 		sprintf(buffer, "%s\nXX%03d HR GET\nXXX%02d MIN SR\nX%05.2f SEC\n%+06.1f R FDAI\n%+06.1f P\n%+06.1f Y\nXX%03d HR T ALIGN\nXXX%02d MIN\nX%05.2f SEC\n", buffer, hh, mm, ss, form->Att[0].x, form->Att[0].y, form->Att[0].z, hh2, mm2, ss2);
 
@@ -2952,50 +2921,50 @@ void MCC::drawPad(bool writetofile){
 		double ss;
 
 		sprintf(buffer, "MAP UPDATE REV %d\n", form->Rev);
-		SStoHHMMSS(form->LOSGET, hh, mm, ss);
+		OrbMech::SStoHHMMSS(form->LOSGET, hh, mm, ss);
 		sprintf(buffer, "%sLOS: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
 		if (form->type == 0)
 		{
-			SStoHHMMSS(form->PMGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->PMGET, hh, mm, ss);
 			sprintf(buffer, "%sPM: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->AOSGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->AOSGET, hh, mm, ss);
 			sprintf(buffer, "%sAOS: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
 		}
 		else if (form->type == 1)
 		{
-			SStoHHMMSS(form->SRGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->SRGET, hh, mm, ss);
 			sprintf(buffer, "%sSR: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->PMGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->PMGET, hh, mm, ss);
 			sprintf(buffer, "%sPM: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->AOSGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->AOSGET, hh, mm, ss);
 			sprintf(buffer, "%sAOS: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->SSGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->SSGET, hh, mm, ss);
 			sprintf(buffer, "%sSS: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
 		}
 		else if (form->type == 2)
 		{
-			SStoHHMMSS(form->PMGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->PMGET, hh, mm, ss);
 			sprintf(buffer, "%sAOS WITH LOI1: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->AOSGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->AOSGET, hh, mm, ss);
 			sprintf(buffer, "%sAOS W/O LOI1: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
 		}
 		else if (form->type == 3)
 		{
-			SStoHHMMSS(form->PMGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->PMGET, hh, mm, ss);
 			sprintf(buffer, "%sPM: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->AOSGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->AOSGET, hh, mm, ss);
 			sprintf(buffer, "%sAOS: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->SSGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->SSGET, hh, mm, ss);
 			sprintf(buffer, "%sSS: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->LOSGET2, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->LOSGET2, hh, mm, ss);
 			sprintf(buffer, "%sLOS: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->SRGET, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->SRGET, hh, mm, ss);
 			sprintf(buffer, "%sSR: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->PMGET2, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->PMGET2, hh, mm, ss);
 			sprintf(buffer, "%sPM: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->AOSGET2, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->AOSGET2, hh, mm, ss);
 			sprintf(buffer, "%sAOS: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->SSGET2, hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->SSGET2, hh, mm, ss);
 			sprintf(buffer, "%sSS: %d:%02d:%02.0f\n", buffer, hh, mm, ss);
 		}
 
@@ -3014,9 +2983,9 @@ void MCC::drawPad(bool writetofile){
 		for (int i = 0;i < form->entries;i++)
 		{
 			sprintf(buffer, "%sLMK ID %s\n", buffer, form->LmkID[i]);
-			SStoHHMMSS(form->T1[i], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->T1[i], hh, mm, ss);
 			sprintf(buffer, "%sT1 %03d:%02d:%02.f (HOR)\n", buffer, hh, mm, ss);
-			SStoHHMMSS(form->T2[i], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->T2[i], hh, mm, ss);
 			sprintf(buffer, "%sT2 %03d:%02d:%02.f (35°)\n", buffer, hh, mm, ss);
 
 			if (form->CRDist[i] > 0)
@@ -3059,7 +3028,7 @@ void MCC::drawPad(bool writetofile){
 			length += sprintf(buffer + length, "P30 LM MANEUVER\n");
 		}
 
-		SStoHHMMSS(form->GETI, hh, mm, ss);
+		OrbMech::SStoHHMMSS(form->GETI, hh, mm, ss, 0.01);
 
 		length += sprintf(buffer + length, "%s PURPOSE\n%+06d HRS N33\n%+06d MIN TIG\n%+07.2f SEC\n%+07.1f DVX ", form->purpose, hh, mm, ss, form->dV.x);
 
@@ -3083,7 +3052,7 @@ void MCC::drawPad(bool writetofile){
 
 		if (MissionType != MTP_D)
 		{
-			SStoHHMMSS(form->burntime, hh2, mm2, ss2);
+			OrbMech::SStoHHMMSS(form->burntime, hh2, mm2, ss2);
 			length += sprintf(buffer + length, "XXX%d:%02.0f BT\n", mm2, ss2);
 		}
 
@@ -3096,8 +3065,8 @@ void MCC::drawPad(bool writetofile){
 		}
 		else
 		{
-			SStoHHMMSS(form->t_CSI, hh, mm, ss);
-			SStoHHMMSS(form->t_TPI, hh2, mm2, ss2);
+			OrbMech::SStoHHMMSS(form->t_CSI, hh, mm, ss, 0.01);
+			OrbMech::SStoHHMMSS(form->t_TPI, hh2, mm2, ss2, 0.01);
 
 			length += sprintf(buffer + length, "%+06d HRS N11\n%+06d MIN CSI\n%+07.2f SEC\n%+06d HRS N37\n%+06d MIN TPI\n%+07.2f SEC\n", hh, mm, ss, hh2, mm2, ss2);
 		}
@@ -3114,8 +3083,8 @@ void MCC::drawPad(bool writetofile){
 		int hh, hh2, mm, mm2, length = 0;
 		double ss, ss2;
 
-		SStoHHMMSS(form->t_CSI, hh, mm, ss);
-		SStoHHMMSS(form->t_TPI, hh2, mm2, ss2);
+		OrbMech::SStoHHMMSS(form->t_CSI, hh, mm, ss, 0.01);
+		OrbMech::SStoHHMMSS(form->t_TPI, hh2, mm2, ss2, 0.01);
 
 		if (MissionType == MTP_D)
 		{
@@ -3154,7 +3123,7 @@ void MCC::drawPad(bool writetofile){
 		double ss;
 
 		sprintf(buffer, "LM AOT STAR OBSERVATION");
-		SStoHHMMSS(form->GET, hh, mm, ss);
+		OrbMech::SStoHHMMSS(form->GET, hh, mm, ss);
 
 		sprintf(buffer, "%s\n%03d HR\n%02d MIN\n%02.0f SEC\n%d AOT DETENT\n%02o NAV STAR\n%03.0f R\n%03.0f P\n%03.0f Y", buffer, hh, mm, ss, form->Detent, form->Star, form->CSMAtt.x, form->CSMAtt.y, form->CSMAtt.z);
 
@@ -3176,7 +3145,7 @@ void MCC::drawPad(bool writetofile){
 		int hh, mm;
 		double ss;
 
-		SStoHHMMSS(form->GETI, hh, mm, ss);
+		OrbMech::SStoHHMMSS(form->GETI, hh, mm, ss, 0.01);
 
 		sprintf(buffer, "TPI UPDATE (P34)\n%+06d HR N37\n%+06d MIN TIG\n%+07.2f SEC TPI\n%+07.1f DVX N81\n%+07.1f DVY LOCAL\n%+07.1f DVZ VERT\n%+07.1f DVR N42\n"
 			"XXX%03.0f RLM FDAI N18\nXXX%03.0f PLM INER\n%+07.2f R TPI N54\n%+07.1f RDOT TPI\n%+07.1f F/A (+/-) N59\n%+07.1f L/R (-/+) DV\n%+07.1f U/D (-/+) LOS", 
@@ -3191,7 +3160,7 @@ void MCC::drawPad(bool writetofile){
 		int hh, mm;
 		double ss;
 
-		SStoHHMMSS(form->GETI, hh, mm, ss);
+		OrbMech::SStoHHMMSS(form->GETI, hh, mm, ss, 0.01);
 
 		sprintf(buffer, "CDH UPDATE (P33)\n%+06d HR N31\n%+06d MIN TIG\n%+07.2f SEC CDH\n%+07.1f DVX N81\n%+07.1f DVY LOCAL\n%+07.1f DVZ VERT\n"
 			"XXX%03.0f PLM INER\n%+07.1f DVX N86\n%+07.1f DVZ AGS",
@@ -3210,10 +3179,10 @@ void MCC::drawPad(bool writetofile){
 
 		for (int i = 0;i < 2;i++)
 		{
-			SStoHHMMSS(form->GETStart[2 * i], hh[2 * i], mm[2 * i], ss[2 * i]);
-			SStoHHMMSS(form->GETStart[2 * i + 1], hh[2 * i + 1], mm[2 * i + 1], ss[2 * i + 1]);
-			SStoHHMMSS(form->TAlign[2 * i], hh2[2 * i], mm2[2 * i], ss2[2 * i]);
-			SStoHHMMSS(form->TAlign[2 * i + 1], hh2[2 * i + 1], mm2[2 * i + 1], ss2[2 * i + 1]);
+			OrbMech::SStoHHMMSS(form->GETStart[2 * i], hh[2 * i], mm[2 * i], ss[2 * i]);
+			OrbMech::SStoHHMMSS(form->GETStart[2 * i + 1], hh[2 * i + 1], mm[2 * i + 1], ss[2 * i + 1]);
+			OrbMech::SStoHHMMSS(form->TAlign[2 * i], hh2[2 * i], mm2[2 * i], ss2[2 * i]);
+			OrbMech::SStoHHMMSS(form->TAlign[2 * i + 1], hh2[2 * i + 1], mm2[2 * i + 1], ss2[2 * i + 1]);
 
 			sprintf(buffer, "%s\n%s %s SITE (OR AREA)\n%06.2f %06.2f R FDAI\n%06.2f %06.2f P\n%06.2f %06.2f Y\nXX%03d XX%03d GET START\n"
 				"XXX%02d XXX%02d MIN (5 MIN PRIOR TO)\nXXX%02.0f XXX%02.0f SEC (FIRST EXPOSURE)\nXX%03d XX%03d T ALIGN\nXXX%02d XXX%02d MIN (IF REQ)\n"
@@ -3243,7 +3212,7 @@ void MCC::drawPad(bool writetofile){
 		int hh, mm;
 		double ss;
 
-		SStoHHMMSS(form->KFactor, hh, mm, ss);
+		OrbMech::SStoHHMMSS(form->KFactor, hh, mm, ss, 0.01);
 
 		sprintf(buffer, "AGS ACTIVATION\n%d:%02d:%05.2f GET\n224 %+06d\n225 %+06d\n226 %+06d\n227 %+06d", hh, mm, ss, form->DEDA224, form->DEDA225, form->DEDA226, form->DEDA227);
 
@@ -3257,8 +3226,8 @@ void MCC::drawPad(bool writetofile){
 		int hh[2], mm[2];
 		double ss[2];
 
-		SStoHHMMSS(form->GETI, hh[0], mm[0], ss[0]);
-		SStoHHMMSS(form->t_go, hh[1], mm[1], ss[1]);
+		OrbMech::SStoHHMMSS(form->GETI, hh[0], mm[0], ss[0], 0.01);
+		OrbMech::SStoHHMMSS(form->t_go, hh[1], mm[1], ss[1], 0.01);
 
 		sprintf(buffer, "PDI PAD\n%+06d HRS TIG\n%+06d MIN PDI\n%+07.2f SEC\nXX%02d:%02.0f TGO N61\n%+07.1f CROSSRANGE\nXXX%03.0f R FDAI\nXXX%03.0f P AT TIG\n"
 			"XXX%03.0f Y\n%+06.0f DEDA 231 IF RQD", hh[0], mm[0], ss[0], mm[1], ss[1], form->CR, form->Att.x, form->Att.y, form->Att.z, form->DEDA231);
@@ -3273,9 +3242,9 @@ void MCC::drawPad(bool writetofile){
 		int hh[3], mm[3];
 		double ss[3];
 
-		SStoHHMMSS(form->T_TPI_Pre10Min, hh[0], mm[0], ss[0]);
-		SStoHHMMSS(form->T_Phasing, hh[1], mm[1], ss[1]);
-		SStoHHMMSS(form->T_TPI_Post10Min, hh[2], mm[2], ss[2]);
+		OrbMech::SStoHHMMSS(form->T_TPI_Pre10Min, hh[0], mm[0], ss[0], 0.01);
+		OrbMech::SStoHHMMSS(form->T_Phasing, hh[1], mm[1], ss[1], 0.01);
+		OrbMech::SStoHHMMSS(form->T_TPI_Post10Min, hh[2], mm[2], ss[2], 0.01);
 
 		if (form->type == 0)
 		{
@@ -3298,15 +3267,15 @@ void MCC::drawPad(bool writetofile){
 		int hh[9], mm[9];
 		double ss[9];
 
-		SStoHHMMSS(form->T2_TIG, hh[0], mm[0], ss[0]);
-		SStoHHMMSS(form->T2_t_Phasing, hh[1], mm[1], ss[1]);
-		SStoHHMMSS(form->T2_t_CSI1, hh[2], mm[2], ss[2]);
-		SStoHHMMSS(form->T2_t_TPI, hh[3], mm[3], ss[3]);
-		SStoHHMMSS(form->T3_TIG, hh[4], mm[4], ss[4]);
-		SStoHHMMSS(form->T3_t_Period, hh[5], mm[5], ss[5]);
-		SStoHHMMSS(form->T3_t_PPlusDT, hh[6], mm[6], ss[6]);
-		SStoHHMMSS(form->T3_t_CSI, hh[7], mm[7], ss[7]);
-		SStoHHMMSS(form->T3_t_TPI, hh[8], mm[8], ss[8]);
+		OrbMech::SStoHHMMSS(form->T2_TIG, hh[0], mm[0], ss[0], 0.01);
+		OrbMech::SStoHHMMSS(form->T2_t_Phasing, hh[1], mm[1], ss[1], 0.01);
+		OrbMech::SStoHHMMSS(form->T2_t_CSI1, hh[2], mm[2], ss[2], 0.01);
+		OrbMech::SStoHHMMSS(form->T2_t_TPI, hh[3], mm[3], ss[3], 0.01);
+		OrbMech::SStoHHMMSS(form->T3_TIG, hh[4], mm[4], ss[4], 0.01);
+		OrbMech::SStoHHMMSS(form->T3_t_Period, hh[5], mm[5], ss[5], 0.01);
+		OrbMech::SStoHHMMSS(form->T3_t_PPlusDT, hh[6], mm[6], ss[6], 0.01);
+		OrbMech::SStoHHMMSS(form->T3_t_CSI, hh[7], mm[7], ss[7], 0.01);
+		OrbMech::SStoHHMMSS(form->T3_t_TPI, hh[8], mm[8], ss[8], 0.01);
 
 		sprintf(buffer, "T2 ABORT\n%+06d HRS T2\n%+06d MIN TIG\n%+07.2f SEC\n%+06d HRS N33\n%+06d MIN PHASING\n%+07.2f SEC TIG\n"
 			"%+06d HRS N11\n%+06d MIN CSI1\n%+07.2f SEC\n%+06d HRS N37\n%+06d MIN TPI\n%+07.2f SEC\n"
@@ -3329,7 +3298,7 @@ void MCC::drawPad(bool writetofile){
 
 		for (int i = 0;i < form->entries;i++)
 		{
-			SStoHHMMSS(form->TIG[i], hh, mm, ss);
+			OrbMech::SStoHHMMSS(form->TIG[i], hh, mm, ss, 0.01);
 
 			sprintf(buffer, "%s%s PURPOSE\n%+06d HRS N33\n%+06d MIN TIG\n%+07.2f SEC\n%+07.1f DVX N84\n%+07.1f DVY\n%+07.1f DVZ\n", 
 				buffer, form->purpose[i], hh, mm, ss, form->DV[i].x, form->DV[i].y, form->DV[i].z);
@@ -3345,7 +3314,7 @@ void MCC::drawPad(bool writetofile){
 		int hh, mm;
 		double ss;
 
-		SStoHHMMSS(form->TIG, hh, mm, ss);
+		OrbMech::SStoHHMMSS(form->TIG, hh, mm, ss, 0.01);
 
 		sprintf(buffer, "LM ASCENT PAD\n%+06d HRS\n%+06d MIN TIG\n%+07.2f SEC\n%+07.1f V (HOR)\n%+07.1f V (VERT) N76\n%+07.1f CROSSRANGE\n"
 			"%+06d DEDA 047\n%+06d DEDA 053\n%+06.0f DEDA 225/226\n%+06.0f DEDA 231\nRemarks: %s", hh, mm, ss, form->V_hor, form->V_vert, form->CR,
@@ -3362,7 +3331,7 @@ void MCC::drawPad(bool writetofile){
 
 		for (int i = 0;i < form->entries;i++)
 		{
-			format_time(tmpbuf, form->TIG[i]);
+			OrbMech::format_time(tmpbuf, form->TIG[i]);
 			sprintf(buffer, "%sT%d %s\n", buffer, form->startdigit + i, tmpbuf);
 		}
 
@@ -3386,8 +3355,8 @@ void MCC::drawPad(bool writetofile){
 		int hh1, hh2, mm1, mm2;
 		double ss1, ss2;
 
-		SStoHHMMSS(form->GET_Day, hh1, mm1, ss1);
-		SStoHHMMSS(form->GET_Night, hh2, mm2, ss2);
+		OrbMech::SStoHHMMSS(form->GET_Day, hh1, mm1, ss1, 0.01);
+		OrbMech::SStoHHMMSS(form->GET_Night, hh2, mm2, ss2, 0.01);
 
 		sprintf_s(buffer, "RETRO ORIENTATION\nMODE A: DAY\nHRS %05d\nMIN %05d\nSEC %06.2f\nR %06.2lf\nP %06.2lf\nY %06.2lf\nMODE B: NIGHT\nHRS %05d\nMIN %05d\nSEC %06.2f\nR %06.2lf\nP %06.2lf\nY %06.2lf",
 			hh1, mm1, ss1, form->RetroAtt_Day.x, form->RetroAtt_Day.y, form->RetroAtt_Day.z, hh2, mm2, ss2, form->RetroAtt_Night.x, form->RetroAtt_Night.y, form->RetroAtt_Night.z);
@@ -3402,8 +3371,8 @@ void MCC::drawPad(bool writetofile){
 		int hh[2], mm[2];
 		double ss[2];
 
-		SStoHHMMSS(form->T_TPI_Pre10Min, hh[0], mm[0], ss[0]);
-		SStoHHMMSS(form->T_TPI_Post10Min, hh[1], mm[1], ss[1]);
+		OrbMech::SStoHHMMSS(form->T_TPI_Pre10Min, hh[0], mm[0], ss[0], 0.01);
+		OrbMech::SStoHHMMSS(form->T_TPI_Post10Min, hh[1], mm[1], ss[1], 0.01);
 
 		sprintf(buffer, "PDI ABORT <10 MIN\n%+06d HRS N37\n%+06d MIN TPI\n%+07.2f SEC\nPDI ABORT >10 MIN\n%+06d HRS N37\n%+06d MIN TPI\n%+07.2f SEC", hh[0], mm[0], ss[0], hh[1], mm[1], ss[1]);
 
@@ -3417,9 +3386,9 @@ void MCC::drawPad(bool writetofile){
 		int hh[3], mm[3];
 		double ss[3];
 
-		SStoHHMMSS(form->T2_TIG, hh[0], mm[0], ss[0]);
-		SStoHHMMSS(form->T2_t_TPI, hh[1], mm[1], ss[1]);
-		SStoHHMMSS(form->T3_TIG, hh[2], mm[2], ss[2]);
+		OrbMech::SStoHHMMSS(form->T2_TIG, hh[0], mm[0], ss[0], 0.01);
+		OrbMech::SStoHHMMSS(form->T2_t_TPI, hh[1], mm[1], ss[1], 0.01);
+		OrbMech::SStoHHMMSS(form->T3_TIG, hh[2], mm[2], ss[2], 0.01);
 
 		sprintf(buffer, "T2 ABORT\n%+06d HRS T2\n%+06d MIN TIG\n%+07.2f SEC\n%+06d HRS N37\n%+06d MIN TPI\n%+07.2f SEC\nT3 ABORT\n%+06d HRS T3\n%+06d MIN TIG\n%+07.2f SEC",
 			hh[0], mm[0], ss[0], hh[1], mm[1], ss[1], hh[2], mm[2], ss[2]);
@@ -3434,7 +3403,7 @@ void MCC::drawPad(bool writetofile){
 		int hh, mm;
 		double ss;
 
-		SStoHHMMSS(form->P22_ACQ_GET, hh, mm, ss);
+		OrbMech::SStoHHMMSS(form->P22_ACQ_GET, hh, mm, ss, 0.01);
 
 		sprintf(buffer, "P22 ACQUISITION\n%+06d HRS\n%+06d MIN\n%+07.2f SEC", hh, mm, ss);
 
@@ -3454,8 +3423,8 @@ void MCC::drawPad(bool writetofile){
 		int hh[2], mm[2];
 		double ss[2];
 
-		SStoHHMMSS(form->TIG, hh[0], mm[0], ss[0]);
-		SStoHHMMSS(form->TIG_2, hh[1], mm[1], ss[1]);
+		OrbMech::SStoHHMMSS(form->TIG, hh[0], mm[0], ss[0], 0.01);
+		OrbMech::SStoHHMMSS(form->TIG_2, hh[1], mm[1], ss[1], 0.01);
 
 		sprintf(buffer, "LM ASCENT PAD\n%+06d HRS\n%+06d MIN TIG\n%+07.2f SEC\n%+07.1f V (HOR)\n%+07.1f V (VERT) N76\n%+07.1f CROSSRANGE\n"
 			"%+06d 047\n%+06d 053\n%+06.0f 225/226\n%+06.0f 231\n%+07.1f 465\n%+06d HRS\n%+06d MIN TIG\n%+07.2f SEC\n%+06.0f LM WT\n%+06.0f CSM WT\nRemarks: %s",

--- a/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
@@ -3444,7 +3444,7 @@ void MCC::drawPad(bool writetofile){
 		OrbMech::SStoHHMMSS(form->t_Undock, hh[0], mm[0], ss[0]);
 		OrbMech::SStoHHMMSS(form->t_Separation, hh[1], mm[1], ss[1]);
 
-		sprintf(buffer, "Undocking: %d:%d:%.0lf\nAttitude: %03.0f %03.0f %03.0f\nSeparation: %d:%d:%.0lf", hh[0], mm[0], ss[0], form->Att_Undock.x, form->Att_Undock.y, form->Att_Undock.z, hh[1], mm[1], ss[1]);
+		sprintf(buffer, "Undocking: %d:%02d:%02.0lf\nAttitude: %03.0f %03.0f %03.0f\nSeparation: %d:%02d:%02.0lf", hh[0], mm[0], ss[0], form->Att_Undock.x, form->Att_Undock.y, form->Att_Undock.z, hh[1], mm[1], ss[1]);
 
 		oapiAnnotationSetText(NHpad, buffer);
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -13345,12 +13345,12 @@ void RTCC::PMXSPT(std::string source, int n)
 		{
 			int hh, mm;
 			double ss;
-			OrbMech::SStoHHMMSSTH(RTCCONLINEMON.DoubleBuffer[0], hh, mm, ss);
+			OrbMech::SStoHHMMSS(RTCCONLINEMON.DoubleBuffer[0], hh, mm, ss, 0.01);
 			sprintf_s(Buffer, "LIFTOFF TIME(GMT) = 00/%02d/%02d/%05.2lf", hh, mm, ss);
 			message.push_back(Buffer);
 			sprintf_s(Buffer, "LAUNCH AZIMUTH (DEG) = %.6lf", RTCCONLINEMON.DoubleBuffer[1]);
 			message.push_back(Buffer);
-			OrbMech::SStoHHMMSSTH(RTCCONLINEMON.DoubleBuffer[2], hh, mm, ss);
+			OrbMech::SStoHHMMSS(RTCCONLINEMON.DoubleBuffer[2], hh, mm, ss, 0.01);
 			sprintf_s(Buffer, "VECTOR TIME(HRS) = 00/%02d/%02d/%05.2lf CS = ECT", hh, mm, ss);
 			message.push_back(Buffer);
 			sprintf_s(Buffer, "   R(ER) = %.10lf %.10lf %.10lf", RTCCONLINEMON.VectorBuffer[0].x, RTCCONLINEMON.VectorBuffer[0].y, RTCCONLINEMON.VectorBuffer[0].z);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -1217,7 +1217,7 @@ void ARCore::UpdateGRRTime(VESSEL *v)
 	int hh, mm;
 	double ss;
 	char Buff[128];
-	OrbMech::SStoHHMMSS(T_L, hh, mm, ss);
+	OrbMech::SStoHHMMSS(T_L, hh, mm, ss, 0.01);
 	sprintf_s(Buff, "P12,IU1,%d:%d:%.2lf,%.3lf;", hh, mm, ss, Azi*DEG);
 	GC->rtcc->GMGMED(Buff);
 }

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -125,7 +125,6 @@ public:
 	void ThrusterName(char *Buff, int n);
 	bool ThrusterType(std::string name, int &id);
 	void MPTAttitudeName(char *Buff, int n);
-	void SStoHHMMSS(double time, int &hours, int &minutes, double &seconds);
 	void CycleREFSMMATopt();
 	void UploadREFSMMAT();
 	void menuSLVTLITargetingUplink();

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -3263,81 +3263,81 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 
 		if (G->PDAPTwoSegment)
 		{
-			skp->Text(1 * W / 8, 2 * H / 14, "Apollo 11", 9);
+			skp->Text(1 * W / 16, 2 * H / 14, "Apollo 12+", 10);
 		}
 		else
 		{
-			skp->Text(1 * W / 8, 2 * H / 14, "Apollo 12+", 10);
+			skp->Text(1 * W / 16, 2 * H / 14, "Apollo 11", 9);
 		}
 
 		if (G->PDAPEngine == 0)
 		{
-			skp->Text(1 * W / 8, 4 * H / 14, "DPS/APS", 7);
+			skp->Text(1 * W / 16, 4 * H / 14, "DPS", 3);
 		}
 		else
 		{
-			skp->Text(1 * W / 8, 4 * H / 14, "APS", 7);
+			skp->Text(1 * W / 16, 4 * H / 14, "APS", 3);
 		}
 
 		skp->Text(4 * W / 8, 3 * H / 21, "TPI:", 4);
 		GET_Display(Buffer, G->t_TPI);
 		skp->Text(5 * W / 8, 3 * H / 21, Buffer, strlen(Buffer));
 
-		skp->Text(1 * W / 8, 5 * H / 21, "PGNS Coefficients:", 18);
+		skp->Text(2 * W / 8, 5 * H / 21, "PGNS Coefficients:", 18);
 		if (G->PDAPTwoSegment == false)
 		{
 			sprintf(Buffer, "%e", G->PDAPABTCOF[0] / 0.3048);
-			skp->Text(1 * W / 8, 6 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 6 * H / 21, Buffer, strlen(Buffer));
 			sprintf(Buffer, "%e", G->PDAPABTCOF[1] / 0.3048);
-			skp->Text(1 * W / 8, 7 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 7 * H / 21, Buffer, strlen(Buffer));
 			sprintf(Buffer, "%e", G->PDAPABTCOF[2] / 0.3048);
-			skp->Text(1 * W / 8, 8 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 8 * H / 21, Buffer, strlen(Buffer));
 			sprintf(Buffer, "%f", G->PDAPABTCOF[3] / 0.3048);
-			skp->Text(1 * W / 8, 9 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 9 * H / 21, Buffer, strlen(Buffer));
 			sprintf(Buffer, "%e", G->PDAPABTCOF[4] / 0.3048);
-			skp->Text(1 * W / 8, 10 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 10 * H / 21, Buffer, strlen(Buffer));
 			sprintf(Buffer, "%e", G->PDAPABTCOF[5] / 0.3048);
-			skp->Text(1 * W / 8, 11 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 11 * H / 21, Buffer, strlen(Buffer));
 			sprintf(Buffer, "%e", G->PDAPABTCOF[6] / 0.3048);
-			skp->Text(1 * W / 8, 12 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 12 * H / 21, Buffer, strlen(Buffer));
 			sprintf(Buffer, "%f", G->PDAPABTCOF[7] / 0.3048);
-			skp->Text(1 * W / 8, 13 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 13 * H / 21, Buffer, strlen(Buffer));
 		}
 		else
 		{
-			skp->Text(1 * W / 8, 6 * H / 21, "J1", 2);
+			skp->Text(2 * W / 8, 6 * H / 21, "J1", 2);
 			sprintf(Buffer, "%.4f NM", G->PDAP_J1 / 1852.0);
-			skp->Text(2 * W / 8, 6 * H / 21, Buffer, strlen(Buffer));
-			skp->Text(1 * W / 8, 7 * H / 21, "K1", 2);
+			skp->Text(3 * W / 8, 6 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 7 * H / 21, "K1", 2);
 			sprintf(Buffer, "%.4f NM/DEG", G->PDAP_K1 / 1852.0 / DEG);
-			skp->Text(2 * W / 8, 7 * H / 21, Buffer, strlen(Buffer));
-			skp->Text(1 * W / 8, 8 * H / 21, "J2", 2);
+			skp->Text(3 * W / 8, 7 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 8 * H / 21, "J2", 2);
 			sprintf(Buffer, "%.4f NM", G->PDAP_J2 / 1852.0);
-			skp->Text(2 * W / 8, 8 * H / 21, Buffer, strlen(Buffer));
-			skp->Text(1 * W / 8, 9 * H / 21, "K2", 2);
+			skp->Text(3 * W / 8, 8 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 9 * H / 21, "K2", 2);
 			sprintf(Buffer, "%.4f NM/DEG", G->PDAP_K2 / 1852.0 / DEG);
-			skp->Text(2 * W / 8, 9 * H / 21, Buffer, strlen(Buffer));
-			skp->Text(1 * W / 8, 10 * H / 21, "THET", 4);
+			skp->Text(3 * W / 8, 9 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 10 * H / 21, "THET", 4);
 			sprintf(Buffer, "%.4f°", G->PDAP_Theta_LIM*DEG);
-			skp->Text(2 * W / 8, 10 * H / 21, Buffer, strlen(Buffer));
-			skp->Text(1 * W / 8, 11 * H / 21, "RMIN", 4);
+			skp->Text(3 * W / 8, 10 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(2 * W / 8, 11 * H / 21, "RMIN", 4);
 			sprintf(Buffer, "%.4f NM", G->PDAP_R_amin / 1852.0);
-			skp->Text(2 * W / 8, 11 * H / 21, Buffer, strlen(Buffer));
+			skp->Text(3 * W / 8, 11 * H / 21, Buffer, strlen(Buffer));
 		}
 
-		skp->Text(1 * W / 8, 15 * H / 21, "AGS Coefficients:", 18);
-		skp->Text(1 * W / 8, 16 * H / 21, "224", 3);
+		skp->Text(2 * W / 8, 15 * H / 21, "AGS Coefficients:", 18);
+		skp->Text(2 * W / 8, 16 * H / 21, "224", 3);
 		sprintf(Buffer, "%+06.0f", G->DEDA224 / 0.3048 / 100.0);
-		skp->Text(2 * W / 8, 16 * H / 21, Buffer, strlen(Buffer));
-		skp->Text(1 * W / 8, 17 * H / 21, "225", 3);
+		skp->Text(3 * W / 8, 16 * H / 21, Buffer, strlen(Buffer));
+		skp->Text(2 * W / 8, 17 * H / 21, "225", 3);
 		sprintf(Buffer, "%+06.0f", G->DEDA225 / 0.3048 / 100.0);
-		skp->Text(2 * W / 8, 17 * H / 21, Buffer, strlen(Buffer));
-		skp->Text(1 * W / 8, 18 * H / 21, "226", 3);
+		skp->Text(3 * W / 8, 17 * H / 21, Buffer, strlen(Buffer));
+		skp->Text(2 * W / 8, 18 * H / 21, "226", 3);
 		sprintf(Buffer, "%+06.0f", G->DEDA226 / 0.3048 / 100.0);
-		skp->Text(2 * W / 8, 18 * H / 21, Buffer, strlen(Buffer));
-		skp->Text(1 * W / 8, 19 * H / 21, "227", 3);
+		skp->Text(3 * W / 8, 18 * H / 21, Buffer, strlen(Buffer));
+		skp->Text(2 * W / 8, 19 * H / 21, "227", 3);
 		sprintf(Buffer, "%+06d", G->DEDA227);
-		skp->Text(2 * W / 8, 19 * H / 21, Buffer, strlen(Buffer));
+		skp->Text(3 * W / 8, 19 * H / 21, Buffer, strlen(Buffer));
 
 		if (G->target != NULL)
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -777,7 +777,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		int hh, mm;
 		double secs;
 
-		SStoHHMMSS(GC->rtcc->GETfromGMT(GC->rtcc->GetAGSClockZero()), hh, mm, secs); //Should be relative to LGC clock zero instead of liftoff time
+		OrbMech::SStoHHMMSS(GC->rtcc->GETfromGMT(GC->rtcc->GetAGSClockZero()), hh, mm, secs, 0.01); //Should be relative to LGC clock zero instead of liftoff time
 		sprintf(Buffer, "%d:%02d:%05.2f GET", hh, mm, secs);
 		skp->Text((int)(0.5 * W / 8), 10 * H / 14, Buffer, strlen(Buffer));
 
@@ -965,7 +965,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				int hh, mm;
 				double secs;
 
-				SStoHHMMSS(G->P30TIG, hh, mm, secs);
+				OrbMech::SStoHHMMSS(G->P30TIG, hh, mm, secs, 0.01);
 
 				skp->Text(7 * W / 8, 3 * H / 26, "N47", 3);
 				skp->Text(7 * W / 8, 4 * H / 26, "N48", 3);
@@ -993,7 +993,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text((int)(3.5 * W / 8), 6 * H / 26, Buffer, strlen(Buffer));
 				sprintf(Buffer, "%+06d MIN", mm);
 				skp->Text((int)(3.5 * W / 8), 7 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+06.0f SEC", secs * 100.0);
+				sprintf(Buffer, "%+07.2f SEC", secs);
 				skp->Text((int)(3.5 * W / 8), 8 * H / 26, Buffer, strlen(Buffer));
 
 				sprintf(Buffer, "%+07.1f DVX", G->dV_LVLH.x / 0.3048);
@@ -1018,7 +1018,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+07.1f VT", G->manpad.Vt);// length(G->dV_LVLH) / 0.3048);
 				skp->Text((int)(3.5 * W / 8), 17 * H / 26, Buffer, strlen(Buffer));
 
-				SStoHHMMSS(G->manpad.burntime, hh, mm, secs);
+				OrbMech::SStoHHMMSS(G->manpad.burntime, hh, mm, secs);
 
 				sprintf(Buffer, "XXX%d:%02.0f BT (MIN:SEC)", mm, secs);
 				skp->Text((int)(3.5 * W / 8), 18 * H / 26, Buffer, strlen(Buffer));
@@ -1092,13 +1092,13 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				int hh, mm;
 				double secs;
 
-				SStoHHMMSS(G->P30TIG, hh, mm, secs);
+				OrbMech::SStoHHMMSS(G->P30TIG, hh, mm, secs, 0.01);
 
 				sprintf(Buffer, "%+06d HRS GETI", hh);
 				skp->Text((int)(3.5 * W / 8), 5 * H / 26, Buffer, strlen(Buffer));
 				sprintf(Buffer, "%+06d MIN", mm);
 				skp->Text((int)(3.5 * W / 8), 6 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+06.0f SEC", secs * 100.0);
+				sprintf(Buffer, "%+07.2f SEC", secs);
 				skp->Text((int)(3.5 * W / 8), 7 * H / 26, Buffer, strlen(Buffer));
 
 				sprintf(Buffer, "%+07.1f DVX", G->dV_LVLH.x / 0.3048);
@@ -1116,7 +1116,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+07.1f DVR", length(G->dV_LVLH) / 0.3048);
 				skp->Text((int)(3.5 * W / 8), 13 * H / 26, Buffer, strlen(Buffer));
 
-				SStoHHMMSS(G->lmmanpad.burntime, hh, mm, secs);
+				OrbMech::SStoHHMMSS(G->lmmanpad.burntime, hh, mm, secs);
 
 				sprintf(Buffer, "XXX%d:%02.0f BT", mm, secs);
 				skp->Text((int)(3.5 * W / 8), 14 * H / 26, Buffer, strlen(Buffer));
@@ -1163,7 +1163,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			int hh, mm; // ss;
 			double secs;
 
-			SStoHHMMSS(G->P30TIG, hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->P30TIG, hh, mm, secs, 0.01);
 
 			skp->Text(7 * W / 8, 3 * H / 20, "N37", 3);
 
@@ -1171,7 +1171,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			skp->Text(3 * W / 8, 3 * H / 20, Buffer, strlen(Buffer));
 			sprintf(Buffer, "%+06d MIN", mm);
 			skp->Text(3 * W / 8, 4 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+06.0f SEC", secs * 100.0);
+			sprintf(Buffer, "%+07.2f SEC", secs);
 			skp->Text(3 * W / 8, 5 * H / 20, Buffer, strlen(Buffer));
 
 			sprintf(Buffer, "%+07.1f DVX", G->dV_LVLH.x / 0.3048);
@@ -1240,7 +1240,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 
 				double secs;
 				int mm, hh;
-				SStoHHMMSS(G->tlipad.BurnTime, hh, mm, secs);
+				OrbMech::SStoHHMMSS(G->tlipad.BurnTime, hh, mm, secs);
 
 				sprintf(Buffer, "XXX%d:%02.0f BT", mm, secs);
 				skp->Text(3 * W / 8, 7 * H / 20, Buffer, strlen(Buffer));
@@ -1301,7 +1301,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				int hh, mm; // ss;
 				double secs;
 
-				SStoHHMMSS(G->pdipad.GETI, hh, mm, secs);
+				OrbMech::SStoHHMMSS(G->pdipad.GETI, hh, mm, secs, 0.01);
 
 				skp->Text(3 * W / 8, 5 * H / 20, "HRS", 3);
 				skp->Text((int)(4.5 * W / 8), 5 * H / 20, "TIG", 3);
@@ -1314,10 +1314,10 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text(6 * W / 8, 6 * H / 20, Buffer, strlen(Buffer));
 
 				skp->Text(3 * W / 8, 7 * H / 20, "SEC", 3);
-				sprintf(Buffer, "%+06.0f", secs * 100.0);
+				sprintf(Buffer, "%+07.2f", secs);
 				skp->Text(6 * W / 8, 7 * H / 20, Buffer, strlen(Buffer));
 
-				SStoHHMMSS(G->pdipad.t_go, hh, mm, secs);
+				OrbMech::SStoHHMMSS(G->pdipad.t_go, hh, mm, secs);
 				skp->Text(3 * W / 8, 8 * H / 20, "TGO", 3);
 				skp->Text((int)(4.5 * W / 8), 8 * H / 20, "N61", 3);
 				sprintf(Buffer, "XX%02d:%02.0f", mm, secs);
@@ -1376,7 +1376,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			double secs;
 			int mm, hh;
 
-			SStoHHMMSS(G->earthentrypad.Ret05[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.Ret05[0], hh, mm, secs);
 
 			sprintf(Buffer, "XX%02d:%02.0f RET  .05G", mm, secs);
 			skp->Text(3 * W / 8, 10 * H / 32, Buffer, strlen(Buffer));
@@ -1386,7 +1386,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			sprintf(Buffer, "%+07.2f LONG", G->earthentrypad.Lng[0]);
 			skp->Text(3 * W / 8, 12 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->earthentrypad.Ret2[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.Ret2[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RET  .2G", mm, secs);
 			skp->Text(3 * W / 8, 13 * H / 32, Buffer, strlen(Buffer));
 
@@ -1396,19 +1396,19 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			sprintf(Buffer, "RR55/55 BANK AN");
 			skp->Text(3 * W / 8, 15 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->earthentrypad.RetRB[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.RetRB[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RET RB", mm, secs);
 			skp->Text(3 * W / 8, 16 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->earthentrypad.RetBBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.RetBBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETBBO", mm, secs);
 			skp->Text(3 * W / 8, 17 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->earthentrypad.RetEBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.RetEBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETEBO", mm, secs);
 			skp->Text(3 * W / 8, 18 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->earthentrypad.RetDrog[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.RetDrog[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETDROG", mm, secs);
 			skp->Text(3 * W / 8, 19 * H / 32, Buffer, strlen(Buffer));
 
@@ -1421,12 +1421,12 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			sprintf(Buffer, "%+06.0f VIO  .05G", G->earthentrypad.PB_VIO[0]);
 			skp->Text(3 * W / 8, 23 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->earthentrypad.PB_Ret05[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.PB_Ret05[0], hh, mm, secs);
 
 			sprintf(Buffer, "XX%02d:%02.0f RET  .05G", mm, secs);
 			skp->Text(3 * W / 8, 24 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->earthentrypad.PB_Ret2[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.PB_Ret2[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RET  .2G", mm, secs);
 			skp->Text(3 * W / 8, 25 * H / 32, Buffer, strlen(Buffer));
 
@@ -1436,19 +1436,19 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			sprintf(Buffer, "RR55/55 BANK AN");
 			skp->Text(3 * W / 8, 27 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->earthentrypad.PB_RetRB[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.PB_RetRB[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RET RB", mm, secs);
 			skp->Text(3 * W / 8, 28 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->earthentrypad.PB_RetBBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.PB_RetBBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETBBO", mm, secs);
 			skp->Text(3 * W / 8, 29 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->earthentrypad.PB_RetEBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.PB_RetEBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETEBO", mm, secs);
 			skp->Text(3 * W / 8, 30 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->earthentrypad.PB_RetDrog[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->earthentrypad.PB_RetDrog[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETDROG", mm, secs);
 			skp->Text(3 * W / 8, 31 * H / 32, Buffer, strlen(Buffer));
 
@@ -1545,7 +1545,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			double secs;
 			int mm, hh;
 
-			SStoHHMMSS(G->lunarentrypad.RET05[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->lunarentrypad.RET05[0], hh, mm, secs);
 
 			sprintf(Buffer, "XX%02d:%02.0f RET  .05G", mm, secs);
 			skp->Text(3 * W / 8, 18 * H / 32, Buffer, strlen(Buffer));
@@ -1565,19 +1565,19 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			sprintf(Buffer, "XXX%04.2f DO", G->lunarentrypad.DO[0]);
 			skp->Text(3 * W / 8, 23 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->lunarentrypad.RETVCirc[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->lunarentrypad.RETVCirc[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RET V CIRC", mm, secs);
 			skp->Text(3 * W / 8, 24 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->lunarentrypad.RETBBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->lunarentrypad.RETBBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETBBO", mm, secs);
 			skp->Text(3 * W / 8, 25 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->lunarentrypad.RETEBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->lunarentrypad.RETEBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETEBO", mm, secs);
 			skp->Text(3 * W / 8, 26 * H / 32, Buffer, strlen(Buffer));
 
-			SStoHHMMSS(G->lunarentrypad.RETDRO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(G->lunarentrypad.RETDRO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETDRO", mm, secs);
 			skp->Text(3 * W / 8, 27 * H / 32, Buffer, strlen(Buffer));
 
@@ -2672,13 +2672,13 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 
 			sprintf_s(Buffer, "%.1lf", tab->DVC / 0.3048);
 			skp->Text((13 + 12 * i) * W / 32, 14 * H / 32, Buffer, strlen(Buffer));
-			SStoHHMMSS(tab->dt, hh, mm, secs);
+			OrbMech::SStoHHMMSS(tab->dt, hh, mm, secs, 0.1);
 			sprintf_s(Buffer, "%02d:%02.1lf", mm, secs);
 			skp->Text((18 + 12 * i) * W / 32, 14 * H / 32, Buffer, strlen(Buffer));
 
 			sprintf_s(Buffer, "%.1lf", tab->dv / 0.3048);
 			skp->Text((13 + 12 * i) * W / 32, 15 * H / 32, Buffer, strlen(Buffer));
-			SStoHHMMSS(tab->dt_ullage, hh, mm, secs);
+			OrbMech::SStoHHMMSS(tab->dt_ullage, hh, mm, secs, 0.1);
 			sprintf_s(Buffer, "%+d %02d:%02.1lf", tab->NumQuads, mm, secs);
 			skp->Text((18 + 12 * i) * W / 32, 15 * H / 32, Buffer, strlen(Buffer));
 
@@ -3217,12 +3217,12 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		int hh, mm;
 		double secs;
 
-		SStoHHMMSS(G->t_LunarLiftoff, hh, mm, secs);
+		OrbMech::SStoHHMMSS(G->t_LunarLiftoff, hh, mm, secs, 0.01);
 		sprintf(Buffer, "%+06d HRS", hh);
 		skp->Text(2 * W / 8, 6 * H / 21, Buffer, strlen(Buffer));
 		sprintf(Buffer, "%+06d MIN TIG", mm);
 		skp->Text(2 * W / 8, 7 * H / 21, Buffer, strlen(Buffer));
-		sprintf(Buffer, "%+06.0f SEC", secs * 100.0);
+		sprintf(Buffer, "%+07.2f SEC", secs);
 		skp->Text(2 * W / 8, 8 * H / 21, Buffer, strlen(Buffer));
 
 		sprintf(Buffer, "%+07.1f V (HOR)", GC->rtcc->PZLTRT.InsertionHorizontalVelocity / 0.3048);
@@ -4279,7 +4279,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		}
 		else
 		{
-			GET_Display(Buffer, G->SVDesiredGET);
+			GET_Display2(Buffer, G->SVDesiredGET);
 		}
 		skp->Text(2 * W / 8, 4 * H / 28, Buffer, strlen(Buffer));
 		sprintf(Buffer, "%04d", tab->SequenceNumber);
@@ -4361,7 +4361,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		skp->Text(22 * W / 32, 21 * H / 28, Buffer, strlen(Buffer));
 		sprintf(Buffer, "%.1f", tab->sv.V.z);
 		skp->Text(22 * W / 32, 23 * H / 28, Buffer, strlen(Buffer));
-		GET_Display(Buffer, tab->sv.GMT, false);
+		GET_Display2(Buffer, tab->sv.GMT);
 		skp->Text(22 * W / 32, 25 * H / 28, Buffer, strlen(Buffer));
 	}
 	else if (screen == 49)
@@ -6508,7 +6508,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 
 		int hh, mm;
 		double ss;
-		SStoHHMMSS(tab->DT_B, hh, mm, ss);
+		OrbMech::SStoHHMMSS(tab->DT_B, hh, mm, ss, 0.1);
 		sprintf_s(Buffer, "%d:%04.1f", mm, ss);
 		skp->Text(28 * W / 64, 10 * H / 32, Buffer, strlen(Buffer));
 		sprintf_s(Buffer, "%.2f", tab->DT_U);
@@ -9058,7 +9058,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			skp->Text(16 * W / 44, 9 * H / 26, Buffer, strlen(Buffer));
 			sprintf_s(Buffer, "%.1lf", tab->DVC);
 			skp->Text(16 * W / 44, 10 * H / 26, Buffer, strlen(Buffer));
-			SStoHHMMSS(tab->BurnTime, hh, mm, secs);
+			OrbMech::SStoHHMMSS(tab->BurnTime, hh, mm, secs, 0.1);
 			sprintf_s(Buffer, "%02d:%04.1lf", mm, secs);
 			skp->Text(22 * W / 44, 10 * H / 26, Buffer, strlen(Buffer));
 			sprintf_s(Buffer, "%.1lf", tab->DVT);
@@ -9073,7 +9073,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			skp->Text(16 * W / 44, 13 * H / 26, Buffer, strlen(Buffer));
 			GET_Display(Buffer, tab->GMTI, false);
 			skp->Text(16 * W / 44, 14 * H / 26, Buffer, strlen(Buffer));
-			SStoHHMMSS(tab->RET400k, hh, mm, secs);
+			OrbMech::SStoHHMMSS(tab->RET400k, hh, mm, secs);
 			sprintf_s(Buffer, "%d:%02.0lf", mm, secs);
 			skp->Text(16 * W / 44, 15 * H / 26, Buffer, strlen(Buffer));
 			sprintf_s(Buffer, "%.0lf", tab->V400k);
@@ -9082,7 +9082,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			skp->Text(22 * W / 44, 16 * H / 26, Buffer, strlen(Buffer));
 			sprintf_s(Buffer, "%.1lf°", tab->BankAngle);
 			skp->Text(16 * W / 44, 17 * H / 26, Buffer, strlen(Buffer));
-			SStoHHMMSS(tab->RETRB, hh, mm, secs);
+			OrbMech::SStoHHMMSS(tab->RETRB, hh, mm, secs);
 			sprintf_s(Buffer, "%d:%02.0lf", mm, secs);
 			skp->Text(16 * W / 44, 18 * H / 26, Buffer, strlen(Buffer));
 			FormatLatitude(Buffer, tab->lat_ML);
@@ -9731,7 +9731,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			skp->Text(16 * W / 44, 9 * H / 26, Buffer, strlen(Buffer));
 			sprintf_s(Buffer, "%.1lf", tab->DVC_Sep);
 			skp->Text(16 * W / 44, 10 * H / 26, Buffer, strlen(Buffer));
-			SStoHHMMSS(tab->BurnTime_Sep, hh, mm, secs);
+			OrbMech::SStoHHMMSS(tab->BurnTime_Sep, hh, mm, secs, 0.1);
 			sprintf_s(Buffer, "%02d:%04.1lf", mm, secs);
 			skp->Text(22 * W / 44, 10 * H / 26, Buffer, strlen(Buffer));
 			sprintf_s(Buffer, "%.1lf", tab->DVT_Sep);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.cpp
@@ -141,8 +141,15 @@ namespace OrbMech{
 		return H*3600.0 + M*60.0 + S;
 	}
 
-	void SStoHHMMSS(double time, int &hours, int &minutes, double &seconds)
+	double round_to(double value, double precision)
 	{
+		return round(value / precision) * precision;
+	}
+
+	void SStoHHMMSS(double time, int &hours, int &minutes, double &seconds, double precision)
+	{
+		time = round_to(time, precision);
+
 		double mins;
 		hours = (int)trunc(time / 3600.0);
 		mins = fmod(time / 60.0, 60.0);
@@ -150,12 +157,32 @@ namespace OrbMech{
 		seconds = (mins - minutes) * 60.0;
 	}
 
-	void SStoHHMMSSTH(double time, int &hours, int &minutes, double &seconds)
+	// Format time to HHH:MM:SS.
+	void format_time(char *buf, double time)
 	{
-		int cs = (int)(round(time*100.0));
-		hours = cs / 360000;
-		minutes = (cs - 360000 * hours) / 6000;
-		seconds = (double)(cs - 360000 * hours - 6000 * minutes) / 100.0;
+		buf[0] = 0; // Clobber
+		if (time < 0) { return; } // don't do that
+
+		int hours, minutes;
+		double seconds;
+
+		SStoHHMMSS(time, hours, minutes, seconds);
+
+		sprintf(buf, "%03d:%02d:%02.0lf", hours, minutes, seconds);
+	}
+
+	// Format precise time.
+	void format_time_prec(char *buf, double time)
+	{
+		buf[0] = 0; // Clobber
+		if (time < 0) { return; } // don't do that
+
+		int hours, minutes;
+		double seconds;
+
+		SStoHHMMSS(time, hours, minutes, seconds, 0.01);
+
+		sprintf(buf, "HRS XXX%03d\nMIN XXXX%02d\nSEC XX%05.2f", hours, minutes, seconds);
 	}
 
 	void adbar_from_rv(double rmag, double vmag, double rtasc, double decl, double fpav, double az, VECTOR3 &R, VECTOR3 &V)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.h
@@ -377,10 +377,6 @@ namespace OrbMech {
 	double trunc(double d);
 	void normalizeAngle(double &a, bool positive = true);
 	double quadratic(double *T, double *DV);
-	double HHMMSSToSS(int H, int M, int S);
-	double HHMMSSToSS(double H, double M, double S);
-	void SStoHHMMSS(double time, int &hours, int &minutes, double &seconds);
-	void SStoHHMMSSTH(double time, int &hours, int &minutes, double &seconds);
 	void adbar_from_rv(double rmag, double vmag, double rtasc, double decl, double fpav, double az, VECTOR3 &R, VECTOR3 &V);
 	void rv_from_adbar(VECTOR3 R, VECTOR3 V, double &rmag, double &vmag, double &rtasc, double &decl, double &fpav, double &az);
 	VECTOR3 LMDockedCoarseAlignment(VECTOR3 csmang, bool samerefs);
@@ -440,6 +436,14 @@ namespace OrbMech {
 	double SumQuad(double *x, int N);
 	double QuadSum(double *x, int N);
 	void DROOTS(double A, double B, double C, double D, double E, int N, double *x, int &M, int &I);
+
+	//Time formatting functions
+	double HHMMSSToSS(int H, int M, int S);
+	double HHMMSSToSS(double H, double M, double S);
+	double round_to(double value, double precision = 1.0);
+	void SStoHHMMSS(double time, int &hours, int &minutes, double &seconds, double precision = 1.0);
+	void format_time(char *buf, double time);
+	void format_time_prec(char *buf, double time);
 }
 
 inline CELEMENTS operator+(const CELEMENTS &a, const CELEMENTS &b)


### PR DESCRIPTION
…, minutes, seconds with selectable precision

@jalexb88 you will have to do a change to your Apollo 17 MCC file for this. Any use of the function "SStoHHMMSS" now rounds to full seconds by default. If you want something more precise it has to be selected, like for the "GROUND LIFTOFF TIME UPDATE" that the MCC does for each mission.

Testing for this PR would involve checking various places in the MCC and RTCC MFD to see that the time formatting on displays is still correct.

Here is the general issue that this tries to fix.

Before:
![image](https://github.com/orbiternassp/NASSP/assets/13571607/07e56e66-87bd-4c41-9a67-e2f5006875eb)

After:
![image](https://github.com/orbiternassp/NASSP/assets/13571607/43d2db77-617a-47cc-aa8b-e937f72ada84)
