### PR TITLE
yaAGC: Implement internally-timed RADARUPTs

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -779,7 +779,6 @@ void Saturn::SystemsTimestep(double simt, double simdt, double mjd) {
 		omnic.TimeStep();
 		omnid.TimeStep();
 		if (pMission->CSMHasVHFRanging()) vhfranging.TimeStep(simdt);
-		agc.RadarRead();
 		vhftransceiver.Timestep();
 		sce.Timestep();
 		dataRecorder.TimeStep( MissionTime, simdt );

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -1534,7 +1534,6 @@ void LEM::SystemsTimestep(double simt, double simdt)
 	optics.Timestep(simdt);
 	LR.Timestep(simdt);
 	RR.Timestep(simdt);
-	agc.RadarRead();
 	RadarTape.Timestep(simdt);
 	crossPointerLeft.Timestep(simdt);
 	crossPointerRight.Timestep(simdt);

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
@@ -323,6 +323,18 @@ typedef union
 	unsigned long word;
 } AGCState;
 
+//
+// Structure for additional yaAGC bits
+//
+
+typedef union
+{
+	struct {
+		unsigned RadarGateCounter:4;
+	} u;
+	unsigned long word;
+} AGCState2;
+
 void ApolloGuidance::SaveState(FILEHANDLE scn)
 
 {
@@ -371,6 +383,13 @@ void ApolloGuidance::SaveState(FILEHANDLE scn)
 	state.u.Trap32 = vagc.Trap32;
 
 	oapiWriteScenario_int(scn, "STATE", state.word);
+
+	AGCState2 state2;
+
+	state2.word = 0;
+	state2.u.RadarGateCounter = vagc.RadarGateCounter;
+
+	oapiWriteScenario_int(scn, "ADDSTATE", state2.word);
 
 	//
 	// Write out any non-zero EMEM state.
@@ -541,6 +560,12 @@ void ApolloGuidance::LoadState(FILEHANDLE scn)
 			vagc.Trap31A = state.u.Trap31A;
 			vagc.Trap31B = state.u.Trap31B;
 			vagc.Trap32 = state.u.Trap32;
+		}
+		else if (!strnicmp(line, "ADDSTATE", 8)) {
+			AGCState2 state;
+			sscanf(line + 8, "%d", &state.word);
+
+			vagc.RadarGateCounter = state.u.RadarGateCounter;
 		}
 		else if (!strnicmp (line, "ONAME", 5)) {
 			strncpy (OtherVesselName, line + 6, 64);
@@ -787,17 +812,14 @@ void ApolloGuidance::RadarRead()
 {
 	ChannelValue val13 = GetInputChannel(013);
 
-	if (val13[RangeUnitActivity] == 1) {
-		int radarBits = 0;
-		if (val13[RangeUnitSelectA] == 1) { radarBits |= 1; }
-		if (val13[RangeUnitSelectB] == 1) { radarBits |= 2; }
-		if (val13[RangeUnitSelectC] == 1) { radarBits |= 4; }
+	int radarBits = 0;
+	if (val13[RangeUnitSelectA] == 1) { radarBits |= 1; }
+	if (val13[RangeUnitSelectB] == 1) { radarBits |= 2; }
+	if (val13[RangeUnitSelectC] == 1) { radarBits |= 4; }
 
-		GetRadarData(radarBits);
+	GetRadarData(radarBits);
 
-		SetInputChannelBit(013, RangeUnitActivity, 0);
-		RaiseInterrupt(ApolloGuidance::Interrupt::RADARUPT);
-	}
+	//sprintf(oapiDebugString(), "%lf %d %o %d", oapiGetSimTime(), radarBits, vagc.Erasable[0][RegRNRAD], vagc.Erasable[0][RegRNRAD]);
 }
 
 //
@@ -1007,5 +1029,13 @@ int ChannelInput (agc_t *State)
 void ChannelRoutine (agc_t *State)
 
 {
+}
+
+void RequestRadarData(agc_t *State)
+{
+	ApolloGuidance *agc;
+
+	agc = (ApolloGuidance *)State->agc_clientdata;
+	agc->RadarRead();
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.cpp
@@ -389,7 +389,7 @@ void ApolloGuidance::SaveState(FILEHANDLE scn)
 	state2.word = 0;
 	state2.u.RadarGateCounter = vagc.RadarGateCounter;
 
-	oapiWriteScenario_int(scn, "ADDSTATE", state2.word);
+	oapiWriteScenario_int(scn, "STATE2", state2.word);
 
 	//
 	// Write out any non-zero EMEM state.
@@ -459,6 +459,7 @@ void ApolloGuidance::LoadState(FILEHANDLE scn)
 
 {
 	char	*line;
+	int inttemp;
 
 	//
 	// Now load the data.
@@ -529,9 +530,11 @@ void ApolloGuidance::LoadState(FILEHANDLE scn)
 			sscanf(line+8, "%d", &val);
 			vagc.InterruptRequests[num] = val;
 		}
-		else if (!strnicmp (line, "STATE", 5)) {
+		else if (papiReadScenario_int(line, "STATE", inttemp))
+		{
 			AGCState state;
-			sscanf (line+5, "%d", &state.word);
+
+			state.word = inttemp;
 
 			Reset = state.u.Reset;
 			isFirstTimestep = (state.u.isFirstTimestep != 0);
@@ -561,9 +564,11 @@ void ApolloGuidance::LoadState(FILEHANDLE scn)
 			vagc.Trap31B = state.u.Trap31B;
 			vagc.Trap32 = state.u.Trap32;
 		}
-		else if (!strnicmp(line, "ADDSTATE", 8)) {
+		else if (papiReadScenario_int(line, "STATE2", inttemp))
+		{
 			AGCState2 state;
-			sscanf(line + 8, "%d", &state.word);
+
+			state.word = inttemp;
 
 			vagc.RadarGateCounter = state.u.RadarGateCounter;
 		}

--- a/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/apolloguidance.h
@@ -262,9 +262,6 @@ public:
 
 	virtual void ProcessIMUCDUReadCount(int channel, int val);
 
-	/// Resets the radar activity bit, reads radar data and causes the RADARUPT. Should be called after the radar timesteps
-	void RadarRead();
-
 	///
 	/// \brief Triggers Virtual AGC core dump
 	///
@@ -374,6 +371,9 @@ public:
 	void GenericWriteMemory(unsigned int loc, int val);
 
 	int16_t ConvertDecimalToAGCOctal(double x, bool highByte);
+
+	/// Read radar data upon request
+	void RadarRead();
 
 	///
 	/// \brief Are we running the reset program?

--- a/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine.c
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine.c
@@ -373,6 +373,12 @@
 				correctly exit standby, due to corruption of the
 				first instruction at address 4000 (usually by a
 				non-zero IndexValue).
+		01/29/24 MAS	Added simulation of RADARUPT. Unlike other
+				interrupts, RADARUPT is automatically generated
+				internally by the AGC itself once a full radar
+				cycle has had time to complete. This is important
+				when running ropes sensitive to this timing,
+				like Artemis and Skylark.
 
   
   The technical documentation for the Apollo Guidance & Navigation (G&N) system,
@@ -2130,6 +2136,11 @@ agc_engine (agc_t * State)
 			  State->ExtraDelay++;
 			  if (CounterPINC(&c(RegTIME5)))
 				  State->InterruptRequests[2] = 1;
+
+			  // Synchronously with TIME5, if radar activity is enabled,
+			  // increment the radar gate counter.
+			  if (State->InputChannel[013] & 010)
+				  State->RadarGateCounter++;
 		  }
 		// TIME4 is the same as TIME3, but 7.5ms out of phase
 		if (010 == (037 & State->InputChannel[ChanSCALER1]))
@@ -2171,6 +2182,22 @@ agc_engine (agc_t * State)
 		  }
 	  }
 
+	  // Similarly, check for radar cycle completion. As with HANDRUPT, the
+	  // timing here is slightly off (early by ~13 MCT), but this should
+	  // not be enough to matter.
+	  if ((State->RadarGateCounter == 9) && (036 == (037 & State->InputChannel[ChanSCALER1])))
+	  {
+		  // Completion of a radar cycle triggers the following actions:
+		  // 1. The radar gate counter is set back to 0.
+		  // 2. The radar activity bit (bit 4 of channel 13) is reset.
+		  // 3. Data from the radar is shifted into the RNRAD counter
+		  //    (this is expected to be performed by RequestRadarData().
+		  // 4. RADARUPT is set pending.
+		  State->RadarGateCounter = 0;
+		  State->InputChannel[013] &= ~010;
+		  RequestRadarData(State);
+		  State->InterruptRequests[9] = 1; // RADARUPT
+	  }
 
       // If we triggered any alarms, simulate a GOJAM
 	  if (TriggeredAlarm || State->ParityFail)

--- a/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine.h
@@ -108,6 +108,8 @@
 						which is the logical OR of channel 11 bit 4 and
 						channel 30 bit 15. The AGC did this internally
 						so the light would still work in standby.
+		01/29/24 MAS	Added the 4-bit RadarGateCounter for timing
+						RADARUPT generation.
    
   For more insight, I'd highly recommend looking at the documents
   http://hrst.mit.edu/hrs/apollo/public/archive/1689.pdf and
@@ -374,6 +376,7 @@ typedef struct
   unsigned Trap31A:1;           // Enable flag for Trap 31A
   unsigned Trap31B:1;           // Enable flag for Trap 31B
   unsigned Trap32:1;            // Enable flag for Trap 32
+  unsigned RadarGateCounter:4;  // Counter tracking radar cycle progress
   uint32_t WarningFilter;       // Current voltage of the AGC warning filter
   uint64_t /*unsigned long long */ DownruptTime;	// Time when next DOWNRUPT occurs.
   int NextZ;                    // Next value for the Z register
@@ -747,6 +750,7 @@ int ChannelInput (agc_t * State);
 void ChannelRoutine (agc_t *State);
 void ChannelRoutineGeneric (void *State, void (*UpdatePeripherals) (void *, Client_t *));
 void ShiftToDeda (agc_t *State, int Data);
+void RequestRadarData(agc_t *State);
 
 // DS20060903 Make these available externally
 int CounterPINC (int16_t * Counter);

--- a/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine_init.c
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/yaAGC/agc_engine_init.c
@@ -71,6 +71,7 @@
 		04/16/17 MAS    Added initialization of warning filter variables.
 		05/16/17 MAS    Enabled interrupts at startup.
 		07/13/17 MAS	Added initialization of the three HANDRUPT traps.
+		01/29/24 MAS	Added initialization of RadarGateCounter.
 */
 
 #include <stdio.h>
@@ -254,6 +255,8 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   State->Trap31A = 0;
   State->Trap31B = 0;
   State->Trap32 = 0;
+
+  State->RadarGateCounter = 0;
 
   if (CoreDump != NULL)
     {


### PR DESCRIPTION
Co-authored-by: thewonderidiot

Changes behavior of all radars (RR, LR, VHF ranging). It will fix instances where the radar interrupt previously happened too late (1210 alarms caused by the LR spurious routine) and when it happens too early (Skylark R27).