### PR TITLE
Force a time acceleration of 1.0x max from T-30 seconds to Guidance Reference Release (T-17 seconds)

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/LC34.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/LC34.cpp
@@ -282,8 +282,14 @@ void LC34::clbkPreStep(double simt, double simdt, double mjd)
 
 		if (sat) sat->ActivatePrelaunchVenting();
 
-		///GRR should happen at a fairly precise time and usually happens on the next timestep, so adding oapiGetSimStep is a decent solution
-		if (MissionTime >= -(17.0 + oapiGetSimStep()))
+		//Enforce 1.0x time acceleration for GRR
+		if (MissionTime >= -30.0 && oapiGetTimeAcceleration() > 1.0)
+		{
+			oapiSetTimeAcceleration(1.0);
+		}
+
+		//Send Prepare to Launch signal and then at T-17 seconds the GRR signal
+		if (MissionTime >= -17.0)
 		{
 			IuESE->SetGuidanceReferenceRelease(true);
 		}
@@ -416,7 +422,7 @@ void LC34::clbkPreStep(double simt, double simdt, double mjd)
 				}
 			}
 
-			if (bCommit == false && MissionTime >= (-0.05 - simdt))
+			if (bCommit == false && MissionTime >= -0.05)
 			{
 				if (Commit())
 				{

--- a/Orbitersdk/samples/ProjectApollo/src_launch/LC37.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/LC37.cpp
@@ -204,8 +204,14 @@ void LC37::clbkPreStep(double simt, double simdt, double mjd)
 	case STATE_CMARM2:
 		if (abort) break; // Don't do anything if we have aborted.
 
-		//GRR should happen at a fairly precise time and usually happens on the next timestep, so adding oapiGetSimStep is a decent solution
-		if (MissionTime >= -(17.0 + oapiGetSimStep()))
+		//Enforce 1.0x time acceleration for GRR
+		if (MissionTime >= -30.0 && oapiGetTimeAcceleration() > 1.0)
+		{
+			oapiSetTimeAcceleration(1.0);
+		}
+
+		//Send Prepare to Launch signal and then at T-17 seconds the GRR signal
+		if (MissionTime >= -17.0)
 		{
 			IuESE->SetGuidanceReferenceRelease(true);
 		}

--- a/Orbitersdk/samples/ProjectApollo/src_launch/ML.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/ML.cpp
@@ -551,8 +551,14 @@ void ML::clbkPreStep(double simt, double simdt, double mjd) {
 
 		sat->ActivatePrelaunchVenting();
 
-		//GRR should happen at a fairly precise time and usually happens on the next timestep, so adding oapiGetSimStep is a decent solution
-		if (sat->GetMissionTime() >= -(17.0 + oapiGetSimStep()))
+		//Enforce 1.0x time acceleration for GRR
+		if (oapiGetTimeAcceleration() > 1.0)
+		{
+			oapiSetTimeAcceleration(1.0);
+		}
+
+		//Send Prepare to Launch signal and then at T-17 seconds the GRR signal
+		if (sat->GetMissionTime() >= -17.0)
 		{
 			IuESE->SetGuidanceReferenceRelease(true);
 		}
@@ -655,7 +661,7 @@ void ML::clbkPreStep(double simt, double simdt, double mjd) {
 			// Soft-Release Pin Dragging
 			HoldDownForce(sat->GetMissionTime());
 
-			if (bCommit == false && sat->GetMissionTime() >= (-0.05 - simdt))
+			if (bCommit == false && sat->GetMissionTime() >= -0.05)
 			{
 				if (Commit())
 				{


### PR DESCRIPTION
Currently there is some code in place that tried to compensate for a delay in the LVDC getting the GRR signal by sending it slightly early. If this is done at a high time acceleration and/or bad framerate however the signal might be early by more than 2 seconds (20 fps at 30x time accel). This causes IU state vector issues, likely because of a desync of the LV IMU being released and the LVDC processing GRR.

To ensure proper GRR timing a time acceleration of 1.0x maximum will be enforced in the seconds before GRR. The only alternative to this that I could see would be to add a bunch of complex code that ensures timing of signals between separate vessels, e.g. between the Mobile Launcher where the GRR signal is sent and the Saturn vessel where it is being received. A much simpler solution is to enforce 1.0x time acceleration for a few seconds, which also avoids these problems.
