### PR TITLE
RTCC: Temporary workaround for short burn simulation bug

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -15810,6 +15810,8 @@ int RTCC::PMMMPT(PMMMPTInput in, MPTManeuver &man)
 
 	int NPHASE = 1;
 
+	T = DT = 0.0;
+
 	if (MPTIsRCSThruster(in.Thruster))
 	{
 		in.DETU = 0.0;
@@ -16053,7 +16055,8 @@ RTCC_PMMMPT_9_A:
 	{
 		man.FrozenManeuverInd = true;
 	}
-	if (in.IterationFlag)
+	//Go to iterate logic if it was requested and the predicted main engine burn time is at least 10 seconds
+	if (in.IterationFlag && T - DT > 10.0)
 	{
 		goto RTCC_PMMMPT_12_A;
 	}


### PR DESCRIPTION
Currently the CSM/LM burn simulation in the RTCC is flawed in that it doesn't burn until the residuals are zero for maneuvers using the short burn constants (burn time < 6 seconds). When the iterate option is used for any maneuver transfer, for example with the RTE Digitials, then the maneuver is converged on the desired trajectory using these simulated burns. With residuals not getting zeroed this can lead to P30 Delta Vs that are off by a few feet per second for these short burns.

Fixing the CSM/LM burn simulation completely will take a lengthy rewrite of those functions, so as a temporary measure this update suppresses the iterate option if the predicted burn time is shorter than 10 seconds. 10 instead of 6 to not run into some case where the predicted burn time is slightly above 6 seconds but the converged one becomes slightly smaller than 6, again running into short burn constants logic.