### PR TITLE
Add back zeroing alt tape when signal removed (per A16 LM timeline)

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -2564,10 +2564,10 @@ void LEM_RadarTape::Timestep(double simdt) {
 			{
 				setRange(lem->LR.GetAltitude());
 			}
-			/*else
+			else
 			{
 				setRange(0);
-			}*/
+			}
 			if (lem->LR.IsVelocityDataGood())
 			{
 				setRate(lem->LR.GetAltitudeRate());


### PR DESCRIPTION
Based on the Apollo 16 LM timeline book, the altitude signal when removed appears to make the tapemeter drive to zero ("ALT - 0, POWER SIGNAL LIGHT ON, X-PNTRS - CENTERED") therefore this will be added back to the tapemeter code for the altitude signal. 

![image](https://github.com/orbiternassp/NASSP/assets/22916885/b81678b0-9606-4807-9768-3342256070af)
