### PR TITLE
CMC translation commands work in Accel Cmd

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/scs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/scs.cpp
@@ -3199,34 +3199,49 @@ void RJEC::TimeStep(double simdt){
 	bool CMTransferMotor2 = sat->secs.rcsc.GetCMTransferMotor2();
 	if (CMTransferMotor1 || CMTransferMotor2) sm_sep = true;
 
-	if ((S18_2 || thc_cw) && !sm_sep) {
-		if (sat->eca.thc_x < 16384) { // PLUS X
-			td[14] = true;
-			td[15] = true;
+	if (!sm_sep) {
+		//Pitch SCS-CMC Reaction Jet Control Logic
+		if (S18_2 || thc_cw || S8_1) {
+			if (sat->eca.thc_y > 49152) { // MINUS Y (FORWARD)
+				td[1] = true;
+				td[2] = true;
+			}
+			if (sat->eca.thc_y < 16384) { // PLUS Y (BACKWARD)
+				td[3] = true;
+				td[4] = true;
+			}
 		}
-		if (sat->eca.thc_x > 49152) { // MINUS X
-			td[16] = true;
-			td[13] = true;
+
+		//Yaw SCS-CMC Reaction Jet Control Logic
+		if (S18_2 || thc_cw || S9_1) {
+			if (sat->eca.thc_y > 49152) { // MINUS Y (FORWARD)
+				td[5] = true;
+				td[6] = true;
+			}
+			if (sat->eca.thc_y < 16384) { // PLUS Y (BACKWARD)
+				td[7] = true;
+				td[8] = true;
+			}
 		}
-		if (sat->eca.thc_y > 49152) { // MINUS Y (FORWARD)
-			td[1] = true;
-			td[2] = true;
-			td[5] = true;
-			td[6] = true;
-		}
-		if (sat->eca.thc_y < 16384) { // PLUS Y (BACKWARD)
-			td[3] = true;
-			td[4] = true;
-			td[7] = true;
-			td[8] = true;
-		}
-		if (sat->eca.thc_z > 49152) { // MINUS Z (UP)
-			td[11] = true;
-			td[12] = true;
-		}
-		if (sat->eca.thc_z < 16384) { // PLUS Z (DOWN)
-			td[9] = true;
-			td[10] = true;
+
+		//Roll SCS-CMC Reaction Jet Control Logic
+		if (S18_2 || thc_cw || S10_1) {
+			if (sat->eca.thc_x < 16384) { // PLUS X
+				td[14] = true;
+				td[15] = true;
+			}
+			if (sat->eca.thc_x > 49152) { // MINUS X
+				td[16] = true;
+				td[13] = true;
+			}
+			if (sat->eca.thc_z > 49152) { // MINUS Z (UP)
+				td[11] = true;
+				td[12] = true;
+			}
+			if (sat->eca.thc_z < 16384) { // PLUS Z (DOWN)
+				td[9] = true;
+				td[10] = true;
+			}
 		}
 	}
 


### PR DESCRIPTION
With the previous behavior CMC translation commands were inhibited if the Manual Attitude switch for an axis was set to Accel Cmd. SCS translations weren't affected.

This behavior is wrong as the RJEC switches to an (Accel Cmd only) SCS mode on an axis per axis basis. Any translation commands for the specific axis are then actually processed through the SCS electronics and aren't coming from the CMC anymore. That way, even with S/C control set to CMC, translations still work. 