### PR TITLE
RTCC: Fix wrong CG location for docked burn simulation

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -2691,7 +2691,7 @@ public:
 	//Maneuver direct input and confirmation math module
 	int PMMMCD(PMMMCDInput in, MPTManeuver &man);
 	//Impulsive Maneuver Transfer Math Module
-	int PMMMPT(PMMMPTInput in, MPTManeuver &man);
+	int PMMMPT(PMMMPTInput &in, MPTManeuver &man);
 	//Lunar Ascent Integrator
 	int PMMLAI(PMMLAIInput in, RTCCNIAuxOutputTable &aux, EphemerisDataTable2 *E = NULL);
 	//LM Lunar Descent Numerical Integration Module


### PR DESCRIPTION
This PR fixes certain cases where the wrong LM weight is given to the Impulsive Maneuver Transfer Math Module PMMMPT. This lead to a wrong CG location of the combined CSM+LM being calculated, which in turns gives wrong SPS trim gimbal angles and with that a possibly incorrect attitude at ignition for maneuvers. The total weight used in burn simulations was always correct, just the LM weight used for the CG calculation was not.

This case was found in the calculation of a docked (CSM + LM ascent stage) TEI burn. If the option is chosen to calculate a TEI REFSMMAT (attitude 180, 0, 0 at ignition with heads down) then an inconsistent burn attitude due to this LM mass issue was calculated. The RTE Digitals then showed an attitude that was 1-2° off from the desired 180, 0, 0.

Also changed in this PR is that PMMMPT changes the masses on the input table to the burnout masses. This is useful in the case multiple maneuvers are transferred to the MPT at once (currently only the case with the TI Processor in our RTCC). After the first call to PMMMPT the masses have been updated and will then be used as the initial masses for the second maneuver, the second call of PMMMPT.