### PR TITLE
A few small RTCC additions/fixes

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -12385,14 +12385,14 @@ void RTCC::MPTMassUpdate(VESSEL *vessel, MED_M50 &med1, MED_M55 &med2, MED_M49 &
 						cfg = "CL";
 						lmapsmass = lem->AscentFuelMassKg;
 						lmdpsmass = lm->GetPropellantMass(lm->GetPropellantHandleByIndex(0));
+						lmrcsmass = lm->GetPropellantMass(lm->GetPropellantHandleByIndex(1)) + lm->GetPropellantMass(lm->GetPropellantHandleByIndex(2));
 					}
 					else
 					{
 						cfg = "CA";
-						lmapsmass = lm->GetPropellantMass(lm->GetPropellantHandleByIndex(0));
+						lmapsmass = lm->GetPropellantMass(lm->GetPropellantHandleByIndex(2));
+						lmrcsmass = lm->GetPropellantMass(lm->GetPropellantHandleByIndex(0)) + lm->GetPropellantMass(lm->GetPropellantHandleByIndex(1));
 					}
-
-					lmrcsmass = lm->GetPropellantMass(lm->GetPropellantHandleByIndex(1)) + lm->GetPropellantMass(lm->GetPropellantHandleByIndex(2));
 				}
 				else
 				{
@@ -12432,6 +12432,7 @@ void RTCC::MPTMassUpdate(VESSEL *vessel, MED_M50 &med1, MED_M55 &med2, MED_M49 &
 			}
 			lmapsmass = lem->AscentFuelMassKg;
 			lmdpsmass = lem->GetPropellantMass(lem->GetPropellantHandleByIndex(0));
+			lmrcsmass = vessel->GetPropellantMass(vessel->GetPropellantHandleByIndex(1)) + vessel->GetPropellantMass(vessel->GetPropellantHandleByIndex(2));
 		}
 		else
 		{
@@ -12443,10 +12444,9 @@ void RTCC::MPTMassUpdate(VESSEL *vessel, MED_M50 &med1, MED_M55 &med2, MED_M49 &
 			{
 				cfg = "A";
 			}
-			lmapsmass = lem->GetPropellantMass(lem->GetPropellantHandleByIndex(0));
+			lmapsmass = lem->GetPropellantMass(lem->GetPropellantHandleByIndex(2));
+			lmrcsmass = vessel->GetPropellantMass(vessel->GetPropellantHandleByIndex(0)) + vessel->GetPropellantMass(vessel->GetPropellantHandleByIndex(1));
 		}
-
-		lmrcsmass = vessel->GetPropellantMass(vessel->GetPropellantHandleByIndex(1)) + vessel->GetPropellantMass(vessel->GetPropellantHandleByIndex(2));
 
 		if (cfg[0] == 'C')
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -3322,7 +3322,7 @@ public:
 		unsigned ManeuverNumber = 1; //Maneuver number in LOI or MCC table
 		int Thruster = RTCC_ENGINETYPE_CSMSPS; //Thruster for maneuver
 		int Attitude = RTCC_ATTITUDE_PGNS_EXDV; //Attitude option
-		double UllageDT = -1;	//Delta T of Ullage
+		double UllageDT = 0.0;	//Delta T of Ullage
 		bool UllageQuads = true;//false = 2 thrusters, true = 4 thrusters
 		bool Iteration = false; //false = do not iterate, true = iterate
 		double TenPercentDT = 26.0;	//Delta T of 10% thrust for the DPS

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/AnalyticEphemerisGenerator.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/AnalyticEphemerisGenerator.cpp
@@ -309,7 +309,7 @@ void PMMLAEG::CALL(AEGHeader &header, AEGDataBlock &in, AEGDataBlock &out)
 
 	header.ErrorInd = 0;
 
-	if (in.coe_osc.a<0.27*OrbMech::R_Earth || in.coe_osc.a > 5.0*OrbMech::R_Earth)
+	if (in.coe_osc.a < 0.2*OrbMech::R_Earth || in.coe_osc.a > 5.0*OrbMech::R_Earth)
 	{
 		goto NewPMMLAEG_V846;
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -6626,6 +6626,13 @@ void ApolloRTCCMFD::menuSetLmkLng()
 	GenericDoubleInput(&G->LmkLng, "Choose the landmark longitude:", RAD);
 }
 
+void ApolloRTCCMFD::menuLmkUseLandingSite()
+{
+	//Load RTCC stored landing site coordinates into input for P22 PAD
+	G->LmkLat = GC->rtcc->BZLAND.lat[0];
+	G->LmkLng = GC->rtcc->BZLAND.lng[0];
+}
+
 void ApolloRTCCMFD::menuSetLDPPVectorTime()
 {
 	if (GC->MissionPlanningActive)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -279,6 +279,7 @@ public:
 	void menuSetLmkTime();
 	void menuSetLmkLat();
 	void menuSetLmkLng();
+	void menuLmkUseLandingSite();
 	void menuLmkPADCalc();
 	void menuSetTargetingMenu();
 	void menuSetPADMenu();

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
@@ -449,7 +449,7 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 		{ "T1 guess", 0, 'T' },
 		{ "Landmark Latitude", 0, 'A' },
 		{ "Landmark Longitude", 0, 'O' },
-		{ "", 0, ' ' },
+		{ "Load landing site coordinates", 0, 'D' },
 		{ "", 0, ' ' },
 		{ "", 0, ' ' },
 
@@ -466,7 +466,7 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 	RegisterFunction("TIM", OAPI_KEY_T, &ApolloRTCCMFD::menuSetLmkTime);
 	RegisterFunction("LAT", OAPI_KEY_A, &ApolloRTCCMFD::menuSetLmkLat);
 	RegisterFunction("LNG", OAPI_KEY_O, &ApolloRTCCMFD::menuSetLmkLng);
-	RegisterFunction("", OAPI_KEY_D, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("LLS", OAPI_KEY_D, &ApolloRTCCMFD::menuLmkUseLandingSite);
 	RegisterFunction("", OAPI_KEY_E, &ApolloRTCCMFD::menuVoid);
 	RegisterFunction("", OAPI_KEY_F, &ApolloRTCCMFD::menuVoid);
 


### PR DESCRIPTION
-Adjust lower limit of semi-major axis for lunar AEG; some LM deorbit trajectories with the GPM processor ran into the limit
-Default ullage duration for MCCs and LOIs to zero seconds
-Fix LM ascent stage MPT propellant mass update
-Add button to P22 PAD page to load the landing site coordinates as the P22 target