### PR TITLE
RTCC numerical integration control module: Minimum number of ephemeris points is now written, if desired

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -13427,7 +13427,7 @@ void RTCC::PMXSPT(std::string source, int n)
 		break;
 	case 65:
 		message.push_back("AEG/PIATSU ERROR - LONGITUDE OF ASCENDING NODE HAS BEEN");
-		message.push_back("ZEROED FOR MANEUVER" + RTCCONLINEMON.TextBuffer[0]);
+		message.push_back("ZEROED FOR MANEUVER " + RTCCONLINEMON.TextBuffer[0]);
 		break;
 	case 66:
 		message.push_back("MANEUVER " + RTCCONLINEMON.TextBuffer[0] + " OVERLAPS PREVIOUS MPT MANEUVER - WILL");
@@ -17606,6 +17606,8 @@ void RTCC::EMSEPH(int QUEID, StateVectorTableEntry &sv, int &L, double PresentGM
 				if (IsKickout[num] == false)
 				{
 					InTable.NIAuxOutputTable.TerminationCode = 7; //To make it continue processing
+					InTable.EphemerisLeftLimitGMT = InTable.AnchorVector.GMT; //Write more ephemeris, starting at current time
+
 					if (num == BODY_EARTH)
 					{
 						InTable.EarthRelStopParam = 50000.0*0.3048;
@@ -17688,6 +17690,17 @@ void RTCC::EMSEPH(int QUEID, StateVectorTableEntry &sv, int &L, double PresentGM
 
 		//Update mission plan table display
 		PMDMPT();
+
+		/*
+		//Debug code
+		char Buffer[256];
+		oapiWriteLog("Ephemeris Points Delta T:");
+		for (unsigned j = 1; j < table->EPHEM.table.size(); j++)
+		{
+			sprintf(Buffer, "%lf", table->EPHEM.table[j].GMT - table->EPHEM.table[j - 1].GMT);
+			oapiWriteLog(Buffer);
+		}
+		*/
 	}
 	StateVectorTableEntry sv_out;
 	sv_out.LandingSiteIndicator = InTable.NIAuxOutputTable.landed;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/EnckeIntegrator.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/EnckeIntegrator.cpp
@@ -60,6 +60,20 @@ void EnckeFreeFlightIntegrator::Propagate(EMMENIInputTable &in)
 	STOPVAE = in.EarthRelStopParam;
 	STOPVAM = in.MoonRelStopParam;
 	HMULT = in.IsForwardIntegration;
+	UseFixedStepLength = in.UseFixedStepLength;
+	FixedStepLength = in.FixedStepLength;
+	if (UseFixedStepLength)
+	{
+		//With integration fixed step length, turn off step size multiplier
+		if (HMULT >= 0.0)
+		{
+			HMULT = 1.0;
+		}
+		else
+		{
+			HMULT = -1.0;
+		}
+	}
 	DRAG = in.DensityMultiplier;
 	VENT = in.VentPerturbationFactor;
 	CSA = -0.5*in.Area*pRTCC->SystemParameters.MCADRG;
@@ -201,7 +215,14 @@ void EnckeFreeFlightIntegrator::Edit()
 EMMENI_Edit_3B:
 	TIME = abs(TRECT + tau);
 	rr = length(R);
-	dt_max = min(dt_lim, K*OrbMech::power(rr, 1.5) / sqrt(mu));
+	if (UseFixedStepLength)
+	{
+		dt_max = FixedStepLength;
+	}
+	else
+	{
+		dt_max = min(dt_lim, K*OrbMech::power(rr, 1.5) / sqrt(mu));
+	}
 
 	//Should we even check?
 	if (ISTOPS == 1)
@@ -329,6 +350,8 @@ EMMENI_Edit_4A:
 		{
 			RestoreVariables();
 		}
+		//Mark as bounding
+		INITE = 1;
 		//Go back to find new dt
 		goto EMMENI_Edit_3B;
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/EnckeIntegrator.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/EnckeIntegrator.h
@@ -38,6 +38,9 @@ struct EMMENIInputTable
 	double MinEphemDT = 0.0;
 	//Integration direction indicator (+X-forward, -X-backward)
 	double IsForwardIntegration = 1.0;
+	//Fixed integration step length
+	bool UseFixedStepLength = false;
+	double FixedStepLength = 10.0;
 	//Desired value of stopping parameter relative to the Earth
 	double EarthRelStopParam = 0.0;
 	//Desired value of stopping parameter relative to the Moon
@@ -149,6 +152,9 @@ private:
 	double r_SPH;
 	//Direction control and step size multiplier
 	double HMULT;
+	//Fixed integration step length
+	bool UseFixedStepLength;
+	double FixedStepLength;
 	//Divisor for termination control
 	double DEV;
 	//Density multiplier (0 if no drag)


### PR DESCRIPTION
Now adheres to this requirement:

![image](https://github.com/orbiternassp/NASSP/assets/13571607/428f5c72-b6d1-44c7-bb41-abbead0a2c36)

Also fixes two ephemeris writing bugs I found in the process of adding this feature.