### PR TITLE
Keyboard shortcuts refactor

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3461,64 +3461,64 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 
 	if (KEYMOD_SHIFT(kstate)){
 		// Do DSKY stuff
-		// Handle key up-down in one switch block
+		DSKYPushSwitch* dskyKeyChanged = nullptr;
 		switch (key) {
 			case OAPI_KEY_DECIMAL:
-				DskySwitchClear.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchClear;
 				break;
 			case OAPI_KEY_PRIOR:
-				DskySwitchReset.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchReset;
 				break;
 			case OAPI_KEY_HOME:
-				DskySwitchKeyRel.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchKeyRel;
 				break;
 			case OAPI_KEY_NUMPADENTER:
-				DskySwitchEnter.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchEnter;
 				break;
 			case OAPI_KEY_DIVIDE:
-				DskySwitchVerb.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchVerb;
 				break;
 			case OAPI_KEY_MULTIPLY:
-				DskySwitchNoun.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchNoun;
 				break;
 			case OAPI_KEY_ADD:
-				DskySwitchPlus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchPlus;
 				break;
 			case OAPI_KEY_SUBTRACT:
-				DskySwitchMinus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchMinus;
 				break;
 			case OAPI_KEY_END:
-				DskySwitchProceed.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchProceed;
 				break;
 			case OAPI_KEY_NUMPAD1:
-				DskySwitchOne.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchOne;
 				break;
 			case OAPI_KEY_NUMPAD2:
-				DskySwitchTwo.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchTwo;
 				break;
 			case OAPI_KEY_NUMPAD3:
-				DskySwitchThree.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchThree;
 				break;
 			case OAPI_KEY_NUMPAD4:
-				DskySwitchFour.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchFour;
 				break;
 			case OAPI_KEY_NUMPAD5:
-				DskySwitchFive.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchFive;
 				break;
 			case OAPI_KEY_NUMPAD6:
-				DskySwitchSix.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchSix;
 				break;
 			case OAPI_KEY_NUMPAD7:
-				DskySwitchSeven.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchSeven;
 				break;
 			case OAPI_KEY_NUMPAD8:
-				DskySwitchEight.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchEight;
 				break;
 			case OAPI_KEY_NUMPAD9:
-				DskySwitchNine.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchNine;
 				break;
 			case OAPI_KEY_NUMPAD0:
-				DskySwitchZero.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dskyKeyChanged = &DskySwitchZero;
 				break;
 			case OAPI_KEY_W: // Minimum impulse controller, pitch down
 				agc.SetInputChannelBit(032, MinusPitchMinImpulse, down ? 1 : 0);
@@ -3539,14 +3539,27 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 				agc.SetInputChannelBit(032, PlusRollMinimumImpulse, down ? 1 : 0);
 				break;
 		}
-		// direction-specific code
+
+		// Direction-specific code, handle DSKY key presses if any.
 		if (down) {
 			// KEY DOWN
+			if (dskyKeyChanged != nullptr) {
+				dskyKeyChanged->SetHeld(true);
+				dskyKeyChanged->SetState(PUSHBUTTON_PUSHED);
+			}
+
 			switch (key) {
 			case OAPI_KEY_K:
 				//kill rotation
 				SetAngularVel(_V(0, 0, 0));
 				break;
+			}
+		}
+		else {
+			// KEY UP
+			if (dskyKeyChanged != nullptr) {
+				// Omitting SetState prevents a second click on key up, the spring-loaded buttons will reset themselves.
+				dskyKeyChanged->SetHeld(false);
 			}
 		}
 		return 0;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3558,8 +3558,9 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 		else {
 			// KEY UP
 			if (dskyKeyChanged != nullptr) {
-				// Omitting SetState prevents a second click on key up, the spring-loaded buttons will reset themselves.
+				// Doing SwitchTo instead of SetState prevents a second click on key up.
 				dskyKeyChanged->SetHeld(false);
+				dskyKeyChanged->SwitchTo(PUSHBUTTON_UNPUSHED);
 			}
 		}
 		return 0;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -147,7 +147,7 @@ void cbCSMVesim(int inputID, int eventType, int newValue, void *pdata) {
 			pSaturn->MoveTHC(0);
 			break;
 		case CSM_BUTTON_DSKY1_PRO:
-			pSaturn->dsky.ProgPressed();
+			pSaturn->dsky.ProceedPressed();
 			break;
 		case CSM_BUTTON_DSKY1_KEY_REL:
 			pSaturn->dsky.KeyRel();
@@ -204,7 +204,7 @@ void cbCSMVesim(int inputID, int eventType, int newValue, void *pdata) {
 			pSaturn->dsky.NumberPressed(9);
 			break;
 		case CSM_BUTTON_DSKY2_PRO:
-			pSaturn->dsky2.ProgPressed();
+			pSaturn->dsky2.ProceedPressed();
 			break;
 		case CSM_BUTTON_DSKY2_KEY_REL:
 			pSaturn->dsky2.KeyRel();
@@ -283,10 +283,10 @@ void cbCSMVesim(int inputID, int eventType, int newValue, void *pdata) {
 	else if (eventType == VESIM_EVTTYPE_BUTTON_OFF) {
 		switch (inputID) {		
 		case CSM_BUTTON_DSKY1_PRO:
-			pSaturn->dsky.ProgReleased();
+			pSaturn->dsky.ProceedReleased();
 			break;
 		case CSM_BUTTON_DSKY2_PRO:
-			pSaturn->dsky2.ProgReleased();
+			pSaturn->dsky2.ProceedReleased();
 			break;
 		case CSM_BUTTON_DIR_ULL:
 			pSaturn->DirectUllageButton.VesimSwitchTo(0);
@@ -3461,112 +3461,92 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 
 	if (KEYMOD_SHIFT(kstate)){
 		// Do DSKY stuff
-		if(down){
-			switch(key){
-				case OAPI_KEY_DECIMAL:
-					dsky.ClearPressed();
-					break;
-				case OAPI_KEY_PRIOR:
-					dsky.ResetPressed();
-					break;
-				case OAPI_KEY_HOME:
-					dsky.KeyRel();
-					break;
-				case OAPI_KEY_NUMPADENTER:
-					dsky.EnterPressed();
-					break;
-				case OAPI_KEY_DIVIDE:
-					dsky.VerbPressed();
-					break;
-				case OAPI_KEY_MULTIPLY:
-					dsky.NounPressed();
-					break;
-				case OAPI_KEY_ADD:
-					dsky.PlusPressed();
-					break;
-				case OAPI_KEY_SUBTRACT:
-					dsky.MinusPressed();
-					break;
-				case OAPI_KEY_END:
-					dsky.ProgPressed();
-					break;
-				case OAPI_KEY_NUMPAD1:
-					dsky.NumberPressed(1);
-					break;
-				case OAPI_KEY_NUMPAD2:
-					dsky.NumberPressed(2);
-					break;
-				case OAPI_KEY_NUMPAD3:
-					dsky.NumberPressed(3);
-					break;
-				case OAPI_KEY_NUMPAD4:
-					dsky.NumberPressed(4);
-					break;
-				case OAPI_KEY_NUMPAD5:
-					dsky.NumberPressed(5);
-					break;
-				case OAPI_KEY_NUMPAD6:
-					dsky.NumberPressed(6);
-					break;
-				case OAPI_KEY_NUMPAD7:
-					dsky.NumberPressed(7);
-					break;
-				case OAPI_KEY_NUMPAD8:
-					dsky.NumberPressed(8);
-					break;
-				case OAPI_KEY_NUMPAD9:
-					dsky.NumberPressed(9);
-					break;
-				case OAPI_KEY_NUMPAD0:
-					dsky.NumberPressed(0);
-					break;
-				case OAPI_KEY_W: // Minimum impulse controller, pitch down
-					agc.SetInputChannelBit(032, MinusPitchMinImpulse,1);
-					break;
-				case OAPI_KEY_S: // Minimum impulse controller, pitch up
-					agc.SetInputChannelBit(032, PlusPitchMinImpulse,1);
-					break;
-				case OAPI_KEY_A: // Minimum impulse controller, yaw left
-					agc.SetInputChannelBit(032, MinusYawMinimumImpulse,1);
-					break;
-				case OAPI_KEY_D: // Minimum impulse controller, yaw right
-					agc.SetInputChannelBit(032, PlusYawMinimumImpulse,1);
-					break;
-				case OAPI_KEY_Q: // Minimum impulse controller, roll left
-					agc.SetInputChannelBit(032, MinusRollMinimumImpulse,1);
-					break;
-				case OAPI_KEY_E: // Minimum impulse controller, roll right
-					agc.SetInputChannelBit(032, PlusRollMinimumImpulse,1);
-					break;
-				case OAPI_KEY_K:
-					//kill rotation
-					SetAngularVel(_V(0, 0, 0));
-					break;
-			}
-		}else{
-			// KEY UP
-			switch(key){
-				case OAPI_KEY_END:
-					dsky.ProgReleased();
-					break;
-				case OAPI_KEY_W: // Minimum impulse controller, pitch down
-					agc.SetInputChannelBit(032, MinusPitchMinImpulse, 0);
-					break;
-				case OAPI_KEY_S: // Minimum impulse controller, pitch up
-					agc.SetInputChannelBit(032, PlusPitchMinImpulse, 0);
-					break;
-				case OAPI_KEY_A: // Minimum impulse controller, yaw left
-					agc.SetInputChannelBit(032, MinusYawMinimumImpulse, 0);
-					break;
-				case OAPI_KEY_D: // Minimum impulse controller, yaw right
-					agc.SetInputChannelBit(032, PlusYawMinimumImpulse, 0);
-					break;
-				case OAPI_KEY_Q: // Minimum impulse controller, roll left
-					agc.SetInputChannelBit(032, MinusRollMinimumImpulse, 0);
-					break;
-				case OAPI_KEY_E: // Minimum impulse controller, roll right
-					agc.SetInputChannelBit(032, PlusRollMinimumImpulse, 0);
-					break;
+		// Handle key up-down in one switch block
+		switch (key) {
+			case OAPI_KEY_DECIMAL:
+				DskySwitchClear.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_PRIOR:
+				DskySwitchReset.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_HOME:
+				DskySwitchKeyRel.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_NUMPADENTER:
+				DskySwitchEnter.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_DIVIDE:
+				DskySwitchVerb.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_MULTIPLY:
+				DskySwitchNoun.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_ADD:
+				DskySwitchPlus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_SUBTRACT:
+				DskySwitchMinus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_END:
+				DskySwitchProceed.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_NUMPAD1:
+				DskySwitchOne.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_NUMPAD2:
+				DskySwitchTwo.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_NUMPAD3:
+				DskySwitchThree.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_NUMPAD4:
+				DskySwitchFour.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_NUMPAD5:
+				DskySwitchFive.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_NUMPAD6:
+				DskySwitchSix.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_NUMPAD7:
+				DskySwitchSeven.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_NUMPAD8:
+				DskySwitchEight.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_NUMPAD9:
+				DskySwitchNine.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_NUMPAD0:
+				DskySwitchZero.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				break;
+			case OAPI_KEY_W: // Minimum impulse controller, pitch down
+				agc.SetInputChannelBit(032, MinusPitchMinImpulse, down ? 1 : 0);
+				break;
+			case OAPI_KEY_S: // Minimum impulse controller, pitch up
+				agc.SetInputChannelBit(032, PlusPitchMinImpulse, down ? 1 : 0);
+				break;
+			case OAPI_KEY_A: // Minimum impulse controller, yaw left
+				agc.SetInputChannelBit(032, MinusYawMinimumImpulse, down ? 1 : 0);
+				break;
+			case OAPI_KEY_D: // Minimum impulse controller, yaw right
+				agc.SetInputChannelBit(032, PlusYawMinimumImpulse, down ? 1 : 0);
+				break;
+			case OAPI_KEY_Q: // Minimum impulse controller, roll left
+				agc.SetInputChannelBit(032, MinusRollMinimumImpulse, down ? 1 : 0);
+				break;
+			case OAPI_KEY_E: // Minimum impulse controller, roll right
+				agc.SetInputChannelBit(032, PlusRollMinimumImpulse, down ? 1 : 0);
+				break;
+		}
+		// direction-specific code
+		if (down) {
+			// KEY DOWN
+			switch (key) {
+			case OAPI_KEY_K:
+				//kill rotation
+				SetAngularVel(_V(0, 0, 0));
+				break;
 			}
 		}
 		return 0;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3554,8 +3554,7 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 				SetAngularVel(_V(0, 0, 0));
 				break;
 			}
-		}
-		else {
+		} else {
 			// KEY UP
 			if (dskyKeyChanged != nullptr) {
 				// Doing SwitchTo instead of SetState prevents a second click on key up.

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -3292,7 +3292,7 @@ protected:
 	DSKYPushSwitch DskySwitchEight;
 	DSKYPushSwitch DskySwitchNine;
 	DSKYPushSwitch DskySwitchClear;
-	DSKYPushSwitch DskySwitchProg;
+	DSKYPushSwitch DskySwitchProceed;
 	DSKYPushSwitch DskySwitchKeyRel;
 	DSKYPushSwitch DskySwitchEnter;
 	DSKYPushSwitch DskySwitchReset;
@@ -3313,7 +3313,7 @@ protected:
 	DSKYPushSwitch Dsky2SwitchEight;
 	DSKYPushSwitch Dsky2SwitchNine;
 	DSKYPushSwitch Dsky2SwitchClear;
-	DSKYPushSwitch Dsky2SwitchProg;
+	DSKYPushSwitch Dsky2SwitchProceed;
 	DSKYPushSwitch Dsky2SwitchKeyRel;
 	DSKYPushSwitch Dsky2SwitchEnter;
 	DSKYPushSwitch Dsky2SwitchReset;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
@@ -3520,7 +3520,7 @@ void Saturn::SetSwitches(int panel) {
 	DskySwitchSix.Init(164, 40, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 164, 40);
 	DskySwitchThree.Init(164, 80, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 164, 80);
 	DskySwitchClear.Init(205, 0, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 205, 0);
-	DskySwitchProg.Init(205, 40, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 205, 40);
+	DskySwitchProceed.Init(205, 40, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 205, 40);
 	DskySwitchKeyRel.Init(205, 80, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 205, 80);
 	DskySwitchEnter.Init(246, 20, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 246, 20);
 	DskySwitchReset.Init(246, 60, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 246, 60);
@@ -3548,7 +3548,7 @@ void Saturn::SetSwitches(int panel) {
 	Dsky2SwitchSix.Init(164 + dx, 40 + dy, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], Dsky2SwitchRow, 164, 40);
 	Dsky2SwitchThree.Init(164 + dx, 80 + dy, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], Dsky2SwitchRow, 164, 80);
 	Dsky2SwitchClear.Init(205 + dx, 0 + dy, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], Dsky2SwitchRow, 205, 0);
-	Dsky2SwitchProg.Init(205 + dx, 40 + dy, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], Dsky2SwitchRow, 205, 40);
+	Dsky2SwitchProceed.Init(205 + dx, 40 + dy, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], Dsky2SwitchRow, 205, 40);
 	Dsky2SwitchKeyRel.Init(205 + dx, 80 + dy, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], Dsky2SwitchRow, 205, 80);
 	Dsky2SwitchEnter.Init(246 + dx, 20 + dy, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], Dsky2SwitchRow, 246, 20);
 	Dsky2SwitchReset.Init(246 + dx, 60 + dy, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], Dsky2SwitchRow, 246, 60);
@@ -6621,7 +6621,7 @@ void Saturn::InitSwitches() {
 	DskySwitchEight.Register(PSH, "DskySwitchEight", false);
 	DskySwitchNine.Register(PSH, "DskySwitchNine", false);
 	DskySwitchClear.Register(PSH, "DskySwitchClear", false);
-	DskySwitchProg.Register(PSH, "DskySwitchProg", false);
+	DskySwitchProceed.Register(PSH, "DskySwitchProg", false);
 	DskySwitchKeyRel.Register(PSH, "DskySwitchKeyRel", false);
 	DskySwitchEnter.Register(PSH, "DskySwitchEnter", false);
 	DskySwitchReset.Register(PSH, "DskySwitchReset", false);
@@ -6640,7 +6640,7 @@ void Saturn::InitSwitches() {
 	DskySwitchSeven.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::sevenCallback));
 	DskySwitchEight.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::eightCallback));
 	DskySwitchNine.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::nineCallback));
-	DskySwitchProg.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::ProgCallback));
+	DskySwitchProceed.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::ProceedCallback));
 	DskySwitchClear.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::ClearCallback));
 	DskySwitchKeyRel.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::KeyRelCallback));
 	DskySwitchEnter.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::EnterCallback));
@@ -6661,7 +6661,7 @@ void Saturn::InitSwitches() {
 	Dsky2SwitchEight.Register(PSH, "Dsky2SwitchEight", false);
 	Dsky2SwitchNine.Register(PSH, "Dsky2SwitchNine", false);
 	Dsky2SwitchClear.Register(PSH, "Dsky2SwitchClear", false);
-	Dsky2SwitchProg.Register(PSH, "Dsky2SwitchProg", false);
+	Dsky2SwitchProceed.Register(PSH, "Dsky2SwitchProg", false);
 	Dsky2SwitchKeyRel.Register(PSH, "Dsky2SwitchKeyRel", false);
 	Dsky2SwitchEnter.Register(PSH, "Dsky2SwitchEnter", false);
 	Dsky2SwitchReset.Register(PSH, "Dsky2SwitchReset", false);
@@ -6680,14 +6680,14 @@ void Saturn::InitSwitches() {
 	Dsky2SwitchSeven.SetCallback(new PanelSwitchCallback<DSKY>(&dsky2, &DSKY::sevenCallback));
 	Dsky2SwitchEight.SetCallback(new PanelSwitchCallback<DSKY>(&dsky2, &DSKY::eightCallback));
 	Dsky2SwitchNine.SetCallback(new PanelSwitchCallback<DSKY>(&dsky2, &DSKY::nineCallback));
-	Dsky2SwitchProg.SetCallback(new PanelSwitchCallback<DSKY>(&dsky2, &DSKY::ProgCallback));
+	Dsky2SwitchProceed.SetCallback(new PanelSwitchCallback<DSKY>(&dsky2, &DSKY::ProceedCallback));
 	Dsky2SwitchClear.SetCallback(new PanelSwitchCallback<DSKY>(&dsky2, &DSKY::ClearCallback));
 	Dsky2SwitchKeyRel.SetCallback(new PanelSwitchCallback<DSKY>(&dsky2, &DSKY::KeyRelCallback));
 	Dsky2SwitchEnter.SetCallback(new PanelSwitchCallback<DSKY>(&dsky2, &DSKY::EnterCallback));
 	Dsky2SwitchReset.SetCallback(new PanelSwitchCallback<DSKY>(&dsky2, &DSKY::ResetCallback));
 
-	DskySwitchProg.SetDelayTime(1.5);
-	Dsky2SwitchProg.SetDelayTime(1.5);
+	DskySwitchProceed.SetDelayTime(1.5);
+	Dsky2SwitchProceed.SetDelayTime(1.5);
 
 	ASCPRollSwitch.Register(PSH, "ASCPRollSwitch", 0, 0, 0, 0);	// dummy switch/display for checklist controller
 	ASCPPitchSwitch.Register(PSH, "ASCPPitchSwitch", 0, 0, 0, 0);

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -3271,9 +3271,9 @@ void Saturn::DefineVCAnimations()
 	DskySwitchClear.SetDirection(P1_3_PB_VECT);
 	DskySwitchClear.DefineMeshGroup(VC_GRP_PB_P2_15);
 
-	MainPanelVC.AddSwitch(&DskySwitchProg, AID_VC_PUSHB_P2_16);
-	DskySwitchProg.SetDirection(P1_3_PB_VECT);
-	DskySwitchProg.DefineMeshGroup(VC_GRP_PB_P2_16);
+	MainPanelVC.AddSwitch(&DskySwitchProceed, AID_VC_PUSHB_P2_16);
+	DskySwitchProceed.SetDirection(P1_3_PB_VECT);
+	DskySwitchProceed.DefineMeshGroup(VC_GRP_PB_P2_16);
 
 	MainPanelVC.AddSwitch(&DskySwitchKeyRel, AID_VC_PUSHB_P2_17);
 	DskySwitchKeyRel.SetDirection(P1_3_PB_VECT);
@@ -4665,9 +4665,9 @@ void Saturn::DefineVCAnimations()
 	Dsky2SwitchClear.SetDirection(pb_P122_vector);
 	Dsky2SwitchClear.DefineMeshGroup(VC_GRP_PB_P122_15);
 
-	MainPanelVC.AddSwitch(&Dsky2SwitchProg, AID_VC_PUSHB_P122_16);
-	Dsky2SwitchProg.SetDirection(pb_P122_vector);
-	Dsky2SwitchProg.DefineMeshGroup(VC_GRP_PB_P122_16);
+	MainPanelVC.AddSwitch(&Dsky2SwitchProceed, AID_VC_PUSHB_P122_16);
+	Dsky2SwitchProceed.SetDirection(pb_P122_vector);
+	Dsky2SwitchProceed.DefineMeshGroup(VC_GRP_PB_P122_16);
 
 	MainPanelVC.AddSwitch(&Dsky2SwitchKeyRel, AID_VC_PUSHB_P122_17);
 	Dsky2SwitchKeyRel.SetDirection(pb_P122_vector);

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -933,7 +933,7 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 			case OAPI_KEY_NUMPADENTER:
 				dedaKeyChanged = &DedaSwitchEnter;
 				break;
-			case OAPI_KEY_DIVIDE:
+			case OAPI_KEY_PRIOR:
 				dedaKeyChanged = &DedaSwitchHold;
 				break;
 			case OAPI_KEY_MULTIPLY:

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -839,63 +839,63 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 		// Do DSKY stuff
 		DSKYPushSwitch* dskyKeyChanged = nullptr;
 		switch (key) {
-		case OAPI_KEY_DECIMAL:
-			dskyKeyChanged = &DskySwitchClear;
-			break;
-		case OAPI_KEY_PRIOR:
-			dskyKeyChanged = &DskySwitchReset;
-			break;
-		case OAPI_KEY_HOME:
-			dskyKeyChanged = &DskySwitchKeyRel;
-			break;
-		case OAPI_KEY_NUMPADENTER:
-			dskyKeyChanged = &DskySwitchEnter;
-			break;
-		case OAPI_KEY_DIVIDE:
-			dskyKeyChanged = &DskySwitchVerb;
-			break;
-		case OAPI_KEY_MULTIPLY:
-			dskyKeyChanged = &DskySwitchNoun;
-			break;
-		case OAPI_KEY_ADD:
-			dskyKeyChanged = &DskySwitchPlus;
-			break;
-		case OAPI_KEY_SUBTRACT:
-			dskyKeyChanged = &DskySwitchMinus;
-			break;
-		case OAPI_KEY_END:
-			dskyKeyChanged = &DskySwitchProceed;
-			break;
-		case OAPI_KEY_NUMPAD1:
-			dskyKeyChanged = &DskySwitchOne;
-			break;
-		case OAPI_KEY_NUMPAD2:
-			dskyKeyChanged = &DskySwitchTwo;
-			break;
-		case OAPI_KEY_NUMPAD3:
-			dskyKeyChanged = &DskySwitchThree;
-			break;
-		case OAPI_KEY_NUMPAD4:
-			dskyKeyChanged = &DskySwitchFour;
-			break;
-		case OAPI_KEY_NUMPAD5:
-			dskyKeyChanged = &DskySwitchFive;
-			break;
-		case OAPI_KEY_NUMPAD6:
-			dskyKeyChanged = &DskySwitchSix;
-			break;
-		case OAPI_KEY_NUMPAD7:
-			dskyKeyChanged = &DskySwitchSeven;
-			break;
-		case OAPI_KEY_NUMPAD8:
-			dskyKeyChanged = &DskySwitchEight;
-			break;
-		case OAPI_KEY_NUMPAD9:
-			dskyKeyChanged = &DskySwitchNine;
-			break;
-		case OAPI_KEY_NUMPAD0:
-			dskyKeyChanged = &DskySwitchZero;
-			break;
+			case OAPI_KEY_DECIMAL:
+				dskyKeyChanged = &DskySwitchClear;
+				break;
+			case OAPI_KEY_PRIOR:
+				dskyKeyChanged = &DskySwitchReset;
+				break;
+			case OAPI_KEY_HOME:
+				dskyKeyChanged = &DskySwitchKeyRel;
+				break;
+			case OAPI_KEY_NUMPADENTER:
+				dskyKeyChanged = &DskySwitchEnter;
+				break;
+			case OAPI_KEY_DIVIDE:
+				dskyKeyChanged = &DskySwitchVerb;
+				break;
+			case OAPI_KEY_MULTIPLY:
+				dskyKeyChanged = &DskySwitchNoun;
+				break;
+			case OAPI_KEY_ADD:
+				dskyKeyChanged = &DskySwitchPlus;
+				break;
+			case OAPI_KEY_SUBTRACT:
+				dskyKeyChanged = &DskySwitchMinus;
+				break;
+			case OAPI_KEY_END:
+				dskyKeyChanged = &DskySwitchProceed;
+				break;
+			case OAPI_KEY_NUMPAD1:
+				dskyKeyChanged = &DskySwitchOne;
+				break;
+			case OAPI_KEY_NUMPAD2:
+				dskyKeyChanged = &DskySwitchTwo;
+				break;
+			case OAPI_KEY_NUMPAD3:
+				dskyKeyChanged = &DskySwitchThree;
+				break;
+			case OAPI_KEY_NUMPAD4:
+				dskyKeyChanged = &DskySwitchFour;
+				break;
+			case OAPI_KEY_NUMPAD5:
+				dskyKeyChanged = &DskySwitchFive;
+				break;
+			case OAPI_KEY_NUMPAD6:
+				dskyKeyChanged = &DskySwitchSix;
+				break;
+			case OAPI_KEY_NUMPAD7:
+				dskyKeyChanged = &DskySwitchSeven;
+				break;
+			case OAPI_KEY_NUMPAD8:
+				dskyKeyChanged = &DskySwitchEight;
+				break;
+			case OAPI_KEY_NUMPAD9:
+				dskyKeyChanged = &DskySwitchNine;
+				break;
+			case OAPI_KEY_NUMPAD0:
+				dskyKeyChanged = &DskySwitchZero;
+				break;
 		}
 
 		// Direction-specific code, handle DSKY key presses if any.
@@ -912,8 +912,7 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 				SetAngularVel(_V(0, 0, 0));
 				break;
 			}
-		}
-		else {
+		} else {
 			// KEY UP
 			if (dskyKeyChanged != nullptr) {
 				// Doing SwitchTo instead of SetState prevents a second click on key up.
@@ -988,8 +987,7 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 				dedaKeyChanged->SetHeld(true);
 				dedaKeyChanged->SetState(PUSHBUTTON_PUSHED);
 			}
-		}
-		else {
+		} else {
 			// KEY UP
 			if (dedaKeyChanged != nullptr) {
 				// Doing SwitchTo instead of SetState prevents a second click on key up.

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -916,8 +916,9 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 		else {
 			// KEY UP
 			if (dskyKeyChanged != nullptr) {
-				// Omitting SetState prevents a second click on key up, the spring-loaded buttons will reset themselves.
+				// Doing SwitchTo instead of SetState prevents a second click on key up.
 				dskyKeyChanged->SetHeld(false);
+				dskyKeyChanged->SwitchTo(PUSHBUTTON_UNPUSHED);
 			}
 		}
 		return 0;
@@ -991,8 +992,9 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 		else {
 			// KEY UP
 			if (dedaKeyChanged != nullptr) {
-				// Omitting SetState prevents a second click on key up, the spring-loaded buttons will reset themselves.
+				// Doing SwitchTo instead of SetState prevents a second click on key up.
 				dedaKeyChanged->SetHeld(false);
+				dedaKeyChanged->SwitchTo(PUSHBUTTON_UNPUSHED);
 			}
 		}
 		return 0;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -223,7 +223,7 @@ void cbLMVesim(int inputID, int eventType, int newValue, void *pdata) {
 			pLM->ButtonClick(); // guardClick is inaccesible
 			break;
 		case LM_BUTTON_DSKY_PRO:
-			pLM->dsky.ProgPressed();
+			pLM->dsky.ProceedPressed();
 			break;
 		case LM_BUTTON_DSKY_KEY_REL:
 			pLM->dsky.KeyRel();
@@ -310,7 +310,7 @@ void cbLMVesim(int inputID, int eventType, int newValue, void *pdata) {
 			pLM->Sclick.play();;
 			break;
 		case LM_BUTTON_DSKY_PRO:
-			pLM->dsky.ProgReleased();
+			pLM->dsky.ProceedReleased();
 			break;
 		}
 	}
@@ -837,150 +837,133 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 	// DS20060404 Allow keys to control DSKY like in the CM
 	if (KEYMOD_SHIFT(keystate)){
 		// Do DSKY stuff
-		if(down){
-			switch(key){
-				case OAPI_KEY_DECIMAL:
-					dsky.ClearPressed();
-					break;
-				case OAPI_KEY_PRIOR:
-					dsky.ResetPressed();
-					break;
-				case OAPI_KEY_HOME:
-					dsky.KeyRel();
-					break;
-				case OAPI_KEY_NUMPADENTER:
-					dsky.EnterPressed();
-					break;
-				case OAPI_KEY_DIVIDE:
-					dsky.VerbPressed();
-					break;
-				case OAPI_KEY_MULTIPLY:
-					dsky.NounPressed();
-					break;
-				case OAPI_KEY_ADD:
-					dsky.PlusPressed();
-					break;
-				case OAPI_KEY_SUBTRACT:
-					dsky.MinusPressed();
-					break;
-				case OAPI_KEY_END:
-					dsky.ProgPressed();
-					break;
-				case OAPI_KEY_NUMPAD1:
-					dsky.NumberPressed(1);
-					break;
-				case OAPI_KEY_NUMPAD2:
-					dsky.NumberPressed(2);
-					break;
-				case OAPI_KEY_NUMPAD3:
-					dsky.NumberPressed(3);
-					break;
-				case OAPI_KEY_NUMPAD4:
-					dsky.NumberPressed(4);
-					break;
-				case OAPI_KEY_NUMPAD5:
-					dsky.NumberPressed(5);
-					break;
-				case OAPI_KEY_NUMPAD6:
-					dsky.NumberPressed(6);
-					break;
-				case OAPI_KEY_NUMPAD7:
-					dsky.NumberPressed(7);
-					break;
-				case OAPI_KEY_NUMPAD8:
-					dsky.NumberPressed(8);
-					break;
-				case OAPI_KEY_NUMPAD9:
-					dsky.NumberPressed(9);
-					break;
-				case OAPI_KEY_NUMPAD0:
-					dsky.NumberPressed(0);
-					break;
-				case OAPI_KEY_A:
-					AbortStageSwitch.SetState(0);
-					break;
-				case OAPI_KEY_K:
-					//kill rotation
-					SetAngularVel(_V(0, 0, 0));
-					break;
-			}
-		}else{
-			// KEY UP
-			switch(key){
-				case OAPI_KEY_END:
-					dsky.ProgReleased();
-					break;
-
+		// Handle key up-down in one switch block
+		switch (key) {
+		case OAPI_KEY_DECIMAL:
+			DskySwitchClear.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_PRIOR:
+			DskySwitchReset.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_HOME:
+			DskySwitchKeyRel.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_NUMPADENTER:
+			DskySwitchEnter.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_DIVIDE:
+			DskySwitchVerb.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_MULTIPLY:
+			DskySwitchNoun.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_ADD:
+			DskySwitchPlus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_SUBTRACT:
+			DskySwitchMinus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_END:
+			DskySwitchProceed.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_NUMPAD1:
+			DskySwitchOne.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_NUMPAD2:
+			DskySwitchTwo.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_NUMPAD3:
+			DskySwitchThree.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_NUMPAD4:
+			DskySwitchFour.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_NUMPAD5:
+			DskySwitchFive.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_NUMPAD6:
+			DskySwitchSix.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_NUMPAD7:
+			DskySwitchSeven.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_NUMPAD8:
+			DskySwitchEight.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_NUMPAD9:
+			DskySwitchNine.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		case OAPI_KEY_NUMPAD0:
+			DskySwitchZero.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			break;
+		}
+		// direction-specific code
+		if (down) {
+			// KEY DOWN
+			switch (key) {
+			case OAPI_KEY_K:
+				//kill rotation
+				SetAngularVel(_V(0, 0, 0));
+				break;
 			}
 		}
 		return 0;
 	}
 	else if (KEYMOD_CONTROL(keystate)) {
 		// Do DEDA stuff
-		if (down) {
-			switch (key) {
+		switch (key) {
 			case OAPI_KEY_DECIMAL:
-				deda.ClearPressed();
+				DedaSwitchClear.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_NUMPADENTER:
-				deda.EnterPressed();
+				DedaSwitchEnter.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_DIVIDE:
-				deda.HoldPressed();
+				DedaSwitchHold.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_MULTIPLY:
-				deda.ReadOutPressed();
+				DedaSwitchReadOut.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_ADD:
-				deda.PlusPressed();
+				DedaSwitchPlus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_SUBTRACT:
-				deda.MinusPressed();
+				DedaSwitchMinus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_NUMPAD1:
-				deda.NumberPressed(1);
+				DedaSwitchOne.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_NUMPAD2:
-				deda.NumberPressed(2);
+				DedaSwitchTwo.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_NUMPAD3:
-				deda.NumberPressed(3);
+				DedaSwitchThree.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_NUMPAD4:
-				deda.NumberPressed(4);
+				DedaSwitchFour.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_NUMPAD5:
-				deda.NumberPressed(5);
+				DedaSwitchFive.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_NUMPAD6:
-				deda.NumberPressed(6);
+				DedaSwitchSix.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_NUMPAD7:
-				deda.NumberPressed(7);
+				DedaSwitchSeven.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_NUMPAD8:
-				deda.NumberPressed(8);
+				DedaSwitchEight.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_NUMPAD9:
-				deda.NumberPressed(9);
+				DedaSwitchNine.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_NUMPAD0:
-				deda.NumberPressed(0);
+				DedaSwitchZero.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
 				break;
 			case OAPI_KEY_D:
 				// Orbiter undocking messes with our undocking system. We consume the keybind here to block it.
 				// This won't work if the user has changed this keybind. Unfortunately Orbiter does not export the keymap through the API (yet). :(
 				return 1;
-			}
-		}
-		else {
-			// KEY UP
-			switch (key) {
-			case OAPI_KEY_DECIMAL:
-				deda.ResetKeyDown();
-				break;
-
-			}
 		}
 		return 0;
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -835,71 +835,77 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 	if (enableVESIM) vesim.clbkConsumeBufferedKey(key, down, keystate);
 
 	// DS20060404 Allow keys to control DSKY like in the CM
-	if (KEYMOD_SHIFT(keystate)){
+	if (KEYMOD_SHIFT(keystate)) {
 		// Do DSKY stuff
-		// Handle key up-down in one switch block
+		DSKYPushSwitch* dskyKeyChanged = nullptr;
 		switch (key) {
 		case OAPI_KEY_DECIMAL:
-			DskySwitchClear.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchClear;
 			break;
 		case OAPI_KEY_PRIOR:
-			DskySwitchReset.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchReset;
 			break;
 		case OAPI_KEY_HOME:
-			DskySwitchKeyRel.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchKeyRel;
 			break;
 		case OAPI_KEY_NUMPADENTER:
-			DskySwitchEnter.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchEnter;
 			break;
 		case OAPI_KEY_DIVIDE:
-			DskySwitchVerb.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchVerb;
 			break;
 		case OAPI_KEY_MULTIPLY:
-			DskySwitchNoun.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchNoun;
 			break;
 		case OAPI_KEY_ADD:
-			DskySwitchPlus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchPlus;
 			break;
 		case OAPI_KEY_SUBTRACT:
-			DskySwitchMinus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchMinus;
 			break;
 		case OAPI_KEY_END:
-			DskySwitchProceed.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchProceed;
 			break;
 		case OAPI_KEY_NUMPAD1:
-			DskySwitchOne.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchOne;
 			break;
 		case OAPI_KEY_NUMPAD2:
-			DskySwitchTwo.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchTwo;
 			break;
 		case OAPI_KEY_NUMPAD3:
-			DskySwitchThree.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchThree;
 			break;
 		case OAPI_KEY_NUMPAD4:
-			DskySwitchFour.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchFour;
 			break;
 		case OAPI_KEY_NUMPAD5:
-			DskySwitchFive.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchFive;
 			break;
 		case OAPI_KEY_NUMPAD6:
-			DskySwitchSix.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchSix;
 			break;
 		case OAPI_KEY_NUMPAD7:
-			DskySwitchSeven.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchSeven;
 			break;
 		case OAPI_KEY_NUMPAD8:
-			DskySwitchEight.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchEight;
 			break;
 		case OAPI_KEY_NUMPAD9:
-			DskySwitchNine.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchNine;
 			break;
 		case OAPI_KEY_NUMPAD0:
-			DskySwitchZero.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+			dskyKeyChanged = &DskySwitchZero;
 			break;
 		}
-		// direction-specific code
+
+		// Direction-specific code, handle DSKY key presses if any.
 		if (down) {
 			// KEY DOWN
+			if (dskyKeyChanged != nullptr) {
+				dskyKeyChanged->SetHeld(true);
+				dskyKeyChanged->SetState(PUSHBUTTON_PUSHED);
+			}
+
 			switch (key) {
 			case OAPI_KEY_K:
 				//kill rotation
@@ -907,63 +913,87 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 				break;
 			}
 		}
+		else {
+			// KEY UP
+			if (dskyKeyChanged != nullptr) {
+				// Omitting SetState prevents a second click on key up, the spring-loaded buttons will reset themselves.
+				dskyKeyChanged->SetHeld(false);
+			}
+		}
 		return 0;
 	}
 	else if (KEYMOD_CONTROL(keystate)) {
 		// Do DEDA stuff
+		DEDAPushSwitch* dedaKeyChanged = nullptr;
 		switch (key) {
 			case OAPI_KEY_DECIMAL:
-				DedaSwitchClear.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchClear;
 				break;
 			case OAPI_KEY_NUMPADENTER:
-				DedaSwitchEnter.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchEnter;
 				break;
 			case OAPI_KEY_DIVIDE:
-				DedaSwitchHold.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchHold;
 				break;
 			case OAPI_KEY_MULTIPLY:
-				DedaSwitchReadOut.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchReadOut;
 				break;
 			case OAPI_KEY_ADD:
-				DedaSwitchPlus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchPlus;
 				break;
 			case OAPI_KEY_SUBTRACT:
-				DedaSwitchMinus.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchMinus;
 				break;
 			case OAPI_KEY_NUMPAD1:
-				DedaSwitchOne.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchOne;
 				break;
 			case OAPI_KEY_NUMPAD2:
-				DedaSwitchTwo.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchTwo;
 				break;
 			case OAPI_KEY_NUMPAD3:
-				DedaSwitchThree.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchThree;
 				break;
 			case OAPI_KEY_NUMPAD4:
-				DedaSwitchFour.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchFour;
 				break;
 			case OAPI_KEY_NUMPAD5:
-				DedaSwitchFive.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchFive;
 				break;
 			case OAPI_KEY_NUMPAD6:
-				DedaSwitchSix.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchSix;
 				break;
 			case OAPI_KEY_NUMPAD7:
-				DedaSwitchSeven.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchSeven;
 				break;
 			case OAPI_KEY_NUMPAD8:
-				DedaSwitchEight.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchEight;
 				break;
 			case OAPI_KEY_NUMPAD9:
-				DedaSwitchNine.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchNine;
 				break;
 			case OAPI_KEY_NUMPAD0:
-				DedaSwitchZero.SetState(down ? PUSHBUTTON_PUSHED : PUSHBUTTON_UNPUSHED);
+				dedaKeyChanged = &DedaSwitchZero;
 				break;
 			case OAPI_KEY_D:
 				// Orbiter undocking messes with our undocking system. We consume the keybind here to block it.
 				// This won't work if the user has changed this keybind. Unfortunately Orbiter does not export the keymap through the API (yet). :(
 				return 1;
+		}
+
+		// Direction-specific code, handle DEDA key presses if any.
+		if (down) {
+			// KEY DOWN
+			if (dedaKeyChanged != nullptr) {
+				dedaKeyChanged->SetHeld(true);
+				dedaKeyChanged->SetState(PUSHBUTTON_PUSHED);
+			}
+		}
+		else {
+			// KEY UP
+			if (dedaKeyChanged != nullptr) {
+				// Omitting SetState prevents a second click on key up, the spring-loaded buttons will reset themselves.
+				dedaKeyChanged->SetHeld(false);
+			}
 		}
 		return 0;
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -1058,7 +1058,7 @@ protected:
 	DSKYPushSwitch DskySwitchEight;
 	DSKYPushSwitch DskySwitchNine;
 	DSKYPushSwitch DskySwitchClear;
-	DSKYPushSwitch DskySwitchProg;
+	DSKYPushSwitch DskySwitchProceed;
 	DSKYPushSwitch DskySwitchKeyRel;
 	DSKYPushSwitch DskySwitchEnter;
 	DSKYPushSwitch DskySwitchReset;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lempanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lempanel.cpp
@@ -782,7 +782,7 @@ void LEM::InitSwitches() {
 	DskySwitchEight.Register(PSH, "DskySwitchEight", false);
 	DskySwitchNine.Register(PSH, "DskySwitchNine", false);
 	DskySwitchClear.Register(PSH, "DskySwitchClear", false);
-	DskySwitchProg.Register(PSH, "DskySwitchProg", false);
+	DskySwitchProceed.Register(PSH, "DskySwitchProg", false);
 	DskySwitchKeyRel.Register(PSH, "DskySwitchKeyRel", false);
 	DskySwitchEnter.Register(PSH, "DskySwitchEnter", false);
 	DskySwitchReset.Register(PSH, "DskySwitchReset", false);
@@ -801,13 +801,13 @@ void LEM::InitSwitches() {
 	DskySwitchSeven.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::sevenCallback));
 	DskySwitchEight.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::eightCallback));
 	DskySwitchNine.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::nineCallback));
-	DskySwitchProg.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::ProgCallback));
+	DskySwitchProceed.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::ProceedCallback));
 	DskySwitchClear.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::ClearCallback));
 	DskySwitchKeyRel.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::KeyRelCallback));
 	DskySwitchEnter.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::EnterCallback));
 	DskySwitchReset.SetCallback(new PanelSwitchCallback<DSKY>(&dsky, &DSKY::ResetCallback));
 
-	DskySwitchProg.SetDelayTime(1.5);
+	DskySwitchProceed.SetDelayTime(1.5);
 
 	DedaSwitchPlus.Register(PSH, "DedaSwitchPlus", false);
 	DedaSwitchMinus.Register(PSH, "DedaSwitchMinus", false);
@@ -2296,7 +2296,7 @@ void LEM::SetSwitches(int panel) {
 	DskySwitchSix.Init(164, 40, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 164, 40);
 	DskySwitchThree.Init(164, 80, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 164, 80);
 	DskySwitchClear.Init(205, 0, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 205, 0);
-	DskySwitchProg.Init(205, 40, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 205, 40);
+	DskySwitchProceed.Init(205, 40, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 205, 40);
 	DskySwitchKeyRel.Init(205, 80, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 205, 80);
 	DskySwitchEnter.Init(246, 20, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 246, 20);
 	DskySwitchReset.Init(246, 60, 38, 38, srf[SRF_DSKYKEY], srf[SRF_BORDER_38x38], DskySwitchRow, 246, 60);

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
@@ -2545,9 +2545,9 @@ void LEM::DefineVCAnimations()
 	DskySwitchClear.SetDirection(P4_PB_VECT);
 	DskySwitchClear.DefineMeshGroup(VC_GRP_PB_P4_15);
 
-	MainPanelVC.AddSwitch(&DskySwitchProg, AID_VC_PUSHB_P4_16);
-	DskySwitchProg.SetDirection(P4_PB_VECT);
-	DskySwitchProg.DefineMeshGroup(VC_GRP_PB_P4_16);
+	MainPanelVC.AddSwitch(&DskySwitchProceed, AID_VC_PUSHB_P4_16);
+	DskySwitchProceed.SetDirection(P4_PB_VECT);
+	DskySwitchProceed.DefineMeshGroup(VC_GRP_PB_P4_16);
 
 	MainPanelVC.AddSwitch(&DskySwitchKeyRel, AID_VC_PUSHB_P4_17);
 	DskySwitchKeyRel.SetDirection(P4_PB_VECT);

--- a/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_mfd/ProjectApolloMFD.cpp
@@ -2187,8 +2187,8 @@ void ProjectApolloMFD::menuPressPROOnCMCLGC()
 
 	if (lem && saturn)
 	{
-		lem->DskySwitchProg.SetState(true);
-		saturn->DskySwitchProg.SetState(true);
+		lem->DskySwitchProceed.SetState(true);
+		saturn->DskySwitchProceed.SetState(true);
 	}
 
 	saturn = NULL;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/dsky.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/dsky.cpp
@@ -370,7 +370,7 @@ void DSKY::MinusPressed()
 	SendKeyCode(27);
 }
 
-void DSKY::ProgPressed()
+void DSKY::ProceedPressed()
 
 {
 	KeyClick();
@@ -378,7 +378,7 @@ void DSKY::ProgPressed()
 	agc.SetInputChannelBit(032, Proceed, true);
 }
 
-void DSKY::ProgReleased()
+void DSKY::ProceedReleased()
 
 {
 	agc.SetInputChannelBit(032, Proceed, false);
@@ -591,7 +591,7 @@ void DSKY::ProcessKeyPress(int mx, int my)
 		}
 		if (my > 41 && my < 79) {
 			KeyDown_Prog = true;
-			ProgPressed();
+			ProceedPressed();
 		}
 		if (my > 81 && my < 119) {
 			KeyDown_KeyRel = true;
@@ -618,7 +618,7 @@ void DSKY::ProcessKeyRelease(int mx, int my)
 {
 	if (mx > 2+5*41 && mx < 39+5*41) {
 		if (my > 41 && my < 79) {
-			ProgReleased();
+			ProceedReleased();
 		}
 	}
 	else {
@@ -1262,16 +1262,16 @@ void DSKY::ResetCallback(PanelSwitchItem* s)
 		ResetKeyDown();
 	}
 }
-void DSKY::ProgCallback(PanelSwitchItem* s)
+void DSKY::ProceedCallback(PanelSwitchItem* s)
 {
 	if (s->GetState() == 1)
 	{
 		KeyDown_Prog = true;
-		ProgPressed();
+		ProceedPressed();
 	}
 	else
 	{
-		ProgReleased();
+		ProceedReleased();
 		ResetKeyDown();
 	}
 }

--- a/Orbitersdk/samples/ProjectApollo/src_sys/dsky.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/dsky.h
@@ -117,8 +117,8 @@ public:
 	void EnterPressed();
 	void ClearPressed();
 	void ResetPressed();
-	void ProgPressed();
-	void ProgReleased();
+	void ProceedPressed();
+	void ProceedReleased();
 	void PlusPressed();
 	void MinusPressed();
 	void NumberPressed(int n);
@@ -128,7 +128,7 @@ public:
 	void EnterCallback(PanelSwitchItem* s);
 	void ClearCallback(PanelSwitchItem* s);
 	void ResetCallback(PanelSwitchItem* s);
-	void ProgCallback(PanelSwitchItem* s);
+	void ProceedCallback(PanelSwitchItem* s);
 	void KeyRelCallback(PanelSwitchItem* s);
 	void PlusCallback(PanelSwitchItem* s);
 	void MinusCallback(PanelSwitchItem* s);

--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.h
@@ -41,8 +41,11 @@
 // Switch states. Only use positive numbers.
 //
 
-#define TOGGLESWITCH_DOWN		0			///< Toggle switch is up.
-#define TOGGLESWITCH_UP			1			///< Toggle switch is down.
+#define TOGGLESWITCH_DOWN		0			///< Toggle switch is down.
+#define TOGGLESWITCH_UP			1			///< Toggle switch is up.
+
+#define PUSHBUTTON_UNPUSHED		0			///< Push button is un-pushed (off).
+#define PUSHBUTTON_PUSHED		1			///< Push button is pushed (on).
 
 #define THREEPOSSWITCH_DOWN		0			///< Three-position switch is down.
 #define THREEPOSSWITCH_CENTER	1			///< Three-position switch is centered.


### PR DESCRIPTION
This reworks the DSKY, DEDA, and CM minimum impulse controller keyboard shortcuts to be slightly simpler, and also changes how DSKY/DEDA keypresses are handled. Now, they actually press, hold, and release the keys themselves instead of sending a signal "behind the scenes", which allows the Checklist MFD to detect them properly. In essence, pressing keys with the keyboard shortcuts should now function like clicking them with your mouse.

Additionally, to avoid a conflict with one of Orbiter's default key bindings (Attitude Controller - Off), I have changed the DEDA HOLD button to use the shortcut Ctrl + PgUp instead of the previous Ctrl + Numpad Divide.