### PR TITLE
Added Plaque meshgroup to landing gear animation

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/LM_DescentStageResource.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LM_DescentStageResource.h
@@ -63,3 +63,4 @@
 #define DS_GRP_SupportStruts2Aft 47
 #define DS_GRP_SupportStruts2Left 48
 #define DS_GRP_SupportStruts2Right 49
+#define DS_GRP_Plaque 50

--- a/Orbitersdk/samples/ProjectApollo/src_lm/Sat5LMDSC.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/Sat5LMDSC.cpp
@@ -222,6 +222,7 @@ void Sat5LMDSC::DefineAnimations(UINT idx) {
 	static UINT meshgroup_Struts[4] = { DS_GRP_SupportStruts2, DS_GRP_SupportStruts2Aft, DS_GRP_SupportStruts2Left, DS_GRP_SupportStruts2Right };
 	static UINT meshgroup_Locks[4] = { DS_GRP_Downlock, DS_GRP_DownlockAft, DS_GRP_DownlockLeft, DS_GRP_DownlockRight };
 	static UINT meshgroup_Ladder = DS_GRP_Ladder;
+	static UINT meshgroup_Plaque = DS_GRP_Plaque;
 	static UINT meshgroup_Probes1[3] = { DS_GRP_Probes1Aft, DS_GRP_Probes1Left, DS_GRP_Probes1Right };
 	static UINT meshgroup_Probes2[3] = { DS_GRP_Probes2Aft, DS_GRP_Probes2Left, DS_GRP_Probes2Right };
 
@@ -249,6 +250,11 @@ void Sat5LMDSC::DefineAnimations(UINT idx) {
 
 	static MGROUP_ROTATE mgt_Ladder(idx, &meshgroup_Ladder, 1, DES_LEG_PIVOT[0], DES_LEG_AXIS[0], (float)(45 * RAD));
 	AddAnimationComponent(anim_Gear, 0.0, 1, &mgt_Ladder);
+
+	SetAnimation(anim_Gear, 0.0);
+
+	static MGROUP_ROTATE mgt_Plaque(idx, &meshgroup_Plaque, 1, DES_LEG_PIVOT[0], DES_LEG_AXIS[0], (float)(45 * RAD));
+	AddAnimationComponent(anim_Gear, 0.0, 1, &mgt_Plaque);
 
 	SetAnimation(anim_Gear, 0.0);
 }

--- a/Orbitersdk/samples/ProjectApollo/src_lm/Sat5LMDSC.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/Sat5LMDSC.cpp
@@ -251,8 +251,6 @@ void Sat5LMDSC::DefineAnimations(UINT idx) {
 	static MGROUP_ROTATE mgt_Ladder(idx, &meshgroup_Ladder, 1, DES_LEG_PIVOT[0], DES_LEG_AXIS[0], (float)(45 * RAD));
 	AddAnimationComponent(anim_Gear, 0.0, 1, &mgt_Ladder);
 
-	SetAnimation(anim_Gear, 0.0);
-
 	static MGROUP_ROTATE mgt_Plaque(idx, &meshgroup_Plaque, 1, DES_LEG_PIVOT[0], DES_LEG_AXIS[0], (float)(45 * RAD));
 	AddAnimationComponent(anim_Gear, 0.0, 1, &mgt_Plaque);
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_eds.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_eds.cpp
@@ -418,8 +418,6 @@ void LEM_EDS::DefineAnimations(UINT idx) {
 	static MGROUP_ROTATE mgt_Ladder(idx, &meshgroup_Ladder, 1, DES_LEG_PIVOT[0], DES_LEG_AXIS[0], (float)(45 * RAD));
 	lem->AddAnimationComponent(anim_Gear, 0.0, 1, &mgt_Ladder);
 
-	lem->SetAnimation(anim_Gear, gear_state.State());
-
 	static MGROUP_ROTATE mgt_Plaque(idx, &meshgroup_Plaque, 1, DES_LEG_PIVOT[0], DES_LEG_AXIS[0], (float)(45 * RAD));
 	lem->AddAnimationComponent(anim_Gear, 0.0, 1, &mgt_Plaque);
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_eds.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_eds.cpp
@@ -389,6 +389,7 @@ void LEM_EDS::DefineAnimations(UINT idx) {
 	static UINT meshgroup_Struts[4] = { DS_GRP_SupportStruts2, DS_GRP_SupportStruts2Aft, DS_GRP_SupportStruts2Left, DS_GRP_SupportStruts2Right };
 	static UINT meshgroup_Locks[4] = { DS_GRP_Downlock, DS_GRP_DownlockAft, DS_GRP_DownlockLeft, DS_GRP_DownlockRight };
 	static UINT meshgroup_Ladder = DS_GRP_Ladder;
+	static UINT meshgroup_Plaque = DS_GRP_Plaque;
 	static UINT meshgroup_Probes1[3] = { DS_GRP_Probes1Aft, DS_GRP_Probes1Left, DS_GRP_Probes1Right };
 	static UINT meshgroup_Probes2[3] = { DS_GRP_Probes2Aft, DS_GRP_Probes2Left, DS_GRP_Probes2Right };
 
@@ -416,6 +417,11 @@ void LEM_EDS::DefineAnimations(UINT idx) {
 
 	static MGROUP_ROTATE mgt_Ladder(idx, &meshgroup_Ladder, 1, DES_LEG_PIVOT[0], DES_LEG_AXIS[0], (float)(45 * RAD));
 	lem->AddAnimationComponent(anim_Gear, 0.0, 1, &mgt_Ladder);
+
+	lem->SetAnimation(anim_Gear, gear_state.State());
+
+	static MGROUP_ROTATE mgt_Plaque(idx, &meshgroup_Plaque, 1, DES_LEG_PIVOT[0], DES_LEG_AXIS[0], (float)(45 * RAD));
+	lem->AddAnimationComponent(anim_Gear, 0.0, 1, &mgt_Plaque);
 
 	lem->SetAnimation(anim_Gear, gear_state.State());
 }


### PR DESCRIPTION
The plaque on the landing leg wasn't in the animation for the gear, thus it was floating in the deployed position all the time.  This is now fixed.  (shoutout to ThatRedMelon on the discord for pointing out this oversight)