### PR TITLE
Delete Saturn V launch engineering cameras

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3658,59 +3658,6 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 		}
 	}
 
-	//
-	// We only allow this switch in VC mode, as we need to disable the panel when selecting these
-	// cameras.
-	//
-	// For now this is limited to the Saturn V.
-	//
-
-	if (key == OAPI_KEY_1 && down == true && InVC && stage < LAUNCH_STAGE_TWO && stage >= LAUNCH_STAGE_ONE) {
-		clbkLoadVC(SATVIEW_ENG1);
-		return 1;
-	}
-
-	if (key == OAPI_KEY_2 && down == true && InVC && stage < LAUNCH_STAGE_SIVB && stage >= LAUNCH_STAGE_ONE) {
-		clbkLoadVC(SATVIEW_ENG2);
-		return 1;
-	}
-
-	if (key == OAPI_KEY_3 && down == true && InVC && stage < LAUNCH_STAGE_SIVB && stage >= PRELAUNCH_STAGE)
-	{
-		//
-		// Key 3 switches to position 3 by default, then cycles around them.
-		//
-		switch (viewpos)
-		{
-		case SATVIEW_ENG3:
-			viewpos = SATVIEW_ENG4;
-			break;
-
-		case SATVIEW_ENG4:
-			viewpos = SATVIEW_ENG5;
-			break;
-
-		case SATVIEW_ENG5:
-			viewpos = SATVIEW_ENG6;
-			break;
-
-		case SATVIEW_ENG6:
-			viewpos = SATVIEW_ENG3;
-			break;
-
-		default:
-			viewpos = SATVIEW_ENG3;
-			break;
-		}
-		clbkLoadVC(viewpos);
-		return 1;
-	}
-
-	//Load left seat
-	if (key == OAPI_KEY_4 && down == true && InVC) {
-		clbkLoadVC(SATVIEW_LEFTSEAT);
-		return 1;
-	}
 	return 0;
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -3862,12 +3862,6 @@ protected:
     #define SATVIEW_TUNNEL          8
     #define SATVIEW_LOWER_CENTER    9
     #define SATVIEW_UPPER_CENTER    10
-	#define SATVIEW_ENG1			20
-	#define SATVIEW_ENG2			21
-	#define SATVIEW_ENG3			22
-	#define SATVIEW_ENG4			23
-	#define SATVIEW_ENG5			24
-	#define SATVIEW_ENG6			25
 
 	unsigned int	viewpos;
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnmesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnmesh.cpp
@@ -1889,13 +1889,6 @@ bool Saturn::clbkLoadGenericCockpit ()
 {
 	TRACESETUP("Saturn::clbkLoadGenericCockpit");
 
-	//
-	// VC-only in engineering camera view.
-	//
-
-	if (viewpos == SATVIEW_ENG1 || viewpos == SATVIEW_ENG2 || viewpos == SATVIEW_ENG3)
-		return false;
-
 	SetCameraRotationRange(0.0, 0.0, 0.0, 0.0);
 	SetCameraDefaultDirection(_V(0.0, 0.0, 1.0));
 	oapiCameraSetCockpitDir(0,0);

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnpanel.cpp
@@ -705,12 +705,6 @@ bool Saturn::clbkLoadPanel (int id) {
 		return false;
 
 	//
-	// No panel in engineering camera view.
-	//
-	if (viewpos == SATVIEW_ENG1 || viewpos == SATVIEW_ENG2 || viewpos == SATVIEW_ENG3)
-		return false;
-
-	//
 	// Get screen info from the configurator
 	//
 	int renderViewportIsWideScreen = GetRenderViewportIsWideScreen();

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -796,13 +796,6 @@ bool Saturn::clbkLoadVC (int id)
 	//Reset Clip Radius settings
 	SetClipRadius(0.0);
 
-	if ((id >= SATVIEW_ENG1) && (id <= SATVIEW_ENG6))
-	{
-		viewpos = id;
-		SetView(true);
-		return true;
-	}
-
 	// Init the 2D panel switches to fix XRSound not giving us switch clicks if we load directly into the VC.
 	// Calling InitPanel(SATPANEL_MAIN) also works, since that function calls SetSwitches() as well.
 	SetSwitches(SATPANEL_MAIN);	// Use main panel as a placeholder, it doesn't actually matter
@@ -2242,108 +2235,6 @@ void Saturn::SetView(double offset, bool update_direction)
 	if (vcidx != -1) {
 		GetMeshOffset(vcidx, ofs_vc);
 		ofs_vc.z = ofs_vc.z - 0.15;
-	}
-
-	//
-	// Engineering cameras
-	//
-	if (viewpos >= SATVIEW_ENG1)
-	{
-		VECTOR3 e1 = _V(0, 0, 0), e2 = _V(0, 0, 0), e3 = _V(0, 0, 0), e4 = _V(0, 0, 0), e5 = _V(0, 0, 0), e6 = _V(0, 0, 0);	
-		VECTOR3 v1 = _V(0, 0, 0), v2 = _V(0, 0, 0), v3 = _V(0, 0, 0), v4 = _V(0, 0, 0), v5 = _V(0, 0, 0), v6 = _V(0, 0, 0);
-		VECTOR3 cd;
-
-		//
-		// We really need different cameras for Saturn V and 1b.
-		//
-
-		switch (stage) {
-		case PRELAUNCH_STAGE:
-			e3 = _V(0.0, 7.5, -10.0+STG0O);
-			v3 = _V(0.0, -0.1, -1.0);
-			e4 = _V(7.5, 0.0, -10.0+STG0O);
-			v4 = _V(-0.1, 0.0, -1.0);
-			e5 = _V(0.0, -7.5, -10.0+STG0O);
-			v5 = _V(0.0, 0.1, -1.0);
-			e6 = _V(-7.5, 0.0, -10.0+STG0O);
-			v6 = _V(0.1, 0.0, -1.0);
-			break;
-
-		case LAUNCH_STAGE_ONE:
-			e1 = _V(4.0, 0.0, -39.0+STG0O);
-			v1 = _V(-0.15, 0, 1.0);
-			e2 = _V(3.5, 0.0, -31.0+STG0O);
-			v2 = _V(-0.15, 0, -1.0);
-			e3 = _V(0.0, 7.5, -10.0+STG0O);
-			v3 = _V(0.0, -0.1, -1.0);
-			e4 = _V(7.5, 0.0, -10.0+STG0O);
-			v4 = _V(-0.1, 0.0, -1.0);
-			e5 = _V(0.0, -7.5, -10.0+STG0O);
-			v5 = _V(0.0, 0.1, -1.0);
-			e6 = _V(-7.5, 0.0, -10.0+STG0O);
-			v6 = _V(0.1, 0.0, -1.0);
-			break;
-
-		case LAUNCH_STAGE_TWO:
-		case LAUNCH_STAGE_TWO_ISTG_JET:
-			e2 = _V(3.5, 0.0, -31.0-STG1O);
-			v2 = _V(-0.15, 0, -1.0);
-			e3 = _V(0.0, 7.5, -10.0-STG1O);
-			v3 = _V(0.0, -0.1, -1.0);
-			e4 = _V(7.5, 0.0, -10.0-STG1O);
-			v4 = _V(-0.1, 0.0, -1.0);
-			e5 = _V(0.0, -7.5, -10.0-STG1O);
-			v5 = _V(0.0, 0.1, -1.0);
-			e6 = _V(-7.5, 0.0, -10.0-STG1O);
-			v6 = _V(0.1, 0.0, -1.0);
-			break;
-
-		//
-		// Switch back to commander view if we're past the point where we can
-		// display anything useful.
-		//
-
-		case LAUNCH_STAGE_SIVB:
-			viewpos = SATVIEW_LEFTSEAT;
-			SetView(offset, true);
-			return;
-		}
-
-		switch (viewpos) {
-		case SATVIEW_ENG1:
-			v = e1;
-			cd = v1;
-			break;
-
-		case SATVIEW_ENG2:
-			v = e2;
-			cd = v2;
-			break;
-
-		case SATVIEW_ENG3:
-			v = e3;
-			cd = v3;
-			break;
-
-		case SATVIEW_ENG4:
-			v = e4;
-			cd = v4;
-			break;
-
-		case SATVIEW_ENG5:
-			v = e5;
-			cd = v5;
-			break;
-
-		case SATVIEW_ENG6:
-			v = e6;
-			cd = v6;
-			break;
-		}
-
-		SetCameraRotationRange(0.0, 0.0, 0.0, 0.0);
-		SetCameraDefaultDirection(cd);
-		oapiCameraSetCockpitDir(0,0);
 	}
 
 	// 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -2241,7 +2241,7 @@ void Saturn::SetView(double offset, bool update_direction)
 	// 2D panel 
 	// Direction/rotation range is in clbkLoadPanel
 	//
-	else if (InPanel) {
+	if (InPanel) {
 		if (PanelId == SATPANEL_LEFT_RNDZ_WINDOW) {
 			v = _V(-0.605, 1.045, offset - 3.0); // Adjusted to line up with docking target
 

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/sat5mesh.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/sat5mesh.cpp
@@ -987,24 +987,21 @@ void SaturnV::SetThirdStageEngines (double offset)
 	// Seperation 'thrusters'.
 	//
 
-	if (viewpos != SATVIEW_ENG1 && viewpos != SATVIEW_ENG2) 
-	{
-		int i;
+	int i;
 
-		ph_sep = CreatePropellantResource(0.25);
+	ph_sep = CreatePropellantResource(0.25);
 
-		th_sep[0] = CreateThruster (s_exhaust_pos1, _V( 1,1,0), 1.0, ph_sep, 10.0, 10.0);
-		th_sep[1] = CreateThruster (s_exhaust_pos2, _V( 1,-1,0), 1.0, ph_sep, 10.0, 10.0);
-		th_sep[2] = CreateThruster (s_exhaust_pos3, _V( -1,1,0), 1.0, ph_sep, 10.0, 10.0);
-		th_sep[3] = CreateThruster (s_exhaust_pos4, _V( -1,-1,0), 1.0, ph_sep, 10.0, 10.0);
-		th_sep[4] = CreateThruster (s_exhaust_pos6, _V( 0,1,0), 1.0, ph_sep, 10.0, 10.0);
-		th_sep[5] = CreateThruster (s_exhaust_pos7, _V( 0,-1,0), 1.0, ph_sep, 10.0, 10.0);
-		th_sep[6] = CreateThruster (s_exhaust_pos8, _V( 1,0,0), 1.0, ph_sep, 10.0, 10.0);
-		th_sep[7] = CreateThruster (s_exhaust_pos9, _V( -1,0,0), 1.0, ph_sep, 10.0, 10.0);
+	th_sep[0] = CreateThruster (s_exhaust_pos1, _V( 1,1,0), 1.0, ph_sep, 10.0, 10.0);
+	th_sep[1] = CreateThruster (s_exhaust_pos2, _V( 1,-1,0), 1.0, ph_sep, 10.0, 10.0);
+	th_sep[2] = CreateThruster (s_exhaust_pos3, _V( -1,1,0), 1.0, ph_sep, 10.0, 10.0);
+	th_sep[3] = CreateThruster (s_exhaust_pos4, _V( -1,-1,0), 1.0, ph_sep, 10.0, 10.0);
+	th_sep[4] = CreateThruster (s_exhaust_pos6, _V( 0,1,0), 1.0, ph_sep, 10.0, 10.0);
+	th_sep[5] = CreateThruster (s_exhaust_pos7, _V( 0,-1,0), 1.0, ph_sep, 10.0, 10.0);
+	th_sep[6] = CreateThruster (s_exhaust_pos8, _V( 1,0,0), 1.0, ph_sep, 10.0, 10.0);
+	th_sep[7] = CreateThruster (s_exhaust_pos9, _V( -1,0,0), 1.0, ph_sep, 10.0, 10.0);
 
-		for (i = 0; i < 8; i++) {
-			AddExhaustStream (th_sep[i], &seperation_junk);
-		}
+	for (i = 0; i < 8; i++) {
+		AddExhaustStream (th_sep[i], &seperation_junk);
 	}
 
 	VECTOR3 m_exhaust_pos1= {0,0,-9+ offset};
@@ -1199,16 +1196,7 @@ void SaturnV::SeparateStage (int new_stage)
 		// Fire 'seperation' thrusters.
 		//
 
-		if (viewpos != SATVIEW_ENG1 && viewpos != SATVIEW_ENG2) 
-		{
-			FireSeperationThrusters(th_sep);
-		}
-
-		if (viewpos == SATVIEW_ENG1) 
-		{
-			oapiSetFocusObject(hstg1);
-			oapiCameraAttach(hstg1, CAM_COCKPIT);
-		}
+		FireSeperationThrusters(th_sep);
 	}
 
 	if (stage == LAUNCH_STAGE_TWO && new_stage == LAUNCH_STAGE_TWO_ISTG_JET)
@@ -1255,10 +1243,7 @@ void SaturnV::SeparateStage (int new_stage)
 		// Fire 'seperation' thrusters.
 		//
 
-		if (viewpos != SATVIEW_ENG1 && viewpos != SATVIEW_ENG2) 
-		{
-			FireSeperationThrusters(th_sep2);
-		}
+		FireSeperationThrusters(th_sep2);
 
 		ConfigureStageMeshes (new_stage);
 	}
@@ -1313,10 +1298,7 @@ void SaturnV::SeparateStage (int new_stage)
 		// Fire 'seperation' thrusters.
 		//
 
-		if (viewpos != SATVIEW_ENG1 && viewpos != SATVIEW_ENG2)
-		{
-			FireSeperationThrusters(th_sep);
-		}
+		FireSeperationThrusters(th_sep);
 	}
 
 	if ((stage == LAUNCH_STAGE_SIVB || stage == STAGE_ORBIT_SIVB) && new_stage != CM_STAGE)


### PR DESCRIPTION
Part of the fix for getting stuck in the engineering cameras (#1211) was reloading the VC using clbkLoadVC instead of only updating the view position by calling SetView. Calling clbkLoadVC directly in code, instead of just letting Orbiter do that, is apparently a very bad idea, as the VC panel areas aren't reset. This caused the panel areas to be created an additional time and certain render functions (like the mission timer) looked very strange as the digits were drawn on it twice (or possibly even more).

The view position code is complex enough as it is and for now my solution for this problem is to delete the engineering cameras entirely. Lots of ugly code was associated with it and not many people actually used it, so, I think this isn't such a bad thing to do.