### PR TITLE
Add RTCC Display to Calculate IMU Parking Angles on Lunar Surface

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
@@ -181,6 +181,7 @@ public:
 	void SaturnVTLITargetUplink();
 	int GetVesselParameters(int Thruster, int &Config, int &TVC, double &CSMMass, double &LMMass);
 	void menuCalculateIMUComparison();
+	void menuCalculateIMUParkingAngles(agc_t* agc);
 
 	int startSubthread(int fcn);
 	int subThread();
@@ -406,6 +407,10 @@ public:
 
 	//DEBUG
 	VECTOR3 DebugIMUTorquingAngles;
+
+	//IMU PARKING ANGLES
+	unsigned int GravVec[6];
+	VECTOR3 IMUParkingAngles;
 
 private:
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -1276,6 +1276,11 @@ void ApolloRTCCMFD::menuSetRTACFPage()
 	SelectPage(129);
 }
 
+void ApolloRTCCMFD::menuSetIMUParkingAnglesPage()
+{
+	SelectPage(131);
+}
+
 void ApolloRTCCMFD::menuPerigeeAdjustCalc()
 {
 	G->PerigeeAdjustCalc();
@@ -8992,6 +8997,18 @@ void ApolloRTCCMFD::UpdateLOSTDisplay()
 void ApolloRTCCMFD::menuCalculateIMUComparison()
 {
 	G->menuCalculateIMUComparison();
+}
+
+void ApolloRTCCMFD::menuCalculateIMUParkingAngles()
+{
+	//Only calculate for LM
+	if (G->vesseltype != 1) return;
+
+	agc_t* vagc;
+	lem = (LEM*)G->vessel;
+	vagc = &lem->agc.vagc;
+
+	G->menuCalculateIMUParkingAngles(vagc);
 }
 
 void ApolloRTCCMFD::menuSLVNavigationUpdateCalc()

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -723,6 +723,8 @@ public:
 	void CalculateLOSTDOKOption();
 	void menuSetDebugPage();
 	void menuCalculateIMUComparison();
+	void menuSetIMUParkingAnglesPage();
+	void menuCalculateIMUParkingAngles();
 	void menuSLVNavigationUpdateCalc();
 	void menuSLVNavigationUpdateUplink();
 	void menuVectorPanelSummaryPage();

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -2073,6 +2073,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		skp->Text(1 * W / 8, 2 * H / 14, "Landing Site", 12);
 		skp->Text(1 * W / 8, 4 * H / 14, "REFSMMAT", 8);
 		skp->Text(1 * W / 8, 6 * H / 14, "RTACF", 5);
+		skp->Text(1 * W / 8, 8 * H / 14, "IMU Parking Angles", 18);
 		skp->Text(1 * W / 8, 10 * H / 14, "Nodal Target Conversion", 23);
 		skp->Text(1 * W / 8, 12 * H / 14, "Descent Abort", 13);
 
@@ -10627,6 +10628,28 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 
 		skp->SetTextAlign(oapi::Sketchpad::CENTER);
 		Text(skp, GC->rtcc->RTCCONLINEMON.LastMEDMessage, 1, 21, 2, 22);
+	}
+	else if (screen == 131)
+	{
+		skp->Text((int)(2.5 * W / 8), 2 * H / 32, "IMU Parking Angles", 18);
+
+		skp->Text((int)(0.5 * W / 8), 4 * H / 14, "Octal Values:", 13);
+
+		for (int i = 0; i < 6; i++)
+		{
+			sprintf(Buffer, "%05o", G->GravVec[i]);
+			skp->Text((int)(0.5 * W / 8), (5 + i) * H / 14, Buffer, strlen(Buffer));
+		}
+
+
+		skp->Text(10 * W / 16, 5 * H / 14, "IMU Angles:", 11);
+
+		sprintf(Buffer, "OGA: %+.2lf°", G->IMUParkingAngles.x * DEG);
+		skp->Text(10 * W / 16, 6 * H / 14, Buffer, strlen(Buffer));
+		sprintf(Buffer, "IGA:   %+.2lf°", G->IMUParkingAngles.y * DEG);
+		skp->Text(10 * W / 16, 7 * H / 14, Buffer, strlen(Buffer));
+		sprintf(Buffer, "MGA: %+.2lf°", G->IMUParkingAngles.z * DEG);
+		skp->Text(10 * W / 16, 8 * H / 14, Buffer, strlen(Buffer));
 	}
 	return true;
 }

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
@@ -722,7 +722,7 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 		{ "Landing Site Update", 0, 'V' },
 		{ "REFSMMAT", 0, 'R' },
 		{ "Optics", 0, 'P' },
-		{ "", 0, ' ' },
+		{ "IMU Parking Angles", 0, 'E' },
 		{ "Convert nodal target", 0, 'N' },
 		{ "Descent abort", 0, 'A' },
 
@@ -739,7 +739,7 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 	RegisterFunction("LS", OAPI_KEY_V, &ApolloRTCCMFD::menuSetLSUpdateMenu);
 	RegisterFunction("REF", OAPI_KEY_R, &ApolloRTCCMFD::menuSetREFSMMATPage);
 	RegisterFunction("OPT", OAPI_KEY_P, &ApolloRTCCMFD::menuSetRTACFPage);
-	RegisterFunction("", OAPI_KEY_E, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("PRK", OAPI_KEY_E, &ApolloRTCCMFD::menuSetIMUParkingAnglesPage);
 	RegisterFunction("NOD", OAPI_KEY_N, &ApolloRTCCMFD::menuSetNodalTargetConversionPage);
 	RegisterFunction("ABO", OAPI_KEY_A, &ApolloRTCCMFD::menuSetPDAPPage);
 
@@ -4453,6 +4453,39 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 	RegisterFunction("", OAPI_KEY_R, &ApolloRTCCMFD::menuVoid);
 	RegisterFunction("", OAPI_KEY_U, &ApolloRTCCMFD::menuVoid);
 	RegisterFunction("BCK", OAPI_KEY_B, &ApolloRTCCMFD::menuSetMenu);
+
+	static const MFDBUTTONMENU mnu131[] =
+	{
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "", 0, ' ' },
+		{ "Back to menu", 0, 'B' },
+	};
+
+	RegisterPage(mnu131, sizeof(mnu131) / sizeof(MFDBUTTONMENU));
+
+	RegisterFunction("", OAPI_KEY_P, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_Q, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_V, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_L, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_H, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_Q, &ApolloRTCCMFD::menuVoid);
+
+	RegisterFunction("CLC", OAPI_KEY_C, &ApolloRTCCMFD::menuCalculateIMUParkingAngles);
+	RegisterFunction("", OAPI_KEY_E, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_Q, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_R, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("", OAPI_KEY_U, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("BCK", OAPI_KEY_B, &ApolloRTCCMFD::menuSetUtilityMenu);
 }
 
 bool ApolloRTCCMFDButtons::SearchForKeysInOtherPages() const


### PR DESCRIPTION
This PR adds a display to the utilities page to automatically gather the gravity vector octals and calculate the parking angles for the powerdown method used on Apollo 16 and 17 (although the calculation will work for any LGC running Luminary 210).

![IMU Parking Angles](https://github.com/orbiternassp/NASSP/assets/34657891/f5bfc263-d77f-4944-a501-1fc52d0b5005)

## Testing Instructions

On a mission running Luminary 210, after running a P57 with a gravity calc, go to UTI->PRK, and press CLC. Verify EMEM addresses 2221-2226 match up with the octal values in the first column, and that parking angles seem reasonable (i.e between 0 and 360 degrees). IGA should always equal to +0° and MGA should be somewhere near +90°.