### PR TITLE
Move all maneuver type PADs to global MFD memory; clean up landmark tracking PAD; improvements to more PAD calculation function inputs; Maneuver PADs are fully MPT compatible

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCCPADForms.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCCPADForms.h
@@ -70,6 +70,23 @@ struct AP7MNV {
 // APOLLO 7 - TERMINAL PHASE INITIATE
 // (The form doesn't match the field list?)
 struct AP7TPI {
+	AP7TPI::AP7TPI()
+	{
+		GETI = 0.0;
+		Vg = _V(0, 0, 0);
+		Backup_dV = _V(0.0, 0.0, 0.0);
+		dH_TPI = 0.0;
+		R = 0.0;
+		Rdot = 0.0;
+		EL = 0.0;
+		AZ = 0.0;
+		E = 0.0;
+		dTT = 0.0;
+		Backup_bT = _V(0.0, 0.0, 0.0);
+		dH_Max = 0.0;
+		dH_Min = 0.0;
+		GET = 0.0;
+	}
 	// ON THE FORM:
 	double GETI;		// TIG
 	VECTOR3 Vg;			// P40 velocity to be gained
@@ -246,6 +263,7 @@ struct AP11MNV {
 		LMWeight = 0.0;
 		dV = _V(0, 0, 0);
 		GETI = 0.0;
+		sprintf(remarks, "");
 	}
 
 	char purpose[64];	// PURPOSE

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCCPADForms.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCCPADForms.h
@@ -223,6 +223,31 @@ struct P27PAD {
 
 // APOLLO 11 - MANEUVER
 struct AP11MNV {
+	AP11MNV()
+	{
+		Trun = 0.0;
+		Shaft = 0.0;
+		Star = 0;
+		BSSStar = 0;
+		SPA = 0.0;
+		SXP = 0.0;
+		Att = _V(0, 0, 0);
+		GDCangles = _V(0, 0, 0);
+		SetStars[0] = 0;
+		SetStars[1] = 0;
+		HA = 0.0;
+		HP = 0.0;
+		Weight = 0.0;
+		burntime = 0.0;
+		Vt = 0.0;
+		Vc = 0.0;
+		pTrim = 0.0;
+		yTrim = 0.0;
+		LMWeight = 0.0;
+		dV = _V(0, 0, 0);
+		GETI = 0.0;
+	}
+
 	char purpose[64];	// PURPOSE
 	char PropGuid[64];	// Propulsion & Guidance System
 	double Weight;		// Vehicle weight
@@ -253,7 +278,25 @@ struct AP11MNV {
 
 // APOLLO 11 LM - MANEUVER
 struct AP11LMMNV {
-	AP11LMMNV() : type(0) {}
+	AP11LMMNV::AP11LMMNV()
+	{
+		type = 0;
+		Att = _V(0, 0, 0);
+		BSSStar = 0;
+		burntime = 0.0;
+		CSMWeight = 0.0;
+		dV = _V(0, 0, 0);
+		dVR = 0.0;
+		dV_AGS = _V(0, 0, 0);
+		GETI = 0.0;
+		HA = 0.0;
+		HP = 0.0;
+		LMWeight = 0.0;
+		SPA = 0.0;
+		SXP = 0.0;
+		IMUAtt = _V(0, 0, 0);
+		sprintf(remarks, "");
+	}
 
 	char purpose[64];	// PURPOSE
 	double GETI;		// TIG

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C.cpp
@@ -1231,11 +1231,11 @@ bool RTCC::CalculationMTP_C(int fcn, LPVOID &pad, char * upString, char * upDesc
 	case 60: //Rev 136 Landmark Tracking Update
 	{
 		LMARKTRKPADOpt opt;
-		SV sv0;
+		EphemerisData sv0;
 
 		AP11LMARKTRKPAD * form = (AP11LMARKTRKPAD *)pad;
 
-		sv0 = StateVectorCalc(calcParams.src);
+		sv0 = StateVectorCalcEphem(calcParams.src);
 
 		opt.sv0 = sv0;
 
@@ -1360,7 +1360,7 @@ bool RTCC::CalculationMTP_C(int fcn, LPVOID &pad, char * upString, char * upDesc
 			opt.entries = 4;
 		}
 
-		LandmarkTrackingPAD(&opt, *form);
+		LandmarkTrackingPAD(opt, *form);
 	}
 	break;
 	case 24: //MISSION C BLOCK DATA 14

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C_PRIME.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C_PRIME.cpp
@@ -1552,7 +1552,7 @@ bool RTCC::CalculationMTP_C_PRIME(int fcn, LPVOID &pad, char * upString, char * 
 		entopt.REFSMMAT = GetREFSMMATfromAGC(&mcc->cm->agc.vagc, true);
 		entopt.sv0 = sv;
 
-		LunarEntryPAD(&entopt, *form);
+		LunarEntryPAD(entopt, *form);
 		sprintf(form->Area[0], "MIDPAC");
 		if (entopt.direct == false)
 		{
@@ -1577,7 +1577,7 @@ bool RTCC::CalculationMTP_C_PRIME(int fcn, LPVOID &pad, char * upString, char * 
 		entopt.REFSMMAT = GetREFSMMATfromAGC(&mcc->cm->agc.vagc, true);
 		entopt.sv0 = sv;
 
-		LunarEntryPAD(&entopt, *form);
+		LunarEntryPAD(entopt, *form);
 		sprintf(form->Area[0], "MIDPAC");
 
 		AGCStateVectorUpdate(buffer1, sv, true);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_D.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_D.cpp
@@ -1761,11 +1761,11 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 	case 54: //LANDMARK TRACKING UPDATE 4
 	{
 		LMARKTRKPADOpt opt;
-		SV sv0;
+		EphemerisData sv0;
 
 		AP11LMARKTRKPAD * form = (AP11LMARKTRKPAD *)pad;
 
-		sv0 = StateVectorCalc(calcParams.src);
+		sv0 = StateVectorCalcEphem(calcParams.src);
 
 		opt.sv0 = sv0;
 
@@ -1876,7 +1876,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			opt.entries = 4;
 		}
 
-		LandmarkTrackingPAD(&opt, *form);
+		LandmarkTrackingPAD(opt, *form);
 	}
 	break;
 	case 55: //BLOCK DATA 16

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
@@ -1324,11 +1324,11 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 	case 57: //REV 30 LANDMARK TRACKING PADs
 	{
 		LMARKTRKPADOpt opt;
-		SV sv0;
+		EphemerisData sv0;
 
 		AP11LMARKTRKPAD * form = (AP11LMARKTRKPAD *)pad;
 
-		sv0 = StateVectorCalc(calcParams.src);
+		sv0 = StateVectorCalcEphem(calcParams.src);
 
 		opt.sv0 = sv0;
 
@@ -1429,7 +1429,7 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 			opt.entries = 2;
 		}
 
-		LandmarkTrackingPAD(&opt, *form);
+		LandmarkTrackingPAD(opt, *form);
 	}
 	break;
 	case 60: //STATE VECTOR and LLS 2 REFSMMAT UPLINK

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
@@ -1980,15 +1980,16 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 		AP10CSIPADOpt manopt;
 		SPQOpt opt;
 		SPQResults res;
-		SV sv_CSM, sv_LM, sv_CSI;
-		MATRIX3 Q_Xx;
+		SV sv_CSM, sv_LM;
 		VECTOR3 dV_LVLH;
 		double GETbase, dt_apo;
+		PLAWDTOutput WeightsTable;
 
 		AP10CSI * form = (AP10CSI *)pad;
 
 		sv_CSM = StateVectorCalc(calcParams.src);
 		sv_LM = StateVectorCalc(calcParams.tgt);
+		WeightsTable = GetWeightsTable(calcParams.tgt, false, false);
 		GETbase = CalcGETBase();
 
 		//CSI at apolune
@@ -2004,19 +2005,21 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 		opt.t_TPI = calcParams.TPI;
 
 		ConcentricRendezvousProcessor(opt, res);
-
-		sv_CSI = coast(sv_LM, opt.t_CSI - OrbMech::GETfromMJD(sv_LM.MJD, GETbase));
-		Q_Xx = OrbMech::LVLH_Matrix(sv_CSI.R, sv_CSI.V);
 		dV_LVLH = res.dV_CSI;
+
+		//Use nominal AGS K-Factor for now
+		SystemParameters.MCGZSS = SystemParameters.MCGZSL + 90.0;
 
 		manopt.dV_LVLH = dV_LVLH;
 		manopt.enginetype = RTCC_ENGINETYPE_LMAPS;
 		manopt.REFSMMAT = GetREFSMMATfromAGC(&mcc->lm->agc.vagc, false);
-		manopt.sv0 = sv_LM;
+		manopt.sv0 = ConvertSVtoEphemData(sv_LM);
+		manopt.WeightsTable = WeightsTable;
 		manopt.t_CSI = calcParams.CSI;
 		manopt.t_TPI = calcParams.TPI;
 
-		AP10CSIPAD(&manopt, *form);
+		AP10CSIPAD(manopt, *form);
+		form->type = 0;
 	}
 	break;
 	case 80: //APS DEPLETION UPDATE
@@ -2352,7 +2355,7 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 		entopt.REFSMMAT = REFSMMAT;
 		entopt.sv0 = sv;
 
-		LunarEntryPAD(&entopt, *form);
+		LunarEntryPAD(entopt, *form);
 		sprintf(form->Area[0], "MIDPAC");
 		if (entopt.direct == false)
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
@@ -1160,10 +1160,10 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		landmarkopt.lat[0] = 1.243*RAD;
 		landmarkopt.LmkTime[0] = calcParams.LOI + 22.5*3600.0;
 		landmarkopt.lng[0] = 23.688*RAD;
-		landmarkopt.sv0 = sv;
+		landmarkopt.sv0 = ConvertSVtoEphemData(sv);
 		landmarkopt.entries = 1;
 
-		LandmarkTrackingPAD(&landmarkopt, *form);
+		LandmarkTrackingPAD(landmarkopt, *form);
 
 		AGCStateVectorUpdate(buffer1, sv, true);
 		AGCDesiredREFSMMATUpdate(buffer2, REFSMMAT);
@@ -1525,11 +1525,11 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 	case 64: //LM ACQUISITION TIME
 	{
 		LMARKTRKPADOpt opt;
-		SV sv0;
+		EphemerisData sv0;
 
 		AP11LMARKTRKPAD * form = (AP11LMARKTRKPAD *)pad;
 
-		sv0 = StateVectorCalc(calcParams.src);
+		sv0 = StateVectorCalcEphem(calcParams.src);
 
 		opt.sv0 = sv0;
 
@@ -1562,7 +1562,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 			opt.entries = 1;
 		}
 
-		LandmarkTrackingPAD(&opt, *form);
+		LandmarkTrackingPAD(opt, *form);
 	}
 	break;
 	case 170: //PDI2 PAD

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
@@ -1607,7 +1607,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		opt.sv0 = sv;
 		opt.t_land = CZTDTGTU.GETTD;
 
-		PDI_PAD(&opt, *form);
+		PDI_PAD(opt, *form);
 	}
 	break;
 	case 71: //PDI ABORT PAD
@@ -2000,15 +2000,19 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 
 		AP10CSIPADOpt opt;
 
+		//Use nominal AGS K-Factor for now
+		SystemParameters.MCGZSS = SystemParameters.MCGZSL + 90.0;
+
 		opt.dV_LVLH = calcParams.DVSTORE1;
 		opt.enginetype = RTCC_ENGINETYPE_LMRCSPLUS4;
-		opt.KFactor = 90.0*3600.0;
 		opt.REFSMMAT = GetREFSMMATfromAGC(&mcc->lm->agc.vagc, false);
-		opt.sv0 = calcParams.SVSTORE1;
+		opt.sv0 = ConvertSVtoEphemData(calcParams.SVSTORE1);
 		opt.t_CSI = calcParams.CSI;
 		opt.t_TPI = calcParams.TPI;
+		opt.WeightsTable.CC[RTCC_CONFIG_A] = true;
+		opt.WeightsTable.ConfigWeight = opt.WeightsTable.LMAscWeight = calcParams.SVSTORE1.mass;
 
-		AP10CSIPAD(&opt, *form);
+		AP10CSIPAD(opt, *form);
 		form->type = 1;
 	}
 	break;
@@ -2390,15 +2394,19 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 
 		AP10CSIPADOpt opt;
 
+		//Use nominal AGS K-Factor for now
+		SystemParameters.MCGZSS = SystemParameters.MCGZSL + 120.0;
+
 		opt.dV_LVLH = calcParams.DVSTORE1;
 		opt.enginetype = RTCC_ENGINETYPE_LMRCSPLUS4;
-		opt.KFactor = 120.0*3600.0;
 		opt.REFSMMAT = EZJGMTX3.data[RTCC_REFSMMAT_TYPE_LLD - 1].REFSMMAT;
-		opt.sv0 = calcParams.SVSTORE1;
+		opt.sv0 = ConvertSVtoEphemData(calcParams.SVSTORE1);
 		opt.t_CSI = calcParams.CSI;
 		opt.t_TPI = calcParams.TPI;
+		opt.WeightsTable.CC[RTCC_CONFIG_A] = true;
+		opt.WeightsTable.ConfigWeight = opt.WeightsTable.LMAscWeight = calcParams.SVSTORE1.mass;
 
-		AP10CSIPAD(&opt, *form);
+		AP10CSIPAD(opt, *form);
 		form->type = 1;
 	}
 	break;
@@ -2682,7 +2690,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		entopt.REFSMMAT = REFSMMAT;
 		entopt.sv0 = sv;
 
-		LunarEntryPAD(&entopt, *form);
+		LunarEntryPAD(entopt, *form);
 		sprintf(form->Area[0], "MIDPAC");
 		if (entopt.direct == false)
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
@@ -1985,16 +1985,16 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 	case 66: //LM ACQUISITION TIME
 	{
 		LMARKTRKPADOpt opt;
-		SV sv0;
+		EphemerisData sv0;
 		double GET_SV;
 
 		AP11LMARKTRKPAD * form = (AP11LMARKTRKPAD *)pad;
 
-		sv0 = StateVectorCalc(calcParams.src);
+		sv0 = StateVectorCalcEphem(calcParams.src);
 
 		opt.sv0 = sv0;
 
-		GET_SV = OrbMech::GETfromMJD(sv0.MJD, CalcGETBase());
+		GET_SV = GETfromGMT(sv0.GMT);
 
 		if (fcn == 61)
 		{
@@ -2071,7 +2071,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 			opt.entries = 1;
 		}
 
-		LandmarkTrackingPAD(&opt, *form);
+		LandmarkTrackingPAD(opt, *form);
 	}
 	break;
 	case 170: //PDI2 PAD

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
@@ -2186,7 +2186,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 		opt.sv0 = sv;
 		opt.t_land = CZTDTGTU.GETTD;
 
-		PDI_PAD(&opt, *form);
+		PDI_PAD(opt, *form);
 	}
 	break;
 	case 71: //PDI ABORT PAD
@@ -3003,13 +3003,14 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 
 		opt.dV_LVLH = calcParams.DVSTORE1;
 		opt.enginetype = RTCC_ENGINETYPE_LMRCSPLUS4;
-		opt.KFactor = GETfromGMT(GetAGSClockZero());
 		opt.REFSMMAT = EZJGMTX3.data[RTCC_REFSMMAT_TYPE_LLD - 1].REFSMMAT;
-		opt.sv0 = calcParams.SVSTORE1;
+		opt.sv0 = ConvertSVtoEphemData(calcParams.SVSTORE1);
 		opt.t_CSI = calcParams.CSI;
 		opt.t_TPI = calcParams.TPI;
+		opt.WeightsTable.CC[RTCC_CONFIG_A] = true;
+		opt.WeightsTable.ConfigWeight = opt.WeightsTable.LMAscWeight = calcParams.SVSTORE1.mass;
 
-		AP10CSIPAD(&opt, *form);
+		AP10CSIPAD(opt, *form);
 		form->type = 1;
 	}
 	break;
@@ -3599,7 +3600,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID &pad, char * upString, char * upDes
 		entopt.REFSMMAT = REFSMMAT;
 		entopt.sv0 = sv;
 
-		LunarEntryPAD(&entopt, *form);
+		LunarEntryPAD(entopt, *form);
 		sprintf(form->Area[0], "MIDPAC");
 		if (entopt.direct == false)
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -313,6 +313,22 @@ AP11LMManPADOpt::AP11LMManPADOpt()
 	sxtstardtime = 0;
 }
 
+AP10CSIPADOpt::AP10CSIPADOpt()
+{
+	t_CSI = 0.0;
+	t_TPI = 0.0;
+	dV_LVLH = _V(0, 0, 0);
+	REFSMMAT = _M(1, 0, 0, 0, 1, 0, 0, 0, 1);
+	enginetype = RTCC_ENGINETYPE_CSMRCSPLUS4;
+}
+
+AP9LMCDHPADOpt::AP9LMCDHPADOpt()
+{
+	TIG = 0.0;
+	dV_LVLH = _V(0, 0, 0);
+	REFSMMAT = _M(1, 0, 0, 0, 1, 0, 0, 0, 1);
+}
+
 FIDOOrbitDigitals::FIDOOrbitDigitals()
 {
 	A = 0.0;
@@ -4049,21 +4065,29 @@ void RTCC::LMThrottleProgram(double F, double v_e, double mass, double dV_LVLH, 
 	}
 }
 
-void RTCC::AP10CSIPAD(AP10CSIPADOpt *opt, AP10CSI &pad)
+void RTCC::AP10CSIPAD(const AP10CSIPADOpt &opt, AP10CSI &pad)
 {
-	SV sv1, sv2;
-	MATRIX3 Q_Xx, M, M_R;
+	EphemerisData sv1, sv2;
+	MATRIX3 M, M_R;
 	VECTOR3 V_G, UX, UY, UZ, IMUangles, FDAIangles, dV_AGS;
-	double dt, TIG_AGS;
+	double GMT_CSI, GMT_TPI, dt, f_T, wdot, OnboardThrust;
 
-	dt = opt->t_CSI - (opt->sv0.MJD - CalcGETBase()) * 24.0 * 60.0 * 60.0;
-	sv1 = coast(opt->sv0, dt);
+	//Convert to GMT
+	GMT_CSI = GMTfromGET(opt.t_CSI);
+	GMT_TPI = GMTfromGET(opt.t_TPI);
 
-	PoweredFlightProcessor(sv1, opt->t_CSI, opt->enginetype, 0.0, opt->dV_LVLH, true, TIG_AGS, dV_AGS, false);
+	//Take state vector to TIG
+	dt = GMT_CSI - opt.sv0.GMT;
+	sv1 = coast(opt.sv0, dt, opt.WeightsTable.ConfigWeight, opt.WeightsTable.ConfigArea, opt.WeightsTable.KFactor, false);
 
-	Q_Xx = OrbMech::LVLH_Matrix(sv1.R, sv1.V);
-	V_G = tmul(Q_Xx, opt->dV_LVLH);
+	//Account for DV vector rotation in P40/P41
+	EngineParametersTable(opt.enginetype, f_T, wdot, OnboardThrust);
+	V_G = PIEXDV(sv1.R, sv1.V, opt.WeightsTable.ConfigWeight, OnboardThrust, opt.dV_LVLH, true);
 
+	//Calculate AGS DV
+	dV_AGS = PIAEDV(V_G, sv1.R, sv1.V, sv1.R, false);
+
+	//Calculate burn attitude
 	UX = unit(V_G);
 
 	if (abs(dotp(UX, unit(sv1.R))) < cos(0.01*RAD))
@@ -4079,7 +4103,7 @@ void RTCC::AP10CSIPAD(AP10CSIPADOpt *opt, AP10CSI &pad)
 	M_R = _M(UX.x, UX.y, UX.z, UY.x, UY.y, UY.z, UZ.x, UZ.y, UZ.z);
 	M = _M(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
 
-	IMUangles = OrbMech::CALCGAR(opt->REFSMMAT, mul(OrbMech::tmat(M), M_R));
+	IMUangles = OrbMech::CALCGAR(opt.REFSMMAT, mul(OrbMech::tmat(M), M_R));
 
 	FDAIangles.z = asin(-cos(IMUangles.z)*sin(IMUangles.x));
 	if (abs(sin(FDAIangles.z)) != 1.0)
@@ -4105,12 +4129,13 @@ void RTCC::AP10CSIPAD(AP10CSIPADOpt *opt, AP10CSI &pad)
 		FDAIangles.z += PI2;
 	}
 
-	pad.DEDA373 = (opt->t_CSI - opt->KFactor) / 60.0;
-	pad.DEDA275 = (opt->t_TPI - opt->KFactor) / 60.0;
+	//Output parameters
+	pad.DEDA373 = (GMT_CSI - GetAGSClockZero()) / 60.0;
+	pad.DEDA275 = (GMT_TPI - GetAGSClockZero()) / 60.0;
 	pad.PLM_FDAI = FDAIangles.y*DEG;
-	pad.t_CSI = opt->t_CSI;
-	pad.t_TPI = opt->t_TPI;
-	pad.dV_LVLH = opt->dV_LVLH / 0.3048;
+	pad.t_CSI = opt.t_CSI;
+	pad.t_TPI = opt.t_TPI;
+	pad.dV_LVLH = opt.dV_LVLH / 0.3048;
 	pad.dV_AGS = dV_AGS / 0.3048;
 }
 
@@ -4681,15 +4706,15 @@ void RTCC::AP7TPIPAD(const AP7TPIPADOpt &opt, AP7TPI &pad)
 	pad.dH_Max = TPIPAD_ddH / 1852.0;
 }
 
-void RTCC::AP9LMTPIPAD(AP9LMTPIPADOpt *opt, AP9LMTPI &pad)
+void RTCC::AP9LMTPIPAD(const AP9LMTPIPADOpt &opt, AP9LMTPI &pad)
 {
 	EphemerisData sv_A1, sv_P1;
 	MATRIX3 Rot1, Rot2, M;
 	VECTOR3 u, U_L, dV_LOS, IMUangles, FDAIangles, R1, R2, R3;
 	double R, Rdot;
 
-	sv_A1 = coast(opt->sv_A, opt->GMT_TIG - opt->sv_A.GMT);
-	sv_P1 = coast(opt->sv_P, opt->GMT_TIG - opt->sv_P.GMT);
+	sv_A1 = coast(opt.sv_A, opt.GMT_TIG - opt.sv_A.GMT);
+	sv_P1 = coast(opt.sv_P, opt.GMT_TIG - opt.sv_P.GMT);
 	Rot1 = OrbMech::LVLH_Matrix(sv_A1.R, sv_A1.V);
 
 	u = unit(crossp(sv_A1.R, sv_A1.V));
@@ -4699,13 +4724,13 @@ void RTCC::AP9LMTPIPAD(AP9LMTPIPADOpt *opt, AP9LMTPI &pad)
 	R3 = crossp(R1, R2);
 	Rot2 = _M(R1.x, R1.y, R1.z, R2.x, R2.y, R2.z, R3.x, R3.y, R3.z);
 
-	dV_LOS = mul(Rot2, tmul(Rot1, opt->dV_LVLH));
+	dV_LOS = mul(Rot2, tmul(Rot1, opt.dV_LVLH));
 
 	R = abs(length(sv_P1.R - sv_A1.R));
 	Rdot = dotp(sv_P1.V - sv_A1.V, U_L);
 
 	M = _M(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
-	IMUangles = OrbMech::CALCGAR(opt->REFSMMAT, mul(OrbMech::tmat(M), Rot1));
+	IMUangles = OrbMech::CALCGAR(opt.REFSMMAT, mul(OrbMech::tmat(M), Rot1));
 
 	FDAIangles.z = asin(-cos(IMUangles.z)*sin(IMUangles.x));
 	if (abs(sin(FDAIangles.z)) != 1.0)
@@ -4733,25 +4758,27 @@ void RTCC::AP9LMTPIPAD(AP9LMTPIPADOpt *opt, AP9LMTPI &pad)
 
 	pad.Att = _V(OrbMech::imulimit(FDAIangles.x*DEG), OrbMech::imulimit(FDAIangles.y*DEG), OrbMech::imulimit(FDAIangles.z*DEG));
 	pad.Backup_dV = dV_LOS / 0.3048;
-	pad.dVR = length(opt->dV_LVLH) / 0.3048;
-	pad.GETI = GETfromGMT(opt->GMT_TIG);
+	pad.dVR = length(opt.dV_LVLH) / 0.3048;
+	pad.GETI = GETfromGMT(opt.GMT_TIG);
 	pad.R = R / 1852.0;
 	pad.Rdot = Rdot / 0.3048;
-	pad.Vg = opt->dV_LVLH / 0.3048;
+	pad.Vg = opt.dV_LVLH / 0.3048;
 }
 
-void RTCC::AP9LMCDHPAD(AP9LMCDHPADOpt *opt, AP9LMCDH &pad)
+void RTCC::AP9LMCDHPAD(const AP9LMCDHPADOpt &opt, AP9LMCDH &pad)
 {
-	SV sv_A1;
+	EphemerisData sv_A1;
 	MATRIX3 Rot1, M;
 	VECTOR3 IMUangles, FDAIangles, V_G;
+	double GMT_TIG;
 
-	sv_A1 = coast(opt->sv_A, opt->TIG - OrbMech::GETfromMJD(opt->sv_A.MJD, CalcGETBase()));
+	GMT_TIG = GMTfromGET(opt.TIG);
+	sv_A1 = coast(opt.sv_A, GMT_TIG - opt.sv_A.GMT);
 	Rot1 = OrbMech::LVLH_Matrix(sv_A1.R, sv_A1.V);
-	V_G = tmul(Rot1, opt->dV_LVLH);
+	V_G = tmul(Rot1, opt.dV_LVLH);
 
 	M = _M(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
-	IMUangles = OrbMech::CALCGAR(opt->REFSMMAT, mul(OrbMech::tmat(M), Rot1));
+	IMUangles = OrbMech::CALCGAR(opt.REFSMMAT, mul(OrbMech::tmat(M), Rot1));
 
 	FDAIangles.z = asin(-cos(IMUangles.z)*sin(IMUangles.x));
 	if (abs(sin(FDAIangles.z)) != 1.0)
@@ -4779,8 +4806,8 @@ void RTCC::AP9LMCDHPAD(AP9LMCDHPADOpt *opt, AP9LMCDH &pad)
 
 	pad.Pitch = OrbMech::imulimit(FDAIangles.y*DEG);
 	pad.Vg_AGS = mul(Rot1, V_G) / 0.3048;
-	pad.GETI = opt->TIG;
-	pad.Vg = opt->dV_LVLH / 0.3048;
+	pad.GETI = opt.TIG;
+	pad.Vg = opt.dV_LVLH / 0.3048;
 }
 
 void RTCC::CSMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool docked)
@@ -4976,7 +5003,7 @@ void RTCC::EarthOrbitEntry(const EarthEntryPADOpt &opt, AP7ENT &pad)
 	}
 }
 
-void RTCC::LunarEntryPAD(LunarEntryPADOpt *opt, AP11ENT &pad)
+void RTCC::LunarEntryPAD(const LunarEntryPADOpt &opt, AP11ENT &pad)
 {
 	VECTOR3 UX, UY, UZ, EIangles, UREI;
 	MATRIX3 M_R;
@@ -4990,13 +5017,13 @@ void RTCC::LunarEntryPAD(LunarEntryPADOpt *opt, AP11ENT &pad)
 	EIAlt = 400000.0*0.3048;
 	EMSAlt = 297431.0*0.3048;
 
-	if (opt->direct || length(opt->dV_LVLH) == 0.0)	//Check against a DV of 0
+	if (opt.direct || length(opt.dV_LVLH) == 0.0)	//Check against a DV of 0
 	{
-		sv1 = opt->sv0;
+		sv1 = opt.sv0;
 	}
 	else
 	{
-		sv1 = ExecuteManeuver(opt->sv0, opt->P30TIG, opt->dV_LVLH, 0.0, RTCC_ENGINETYPE_CSMSPS);
+		sv1 = ExecuteManeuver(opt.sv0, opt.P30TIG, opt.dV_LVLH, 0.0, RTCC_ENGINETYPE_CSMSPS);
 	}
 
 	if (sv1.gravref == hMoon)
@@ -5023,8 +5050,8 @@ void RTCC::LunarEntryPAD(LunarEntryPADOpt *opt, AP11ENT &pad)
 	entin.R0 = sv_EI_ECT.R;
 	entin.V0 = sv_EI_ECT.V;
 	entin.GMT0 = sv_EI_ECT.GMT;
-	entin.lat_T = opt->lat;
-	entin.lng_T = opt->lng;
+	entin.lat_T = opt.lat;
+	entin.lng_T = opt.lng;
 	entin.KSWCH = 3;
 
 	RMMYNI(entin, entout);
@@ -5046,7 +5073,7 @@ void RTCC::LunarEntryPAD(LunarEntryPADOpt *opt, AP11ENT &pad)
 	UZD = crossp(UXD, UYD);
 
 	M_R = _M(UXD.x, UXD.y, UXD.z, UYD.x, UYD.y, UYD.z, UZD.x, UZD.y, UZD.z);
-	EIangles = OrbMech::CALCGAR(opt->REFSMMAT, M_R);
+	EIangles = OrbMech::CALCGAR(opt.REFSMMAT, M_R);
 
 	UREI = unit(svEI.R);
 	EntryPADV400k = length(svEI.V);
@@ -5085,9 +5112,9 @@ void RTCC::LunarEntryPAD(LunarEntryPADOpt *opt, AP11ENT &pad)
 	Y_NB = unit(crossp(svEI.V, svEI.R));
 	X_NB = crossp(Y_NB, Z_NB);
 
-	X_SM = _V(opt->REFSMMAT.m11, opt->REFSMMAT.m12, opt->REFSMMAT.m13);
-	Y_SM = _V(opt->REFSMMAT.m21, opt->REFSMMAT.m22, opt->REFSMMAT.m23);
-	Z_SM = _V(opt->REFSMMAT.m31, opt->REFSMMAT.m32, opt->REFSMMAT.m33);
+	X_SM = _V(opt.REFSMMAT.m11, opt.REFSMMAT.m12, opt.REFSMMAT.m13);
+	Y_SM = _V(opt.REFSMMAT.m21, opt.REFSMMAT.m22, opt.REFSMMAT.m23);
+	Z_SM = _V(opt.REFSMMAT.m31, opt.REFSMMAT.m32, opt.REFSMMAT.m33);
 	A_MG = unit(crossp(X_NB, Y_SM));
 	cosIGA = dotp(A_MG, Z_SM);
 	sinIGA = dotp(A_MG, X_SM);
@@ -5100,7 +5127,7 @@ void RTCC::LunarEntryPAD(LunarEntryPADOpt *opt, AP11ENT &pad)
 	int Entrystaroct, EntryCOASstaroct;
 
 	//Sextant star check either at entry attitude or at horizon check attitude
-	if (opt->SxtStarCheckAttitudeOpt)
+	if (opt.SxtStarCheckAttitudeOpt)
 	{
 		SextantStarCheckAtt = _V(OrbMech::round(EIangles.x*DEG)*RAD, OrbMech::round(EIangles.y*DEG)*RAD, OrbMech::round(EIangles.z*DEG)*RAD);
 	}
@@ -5109,8 +5136,8 @@ void RTCC::LunarEntryPAD(LunarEntryPADOpt *opt, AP11ENT &pad)
 		SextantStarCheckAtt = _V(0, OrbMech::round(EntryPADHorChkPit*DEG)*RAD, 0);
 	}
 
-	OrbMech::checkstar(EZJGSTAR, opt->REFSMMAT, SextantStarCheckAtt, svSxtCheck.R, OrbMech::R_Earth, Entrystaroct, Entrytrunnion, Entryshaft);
-	OrbMech::coascheckstar(EZJGSTAR, opt->REFSMMAT, SextantStarCheckAtt, svSxtCheck.R, OrbMech::R_Earth, EntryCOASstaroct, EntryBSSpitch, EntryBSSXPos);
+	OrbMech::checkstar(EZJGSTAR, opt.REFSMMAT, SextantStarCheckAtt, svSxtCheck.R, OrbMech::R_Earth, Entrystaroct, Entrytrunnion, Entryshaft);
+	OrbMech::coascheckstar(EZJGSTAR, opt.REFSMMAT, SextantStarCheckAtt, svSxtCheck.R, OrbMech::R_Earth, EntryCOASstaroct, EntryBSSpitch, EntryBSSXPos);
 
 	pad.Att05[0] = _V(OrbMech::imulimit(EIangles.x*DEG), OrbMech::imulimit(EIangles.y*DEG), OrbMech::imulimit(EIangles.z*DEG));
 	pad.BSS[0] = EntryCOASstaroct;
@@ -5119,8 +5146,8 @@ void RTCC::LunarEntryPAD(LunarEntryPADOpt *opt, AP11ENT &pad)
 	pad.DO[0] = EntryPADDO;
 	pad.Gamma400K[0] = EntryPADgamma400k*DEG;
 	pad.GETHorCheck[0] = EntryPADHorChkGET;
-	pad.Lat[0] = opt->lat*DEG;
-	pad.Lng[0] = opt->lng*DEG;
+	pad.Lat[0] = opt.lat*DEG;
+	pad.Lng[0] = opt.lng*DEG;
 	pad.MaxG[0] = entout.gmax;
 	pad.PitchHorCheck[0] = OrbMech::imulimit(EntryPADHorChkPit*DEG);
 	pad.RET05[0] = entout.t_05g - sv_EI_eph.GMT;
@@ -6161,7 +6188,7 @@ void RTCC::TLI_PAD(const TLIPADOpt &opt, TLIPAD &pad)
 	pad.VI = length(sv_TLI.V) / 0.3048;
 }
 
-bool RTCC::PDI_PAD(PDIPADOpt* opt, AP11PDIPAD &pad)
+bool RTCC::PDI_PAD(const PDIPADOpt &opt, AP11PDIPAD &pad)
 {
 	SV sv1, sv2, sv_I;
 	MATRIX3 REFSMMAT;
@@ -6170,16 +6197,16 @@ bool RTCC::PDI_PAD(PDIPADOpt* opt, AP11PDIPAD &pad)
 
 	GETbase = CalcGETBase();
 
-	if (opt->direct)
+	if (opt.direct)
 	{
-		sv2 = opt->sv0;
+		sv2 = opt.sv0;
 	}
 	else
 	{
-		sv2 = ExecuteManeuver(opt->sv0, opt->P30TIG, opt->dV_LVLH, 0.0, RTCC_ENGINETYPE_LMDPS);
+		sv2 = ExecuteManeuver(opt.sv0, opt.P30TIG, opt.dV_LVLH, 0.0, RTCC_ENGINETYPE_LMDPS);
 	}
 
-	if (!PDIIgnitionAlgorithm(sv2, opt->R_LS, opt->t_land, sv_I, TTT, C_R, U_FDP, REFSMMAT))
+	if (!PDIIgnitionAlgorithm(sv2, opt.R_LS, opt.t_land, sv_I, TTT, C_R, U_FDP, REFSMMAT))
 	{
 		return false;
 	}
@@ -6190,7 +6217,7 @@ bool RTCC::PDI_PAD(PDIPADOpt* opt, AP11PDIPAD &pad)
 	MATRIX3 M, M_R;
 	double headsswitch;
 
-	if (opt->HeadsUp)
+	if (opt.HeadsUp)
 	{
 		headsswitch = -1.0;
 	}
@@ -6199,7 +6226,7 @@ bool RTCC::PDI_PAD(PDIPADOpt* opt, AP11PDIPAD &pad)
 		headsswitch = 1.0;
 	}
 
-	X_B = tmul(opt->REFSMMAT, unit(U_FDP));
+	X_B = tmul(opt.REFSMMAT, unit(U_FDP));
 	UX = X_B;
 	if (abs(dotp(UX, unit(sv_I.R))) < cos(0.01*RAD))
 	{
@@ -6213,7 +6240,7 @@ bool RTCC::PDI_PAD(PDIPADOpt* opt, AP11PDIPAD &pad)
 
 	M_R = _M(UX.x, UX.y, UX.z, UY.x, UY.y, UY.z, UZ.x, UZ.y, UZ.z);
 	M = _M(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
-	IMUangles = OrbMech::CALCGAR(opt->REFSMMAT, mul(OrbMech::tmat(M), M_R));
+	IMUangles = OrbMech::CALCGAR(opt.REFSMMAT, mul(OrbMech::tmat(M), M_R));
 
 	FDAIangles.z = asin(-cos(IMUangles.z)*sin(IMUangles.x));
 	if (abs(sin(FDAIangles.z)) != 1.0)
@@ -6241,14 +6268,14 @@ bool RTCC::PDI_PAD(PDIPADOpt* opt, AP11PDIPAD &pad)
 
 	pad.Att = _V(OrbMech::imulimit(FDAIangles.x*DEG), OrbMech::imulimit(FDAIangles.y*DEG), OrbMech::imulimit(FDAIangles.z*DEG));
 	pad.CR = C_R / 1852.0;
-	pad.DEDA231 = length(opt->R_LS) / 0.3048 / 100.0;
+	pad.DEDA231 = length(opt.R_LS) / 0.3048 / 100.0;
 	pad.GETI = t_IG;
 	pad.t_go = -TTT;
 
 	return true;
 }
 
-void RTCC::LunarAscentPAD(ASCPADOpt opt, AP11LMASCPAD &pad)
+void RTCC::LunarAscentPAD(const ASCPADOpt &opt, AP11LMASCPAD &pad)
 {
 	EphemerisData sv_Ins, sv_CSM_TIG;
 	MATRIX3 Rot_MCT_MCI;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -341,13 +341,15 @@ struct AP11LMManPADOpt
 
 struct AP10CSIPADOpt
 {
-	SV sv0;
-	double t_CSI;
-	double t_TPI;
-	VECTOR3 dV_LVLH;
-	MATRIX3 REFSMMAT;
-	int enginetype = RTCC_ENGINETYPE_CSMRCSPLUS4; //Engine type used for the maneuver
-	double KFactor = 0.0;
+	AP10CSIPADOpt();
+
+	EphemerisData sv0;			// State vector of active vehicle
+	double t_CSI;				// Time of CSI (GET)
+	double t_TPI;				// Time of TPI (GET)
+	VECTOR3 dV_LVLH;			// DV of CSI maneuver (LVLH)
+	MATRIX3 REFSMMAT;			// REFSMMAT during the maneuver
+	int enginetype;				//Engine type used for the maneuver
+	PLAWDTOutput WeightsTable;	// Table with spacecraft weights
 };
 
 struct AP7TPIPADOpt
@@ -370,7 +372,9 @@ struct AP9LMTPIPADOpt
 
 struct AP9LMCDHPADOpt
 {
-	SV sv_A; //Chaser state vector
+	AP9LMCDHPADOpt();
+
+	EphemerisData sv_A; //Chaser state vector
 	double TIG; //Time of Ignition
 	VECTOR3 dV_LVLH; //Delta V in LVLH coordinates
 	MATRIX3 REFSMMAT;	//REFSMMAT
@@ -2444,13 +2448,13 @@ private:
 	void TimeUpdate();
 public:
 	void AP7TPIPAD(const AP7TPIPADOpt &opt, AP7TPI &pad);
-	void AP9LMTPIPAD(AP9LMTPIPADOpt *opt, AP9LMTPI &pad);
-	void AP9LMCDHPAD(AP9LMCDHPADOpt *opt, AP9LMCDH &pad);
+	void AP9LMTPIPAD(const AP9LMTPIPADOpt &opt, AP9LMTPI &pad);
+	void AP9LMCDHPAD(const AP9LMCDHPADOpt &opt, AP9LMCDH &pad);
 	void TLI_PAD(const TLIPADOpt &opt, TLIPAD &pad);
-	bool PDI_PAD(PDIPADOpt* opt, AP11PDIPAD &pad);
-	void LunarAscentPAD(ASCPADOpt opt, AP11LMASCPAD &pad);
+	bool PDI_PAD(const PDIPADOpt &opt, AP11PDIPAD &pad);
+	void LunarAscentPAD(const ASCPADOpt &opt, AP11LMASCPAD &pad);
 	void EarthOrbitEntry(const EarthEntryPADOpt &opt, AP7ENT &pad);
-	void LunarEntryPAD(LunarEntryPADOpt *opt, AP11ENT &pad);
+	void LunarEntryPAD(const LunarEntryPADOpt &opt, AP11ENT &pad);
 	//Conic Fit
 	int PCZYCF(double R1, double R2, double PHIT, double DELT, double VXI2, double VYI2, double VXF1, double VYF1, double SQRMU, int NREVS, int body, double &a, double &e, double &f_T, double &t_PT);
 	int PMMTIS(EphemerisData sv_A1, EphemerisData sv_P1, double dt, double DH, double theta, EphemerisData &sv_A1_apo, EphemerisData &sv_A2, EphemerisData &sv_A2_apo);
@@ -2476,7 +2480,7 @@ public:
 	void AGSStateVectorPAD(const AGSSVOpt &opt, AP11AGSSVPAD &pad);
 	void AP11LMManeuverPAD(const AP11LMManPADOpt &opt, AP11LMMNV &pad);
 	void AP11ManeuverPAD(const AP11ManPADOpt &opt, AP11MNV &pad);
-	void AP10CSIPAD(AP10CSIPADOpt *opt, AP10CSI &pad);
+	void AP10CSIPAD(const AP10CSIPADOpt &opt, AP10CSI &pad);
 	void CSMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool docked);
 	void LMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool docked, bool asc = false);
 	void RTEMoonTargeting(RTEMoonOpt *opt, EntryResults *res);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -717,8 +717,9 @@ struct ASCPADOpt
 
 struct LMARKTRKPADOpt
 {
-	SV sv0; //Input state vector
-	double LmkTime[4]; //initial guess for time over landmark
+	EphemerisData sv0; //Input state vector
+	double Elevation = 35.0*RAD; //Elevation angle at acquisition
+	double LmkTime[4]; //initial guess for time over landmark (GET)
 	double lat[4];		//landmark latitude
 	double lng[4];		//landmark longitude
 	double alt[4] = { 0,0,0,0 };	//landmark altitude
@@ -2480,7 +2481,7 @@ public:
 	void LMDAPUpdate(VESSEL *v, AP10DAPDATA &pad, bool docked, bool asc = false);
 	void RTEMoonTargeting(RTEMoonOpt *opt, EntryResults *res);
 	void LunarOrbitMapUpdate(EphemerisData sv0, AP10MAPUPDATE &pad, double pm = -150.0*RAD);
-	void LandmarkTrackingPAD(LMARKTRKPADOpt *opt, AP11LMARKTRKPAD &pad);
+	void LandmarkTrackingPAD(const LMARKTRKPADOpt &opt, AP11LMARKTRKPAD &pad);
 	//S-IVB TLI IGM Pre-Thrust Targeting Module
 	int PMMSPT(PMMSPTInput &in);
 	int PCMSP2(TLITargetingParametersTable *tlitab, int J, double t_D, double &cos_sigma, double &C3, double &e_N, double &RA, double &DEC);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -62,15 +62,6 @@ AR_GCore::AR_GCore(VESSEL* v)
 	AGOP_REFSMMAT = _M(1, 0, 0, 0, 1, 0, 0, 0, 1);
 	AGOP_REFSMMAT_Vehicle = 0;
 
-	TPI_PAD.AZ = 0.0;
-	TPI_PAD.dH_TPI = 0.0;
-	TPI_PAD.Backup_dV = _V(0.0, 0.0, 0.0);
-	TPI_PAD.EL = 0.0;
-	TPI_PAD.R = 0.0;
-	TPI_PAD.Rdot = 0.0;
-	TPI_PAD.dH_Max = 0.0;
-	TPI_PAD.Backup_bT = _V(0.0, 0.0, 0.0);
-
 	tlipad.TB6P = 0.0;
 	tlipad.BurnTime = 0.0;
 	tlipad.dVC = 0.0;
@@ -4623,7 +4614,7 @@ int ARCore::subThread()
 			PMMMPTInput in;
 
 			//Get all required data for PMMMPT and error checking
-			if (GetVesselParameters(GC->rtcc->PZMYSAVE.plan[0] == RTCC_MPT_CSM, vesselisdocked, GC->rtcc->med_m72.Thruster, in.CONFIG, in.VC, in.CSMWeight, in.LMWeight))
+			if (GetVesselParameters(GC->rtcc->PZTIPREG.MAN_VEH == RTCC_MPT_CSM, vesselisdocked, GC->rtcc->med_m72.Thruster, in.CONFIG, in.VC, in.CSMWeight, in.LMWeight))
 			{
 				//Error
 				Result = DONE;
@@ -4890,7 +4881,7 @@ int ARCore::subThread()
 				dV_LVLH = DV;
 				manpadenginetype = GC->rtcc->med_m65.Thruster;
 				HeadsUp = true;
-				manpad_ullage_dt = GC->rtcc->med_m65.UllageDT;
+				manpad_ullage_dt = in.DETU;
 				manpad_ullage_opt = GC->rtcc->med_m65.UllageQuads;
 			}
 		}

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -3704,7 +3704,7 @@ int ARCore::subThread()
 		opt.R_LS = OrbMech::r_from_latlong(GC->rtcc->BZLAND.lat[RTCC_LMPOS_BEST], GC->rtcc->BZLAND.lng[RTCC_LMPOS_BEST], GC->rtcc->BZLAND.rad[RTCC_LMPOS_BEST]);
 		opt.t_land = GC->rtcc->CZTDTGTU.GETTD;
 
-		PADSolGood = GC->rtcc->PDI_PAD(&opt, temppdipad);
+		PADSolGood = GC->rtcc->PDI_PAD(opt, temppdipad);
 
 		if (PADSolGood)
 		{
@@ -4289,7 +4289,7 @@ int ARCore::subThread()
 				opt.REFSMMAT = GC->rtcc->EZJGMTX1.data[0].REFSMMAT;
 				opt.SxtStarCheckAttitudeOpt = GC->EntryPADSxtStarCheckAttOpt;
 
-				GC->rtcc->LunarEntryPAD(&opt, GC->lunarentrypad);
+				GC->rtcc->LunarEntryPAD(opt, GC->lunarentrypad);
 			}
 		}
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -62,6 +62,134 @@ AR_GCore::AR_GCore(VESSEL* v)
 	AGOP_REFSMMAT = _M(1, 0, 0, 0, 1, 0, 0, 0, 1);
 	AGOP_REFSMMAT_Vehicle = 0;
 
+	manpad.Trun = 0.0;
+	manpad.Shaft = 0.0;
+	manpad.Star = 0;
+	manpad.BSSStar = 0;
+	manpad.SPA = 0.0;
+	manpad.SXP = 0.0;
+	manpad.Att = _V(0, 0, 0);
+	manpad.GDCangles = _V(0, 0, 0);
+	manpad.SetStars[0] = 0;
+	manpad.SetStars[1] = 0;
+	manpad.HA = 0.0;
+	manpad.HP = 0.0;
+	manpad.Weight = 0.0;
+	manpad.burntime = 0.0;
+	manpad.Vt = 0.0;
+	manpad.Vc = 0.0;
+	manpad.pTrim = 0.0;
+	manpad.yTrim = 0.0;
+	manpad.LMWeight = 0.0;
+
+	lmmanpad.Att = _V(0, 0, 0);
+	lmmanpad.BSSStar = 0;
+	lmmanpad.burntime = 0.0;
+	lmmanpad.CSMWeight = 0.0;
+	lmmanpad.dV = _V(0, 0, 0);
+	lmmanpad.dVR = 0.0;
+	lmmanpad.dV_AGS = _V(0, 0, 0);
+	lmmanpad.GETI = 0.0;
+	lmmanpad.HA = 0.0;
+	lmmanpad.HP = 0.0;
+	lmmanpad.LMWeight = 0.0;
+	lmmanpad.SPA = 0.0;
+	lmmanpad.SXP = 0.0;
+	lmmanpad.IMUAtt = _V(0, 0, 0);
+	sprintf(lmmanpad.remarks, "");
+
+	TPI_PAD.AZ = 0.0;
+	TPI_PAD.dH_TPI = 0.0;
+	TPI_PAD.Backup_dV = _V(0.0, 0.0, 0.0);
+	TPI_PAD.EL = 0.0;
+	TPI_PAD.R = 0.0;
+	TPI_PAD.Rdot = 0.0;
+	TPI_PAD.dH_Max = 0.0;
+	TPI_PAD.Backup_bT = _V(0.0, 0.0, 0.0);
+
+	tlipad.TB6P = 0.0;
+	tlipad.BurnTime = 0.0;
+	tlipad.dVC = 0.0;
+	tlipad.VI = 0.0;
+	tlipad.SepATT = _V(0.0, 0.0, 0.0);
+	tlipad.IgnATT = _V(0.0, 0.0, 0.0);
+	tlipad.ExtATT = _V(0.0, 0.0, 0.0);
+
+	pdipad.Att = _V(0, 0, 0);
+	pdipad.CR = 0.0;
+	pdipad.DEDA231 = 0.0;
+	pdipad.GETI = 0.0;
+	pdipad.t_go = 0.0;
+
+	earthentrypad.Att400K[0] = _V(0, 0, 0);
+	earthentrypad.BankAN[0] = 0;
+	earthentrypad.DRE[0] = 0;
+	earthentrypad.dVTO[0] = 0;
+	earthentrypad.Lat[0] = 0;
+	earthentrypad.Lng[0] = 0;
+	earthentrypad.PB_BankAN[0] = 0;
+	earthentrypad.PB_DRE[0] = 0;
+	earthentrypad.PB_R400K[0] = 0;
+	earthentrypad.PB_Ret05[0] = 0;
+	earthentrypad.PB_Ret2[0] = 0;
+	earthentrypad.PB_RetBBO[0] = 0;
+	earthentrypad.PB_RetDrog[0] = 0;
+	earthentrypad.PB_RetEBO[0] = 0;
+	earthentrypad.PB_RetRB[0] = 0;
+	earthentrypad.PB_RTGO[0] = 0;
+	earthentrypad.PB_VIO[0] = 0;
+	earthentrypad.Ret05[0] = 0;
+	earthentrypad.Ret2[0] = 0;
+	earthentrypad.RetBBO[0] = 0;
+	earthentrypad.RetDrog[0] = 0;
+	earthentrypad.RetEBO[0] = 0;
+	earthentrypad.RetRB[0] = 0;
+	earthentrypad.RTGO[0] = 0;
+	earthentrypad.VIO[0] = 0;
+
+	lunarentrypad.Att05[0] = _V(0, 0, 0);
+	lunarentrypad.BSS[0] = 0;
+	lunarentrypad.DO[0] = 0.0;
+	lunarentrypad.Gamma400K[0] = 0.0;
+	lunarentrypad.GETHorCheck[0] = 0.0;
+	lunarentrypad.Lat[0] = 0.0;
+	lunarentrypad.LiftVector[0][0] = 0;
+	lunarentrypad.Lng[0] = 0.0;
+	lunarentrypad.MaxG[0] = 0.0;
+	lunarentrypad.PitchHorCheck[0] = 0.0;
+	lunarentrypad.RET05[0] = 0.0;
+	lunarentrypad.RRT[0] = 0.0;
+	lunarentrypad.RTGO[0] = 0.0;
+	lunarentrypad.SFT[0] = 0.0;
+	lunarentrypad.SPA[0] = 0.0;
+	lunarentrypad.SXP[0] = 0.0;
+	lunarentrypad.SXTS[0] = 0;
+	lunarentrypad.TRN[0] = 0;
+	lunarentrypad.V400K[0] = 0.0;
+	lunarentrypad.VIO[0] = 0.0;
+	lunarentrypad.RETBBO[0] = 0.0;
+	lunarentrypad.RETEBO[0] = 0.0;
+	lunarentrypad.RETDRO[0] = 0.0;
+	lunarentrypad.RETVCirc[0] = 0.0;
+	lunarentrypad.DLMax[0] = 0.0;
+	lunarentrypad.DLMin[0] = 0.0;
+	lunarentrypad.VLMax[0] = 0.0;
+	lunarentrypad.VLMin[0] = 0.0;
+
+	entrypadopt = 0;
+	EntryPADSxtStarCheckAttOpt = true;
+
+	LmkLat = 0;
+	LmkLng = 0;
+	LmkTime = 0;
+	LmkElevation = 35.0*RAD;
+	landmarkpad.T1[0] = 0;
+	landmarkpad.T2[0] = 0;
+	landmarkpad.CRDist[0] = 0;
+	landmarkpad.Alt[0] = 0;
+	landmarkpad.Lat[0] = 0;
+	landmarkpad.Lng05[0] = 0;
+
 	int mission = 0;
 
 	if (strcmp(v->GetName(), "AS-205") == 0)
@@ -581,53 +709,9 @@ ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
 	RTEASTType = 76;
 
 	SVDesiredGET = -1;
-	manpad.Trun = 0.0;
-	manpad.Shaft = 0.0;
-	manpad.Star = 0;
-	manpad.BSSStar = 0;
-	manpad.SPA = 0.0;
-	manpad.SXP = 0.0;
-	manpad.Att = _V(0, 0, 0);
-	manpad.GDCangles = _V(0, 0, 0);
-	//GDCset = 0;
-	manpad.SetStars[0] = 0;
-	manpad.SetStars[1] = 0;
 	HeadsUp = false;
-	manpad.HA = 0.0;
-	manpad.HP = 0.0;
-	manpad.Weight = 0.0;
-	manpad.burntime = 0.0;
-	manpad.Vt = 0.0;
-	manpad.Vc = 0.0;
-	manpad.pTrim = 0.0;
-	manpad.yTrim = 0.0;
-	manpad.LMWeight = 0.0;
-	lmmanpad.Att = _V(0, 0, 0);
-	lmmanpad.BSSStar = 0;
-	lmmanpad.burntime = 0.0;
-	lmmanpad.CSMWeight = 0.0;
-	lmmanpad.dV = _V(0, 0, 0);
-	lmmanpad.dVR = 0.0;
-	lmmanpad.dV_AGS = _V(0, 0, 0);
-	lmmanpad.GETI = 0.0;
-	lmmanpad.HA = 0.0;
-	lmmanpad.HP = 0.0;
-	lmmanpad.LMWeight = 0.0;
-	lmmanpad.SPA = 0.0;
-	lmmanpad.SXP = 0.0;
-	lmmanpad.IMUAtt = _V(0, 0, 0);
-	sprintf(lmmanpad.remarks, "");
-	entrypadopt = 0;
-	EntryPADSxtStarCheckAttOpt = true;
+
 	manpadenginetype = RTCC_ENGINETYPE_CSMSPS;
-	TPI_PAD.AZ = 0.0;
-	TPI_PAD.dH_TPI = 0.0;
-	TPI_PAD.Backup_dV = _V(0.0, 0.0, 0.0);
-	TPI_PAD.EL = 0.0;
-	TPI_PAD.R = 0.0;
-	TPI_PAD.Rdot = 0.0;
-	TPI_PAD.dH_Max = 0.0;
-	TPI_PAD.Backup_bT = _V(0.0, 0.0, 0.0);
 	sxtstardtime = -30.0*60.0;
 	manpad_ullage_dt = 0.0;
 	manpad_ullage_opt = true;
@@ -650,34 +734,10 @@ ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
 
 	landingzone = 0;
 	entryprecision = -1;
-	
-	tlipad.TB6P = 0.0;
-	tlipad.BurnTime = 0.0;
-	tlipad.dVC = 0.0;
-	tlipad.VI = 0.0;
-	tlipad.SepATT = _V(0.0, 0.0, 0.0);
-	tlipad.IgnATT = _V(0.0, 0.0, 0.0);
-	tlipad.ExtATT = _V(0.0, 0.0, 0.0);
-
-	pdipad.Att = _V(0, 0, 0);
-	pdipad.CR = 0.0;
-	pdipad.DEDA231 = 0.0;
-	pdipad.GETI = 0.0;
-	pdipad.t_go = 0.0;
 
 	subThreadMode = 0;
 	subThreadStatus = DONE;
 	IsCSMCalculation = false;
-
-	LmkLat = 0;
-	LmkLng = 0;
-	LmkTime = 0;
-	landmarkpad.T1[0] = 0;
-	landmarkpad.T2[0] = 0;
-	landmarkpad.CRDist[0] = 0;
-	landmarkpad.Alt[0] = 0;
-	landmarkpad.Lat[0] = 0;
-	landmarkpad.Lng05[0] = 0;
 
 	VECoption = 0;
 	VECdirection = 0;
@@ -724,61 +784,6 @@ ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
 	EMPUplinkMaxNumber = 0;
 
 	LVDCLaunchAzimuth = 0.0;
-
-	earthentrypad.Att400K[0] = _V(0, 0, 0);
-	earthentrypad.BankAN[0] = 0;
-	earthentrypad.DRE[0] = 0;
-	earthentrypad.dVTO[0] = 0;
-	earthentrypad.Lat[0] = 0;
-	earthentrypad.Lng[0] = 0;
-	earthentrypad.PB_BankAN[0] = 0;
-	earthentrypad.PB_DRE[0] = 0;
-	earthentrypad.PB_R400K[0] = 0;
-	earthentrypad.PB_Ret05[0] = 0;
-	earthentrypad.PB_Ret2[0] = 0;
-	earthentrypad.PB_RetBBO[0] = 0;
-	earthentrypad.PB_RetDrog[0] = 0;
-	earthentrypad.PB_RetEBO[0] = 0;
-	earthentrypad.PB_RetRB[0] = 0;
-	earthentrypad.PB_RTGO[0] = 0;
-	earthentrypad.PB_VIO[0] = 0;
-	earthentrypad.Ret05[0] = 0;
-	earthentrypad.Ret2[0] = 0;
-	earthentrypad.RetBBO[0] = 0;
-	earthentrypad.RetDrog[0] = 0;
-	earthentrypad.RetEBO[0] = 0;
-	earthentrypad.RetRB[0] = 0;
-	earthentrypad.RTGO[0] = 0;
-	earthentrypad.VIO[0] = 0;
-
-	lunarentrypad.Att05[0] = _V(0, 0, 0);
-	lunarentrypad.BSS[0] = 0;
-	lunarentrypad.DO[0] = 0.0;
-	lunarentrypad.Gamma400K[0] = 0.0;
-	lunarentrypad.GETHorCheck[0] = 0.0;
-	lunarentrypad.Lat[0] = 0.0;
-	lunarentrypad.LiftVector[0][0] = 0;
-	lunarentrypad.Lng[0] = 0.0;
-	lunarentrypad.MaxG[0] = 0.0;
-	lunarentrypad.PitchHorCheck[0] = 0.0;
-	lunarentrypad.RET05[0] = 0.0;
-	lunarentrypad.RRT[0] = 0.0;
-	lunarentrypad.RTGO[0] = 0.0;
-	lunarentrypad.SFT[0] = 0.0;
-	lunarentrypad.SPA[0] = 0.0;
-	lunarentrypad.SXP[0] = 0.0;
-	lunarentrypad.SXTS[0] = 0;
-	lunarentrypad.TRN[0] = 0;
-	lunarentrypad.V400K[0] = 0.0;
-	lunarentrypad.VIO[0] = 0.0;
-	lunarentrypad.RETBBO[0] = 0.0;
-	lunarentrypad.RETEBO[0] = 0.0;
-	lunarentrypad.RETDRO[0] = 0.0;
-	lunarentrypad.RETVCirc[0] = 0.0;
-	lunarentrypad.DLMax[0] = 0.0;
-	lunarentrypad.DLMin[0] = 0.0;
-	lunarentrypad.VLMax[0] = 0.0;
-	lunarentrypad.VLMin[0] = 0.0;
 
 	navcheckpad.alt[0] = 0.0;
 	navcheckpad.lat[0] = 0.0;
@@ -3190,7 +3195,7 @@ int ARCore::subThread()
 		opt.sv_P = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pLM);
 		opt.mass = GC->rtcc->pCSM->GetMass();
 
-		GC->rtcc->AP7TPIPAD(opt, TPI_PAD);
+		GC->rtcc->AP7TPIPAD(opt, GC->TPI_PAD);
 
 		Result = DONE;
 	}
@@ -3267,7 +3272,7 @@ int ARCore::subThread()
 		opt.SeparationAttitude = lvdc->XLunarAttitude;
 		opt.sv0 = GC->rtcc->StateVectorCalcEphem(GC->rtcc->pCSM);
 
-		GC->rtcc->TLI_PAD(opt, tlipad);
+		GC->rtcc->TLI_PAD(opt, GC->tlipad);
 
 		Result = DONE;
 	}
@@ -3334,7 +3339,7 @@ int ARCore::subThread()
 			opt.UllageDT = manpad_ullage_dt;
 			opt.UllageThrusterOpt = manpad_ullage_opt;
 
-			GC->rtcc->AP11ManeuverPAD(opt, manpad);
+			GC->rtcc->AP11ManeuverPAD(opt, GC->manpad);
 		}
 		else
 		{
@@ -3349,7 +3354,7 @@ int ARCore::subThread()
 			opt.RV_MCC = sv_A;
 			opt.WeightsTable = WeightsTable;
 
-			GC->rtcc->AP11LMManeuverPAD(opt, lmmanpad);
+			GC->rtcc->AP11LMManeuverPAD(opt, GC->lmmanpad);
 		}
 
 		Result = DONE;
@@ -3703,7 +3708,7 @@ int ARCore::subThread()
 
 		if (PADSolGood)
 		{
-			pdipad = temppdipad;
+			GC->pdipad = temppdipad;
 		}
 
 		Result = DONE;
@@ -4213,7 +4218,7 @@ int ARCore::subThread()
 		hEarth = oapiGetObjectByName("Earth");
 		mu = GGRAV * oapiGetMass(hEarth);
 
-		if (entrypadopt == 0)
+		if (GC->entrypadopt == 0)
 		{
 			EarthEntryPADOpt opt;
 
@@ -4246,12 +4251,12 @@ int ARCore::subThread()
 			if (peri < oapiGetSize(gravref) + 50 * 1852.0)
 			{
 				opt.preburn = false;
-				GC->rtcc->EarthOrbitEntry(opt, earthentrypad);
+				GC->rtcc->EarthOrbitEntry(opt, GC->earthentrypad);
 			}
 			else
 			{
 				opt.preburn = true;
-				GC->rtcc->EarthOrbitEntry(opt, earthentrypad);
+				GC->rtcc->EarthOrbitEntry(opt, GC->earthentrypad);
 			}
 		}
 		else
@@ -4282,9 +4287,9 @@ int ARCore::subThread()
 				opt.lat = GC->rtcc->RZDBSC1.lat_T;
 				opt.lng = GC->rtcc->RZDBSC1.lng_T;
 				opt.REFSMMAT = GC->rtcc->EZJGMTX1.data[0].REFSMMAT;
-				opt.SxtStarCheckAttitudeOpt = EntryPADSxtStarCheckAttOpt;
+				opt.SxtStarCheckAttitudeOpt = GC->EntryPADSxtStarCheckAttOpt;
 
-				GC->rtcc->LunarEntryPAD(&opt, lunarentrypad);
+				GC->rtcc->LunarEntryPAD(&opt, GC->lunarentrypad);
 			}
 		}
 
@@ -4295,7 +4300,7 @@ int ARCore::subThread()
 	{
 		EphemerisData sv0;
 
-		if (GC->MissionPlanningActive && GC->rtcc->MPTHasManeuvers(RTCC_MPT_CSM))
+		if (GC->MissionPlanningActive)
 		{
 			double gmt;
 
@@ -4378,26 +4383,28 @@ int ARCore::subThread()
 	case 33: //Landmark Tracking PAD
 	{
 		LMARKTRKPADOpt opt;
-		SV sv0;
+		EphemerisData sv0, sv1;
 
-		if (GC->MissionPlanningActive && GC->rtcc->MPTHasManeuvers(RTCC_MPT_CSM))
+		double get, gmt;
+
+		if (GC->LmkTime <= 0.0)
 		{
-			if (LmkTime <= 0.0)
+			gmt = GC->rtcc->RTCCPresentTimeGMT();
+			get = GC->rtcc->GETfromGMT(gmt);
+		}
+		else
+		{
+			get = GC->LmkTime;
+			gmt = GC->rtcc->GMTfromGET(get);
+		}
+
+		if (GC->MissionPlanningActive)
+		{
+			EphemerisData sv;
+			if (GC->rtcc->EMSFFV(gmt, RTCC_MPT_CSM, sv0))
 			{
-				GC->rtcc->NewMPTTrajectory(RTCC_MPT_CSM, sv0);
-			}
-			else
-			{
-				EphemerisData sv;
-				if (GC->rtcc->EMSFFV(GC->rtcc->GMTfromGET(LmkTime), RTCC_MPT_CSM, sv))
-				{
-					Result = DONE;
-					break;
-				}
-				sv0.R = sv.R;
-				sv0.V = sv.V;
-				sv0.MJD = OrbMech::MJDfromGET(sv.GMT, GC->rtcc->GetGMTBase());
-				sv0.gravref = GC->rtcc->GetGravref(sv.RBI);
+				Result = DONE;
+				break;
 			}
 		}
 		else
@@ -4410,16 +4417,17 @@ int ARCore::subThread()
 				break;
 			}
 
-			sv0 = GC->rtcc->StateVectorCalc(v);
+			sv0 = GC->rtcc->StateVectorCalcEphem(v);
 		}
 
-		opt.lat[0] = LmkLat;
-		opt.LmkTime[0] = LmkTime;
-		opt.lng[0] = LmkLng;
+		opt.lat[0] = GC->LmkLat;
+		opt.LmkTime[0] = get;
+		opt.lng[0] = GC->LmkLng;
 		opt.sv0 = sv0;
+		opt.Elevation = GC->LmkElevation;
 		opt.entries = 1;
 
-		GC->rtcc->LandmarkTrackingPAD(&opt, landmarkpad);
+		GC->rtcc->LandmarkTrackingPAD(opt, GC->landmarkpad);
 
 		Result = DONE;
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -4299,20 +4299,19 @@ int ARCore::subThread()
 	case 32: //Map Update
 	{
 		EphemerisData sv0;
+		double gmt;
+
+		if (mapUpdateGET <= 0.0)
+		{
+			gmt = GC->rtcc->RTCCPresentTimeGMT();
+		}
+		else
+		{
+			gmt = GC->rtcc->GMTfromGET(mapUpdateGET);
+		}
 
 		if (GC->MissionPlanningActive)
 		{
-			double gmt;
-
-			if (mapUpdateGET <= 0.0)
-			{
-				gmt = GC->rtcc->RTCCPresentTimeGMT();
-			}
-			else
-			{
-				gmt = GC->rtcc->GMTfromGET(mapUpdateGET);
-			}
-
 			if (GC->rtcc->EMSFFV(gmt, RTCC_MPT_CSM, sv0))
 			{
 				Result = DONE;
@@ -4338,11 +4337,10 @@ int ARCore::subThread()
 			}
 
 			sv0 = GC->rtcc->StateVectorCalcEphem(v);
-			if (mapUpdateGET > 0)
-			{
-				sv0 = GC->rtcc->coast(sv0, GC->rtcc->GMTfromGET(mapUpdateGET) - sv0.GMT);
-			}
 		}
+
+		//Coast to desired GMT
+		sv0 = GC->rtcc->coast(sv0, gmt - sv0.GMT);
 
 		if (mappage == 0)
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -3252,6 +3252,13 @@ int ARCore::subThread()
 
 			unsigned num = (unsigned)(ManPADMPTManeuver - 1);
 
+			//Does the maneuver exist?
+			if (num >= mpt->mantable.size())
+			{
+				Result = DONE;
+				break;
+			}
+
 			MPTManeuver *man = &mpt->mantable[num];
 
 			if (IsCSMCalculation)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
@@ -46,6 +46,25 @@ public:
 
 	RTCC* rtcc;
 
+	//MANEUVER PAD PAGE
+	AP11MNV manpad;
+	AP11LMMNV lmmanpad;
+	AP7TPI TPI_PAD;
+	TLIPAD tlipad;
+	AP11PDIPAD pdipad;
+
+	//ENTRY PAD PAGE
+	AP11ENT lunarentrypad;
+	AP7ENT earthentrypad;
+	int entrypadopt; //0 = Earth Entry Update, 1 = Lunar Entry
+	bool EntryPADSxtStarCheckAttOpt; //true = sextant star attitude check at entry attitude, false = sextant star check at horizon check attitude
+
+	//LANDMARK TRACKING PAGE
+	AP11LMARKTRKPAD landmarkpad;
+	double LmkLat, LmkLng;
+	double LmkTime;
+	double LmkElevation;
+
 	//APOLLO GENERALIZED OPTICS PROGRAM
 	int AGOP_Page;
 	int AGOP_Option;
@@ -272,22 +291,11 @@ public:
 	AP11AGSSVPAD agssvpad;
 
 	//MANEUVER PAD PAGE
-	AP11MNV manpad;
-	AP11LMMNV lmmanpad;
 	bool HeadsUp;
-	AP7TPI TPI_PAD;
 	int manpadopt; //0 = CSM Maneuver PAD, 1 = LM Maneuver PAD, 2 = TPI PAD, 3 = TLI PAD, 4 = PDI PAD
 	double sxtstardtime;
 	double manpad_ullage_dt;
 	bool manpad_ullage_opt; //true = 4 jets, false = 2 jets
-	TLIPAD tlipad;
-	AP11PDIPAD pdipad;
-
-	//ENTRY PAD PAGE
-	AP11ENT lunarentrypad;
-	AP7ENT earthentrypad;
-	int entrypadopt; //0 = Earth Entry Update, 1 = Lunar Entry
-	bool EntryPADSxtStarCheckAttOpt; //true = sextant star attitude check at entry attitude, false = sextant star check at horizon check attitude
 
 	//MAP UPDATE PAGE
 	AP10MAPUPDATE mapupdate;
@@ -298,11 +306,6 @@ public:
 
 	//TLCC PAGE
 	int TLCCSolGood;
-
-	//LANDMARK TRACKING PAGE
-	AP11LMARKTRKPAD landmarkpad;
-	double LmkLat, LmkLng;
-	double LmkTime;
 
 	//VECPOINT PAGE
 	int VECoption;		//0 = Point SC at body, 1 = Open hatch thermal control

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
@@ -296,6 +296,8 @@ public:
 	double sxtstardtime;
 	double manpad_ullage_dt;
 	bool manpad_ullage_opt; //true = 4 jets, false = 2 jets
+	int ManPADMPT; //1 = CSM, 3 = LEM
+	int ManPADMPTManeuver; //1-15
 
 	//MAP UPDATE PAGE
 	AP10MAPUPDATE mapupdate;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -5983,13 +5983,13 @@ void ApolloRTCCMFD::menuCalcMapUpdate()
 
 void ApolloRTCCMFD::menuSwitchEntryPADOpt()
 {
-	if (G->entrypadopt < 1)
+	if (GC->entrypadopt < 1)
 	{
-		G->entrypadopt++;
+		GC->entrypadopt++;
 	}
 	else
 	{
-		G->entrypadopt = 0;
+		GC->entrypadopt = 0;
 	}
 }
 
@@ -6334,9 +6334,9 @@ void ApolloRTCCMFD::GetREFSMMATfromAGC()
 
 void ApolloRTCCMFD::menuCycleLunarEntryPADSxtOption()
 {
-	if (G->entrypadopt == 1)
+	if (GC->entrypadopt == 1)
 	{
-		G->EntryPADSxtStarCheckAttOpt = !G->EntryPADSxtStarCheckAttOpt;
+		GC->EntryPADSxtStarCheckAttOpt = !GC->EntryPADSxtStarCheckAttOpt;
 	}
 }
 
@@ -6836,24 +6836,29 @@ void ApolloRTCCMFD::menuLmkPADCalc()
 
 void ApolloRTCCMFD::menuSetLmkTime()
 {
-	GenericGETInput(&G->LmkTime, "Choose the guess for T1:");
+	GenericGETInput(&GC->LmkTime, "Choose the guess for T1:");
+}
+
+void ApolloRTCCMFD::menuSetLmkElevation()
+{
+	GenericDoubleInput(&GC->LmkElevation, "Choose the T2 elevation in degrees (0-90°):", RAD);
 }
 
 void ApolloRTCCMFD::menuSetLmkLat()
 {
-	GenericDoubleInput(&G->LmkLat, "Choose the landmark latitude:", RAD);
+	GenericDoubleInput(&GC->LmkLat, "Choose the landmark latitude:", RAD);
 }
 
 void ApolloRTCCMFD::menuSetLmkLng()
 {
-	GenericDoubleInput(&G->LmkLng, "Choose the landmark longitude:", RAD);
+	GenericDoubleInput(&GC->LmkLng, "Choose the landmark longitude:", RAD);
 }
 
 void ApolloRTCCMFD::menuLmkUseLandingSite()
 {
 	//Load RTCC stored landing site coordinates into input for P22 PAD
-	G->LmkLat = GC->rtcc->BZLAND.lat[0];
-	G->LmkLng = GC->rtcc->BZLAND.lng[0];
+	GC->LmkLat = GC->rtcc->BZLAND.lat[0];
+	GC->LmkLng = GC->rtcc->BZLAND.lng[0];
 }
 
 void ApolloRTCCMFD::menuSetLDPPVectorTime()

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -521,35 +521,35 @@ void ApolloRTCCMFD::ThrusterName(char *Buff, int n)
 	}
 	else if (n == RTCC_ENGINETYPE_CSMRCSPLUS2)
 	{
-		sprintf(Buff, "CSM RCS +X (2 quads)");
+		sprintf(Buff, "SM RCS 2+X");
 	}
 	else if (n == RTCC_ENGINETYPE_LMRCSPLUS2)
 	{
-		sprintf(Buff, "LM RCS +X (2 quads)");
+		sprintf(Buff, "LM RCS 2+X");
 	}
 	else if (n == RTCC_ENGINETYPE_CSMRCSPLUS4)
 	{
-		sprintf(Buff, "CSM RCS +X (4 quads)");
+		sprintf(Buff, "SM RCS 4+X");
 	}
 	else if (n == RTCC_ENGINETYPE_LMRCSPLUS4)
 	{
-		sprintf(Buff, "LM RCS +X (4 quads)");
+		sprintf(Buff, "LM RCS 4+X");
 	}
 	else if (n == RTCC_ENGINETYPE_CSMRCSMINUS2)
 	{
-		sprintf(Buff, "CSM RCS -X (2 quads)");
+		sprintf(Buff, "SM RCS 2-X");
 	}
 	else if (n == RTCC_ENGINETYPE_LMRCSMINUS2)
 	{
-		sprintf(Buff, "LM RCS -X (2 quads)");
+		sprintf(Buff, "LM RCS 2-X");
 	}
 	else if (n == RTCC_ENGINETYPE_CSMRCSMINUS4)
 	{
-		sprintf(Buff, "CSM RCS -X (4 quads)");
+		sprintf(Buff, "SM RCS 4-X");
 	}
 	else if (n == RTCC_ENGINETYPE_LMRCSMINUS4)
 	{
-		sprintf(Buff, "LM RCS -X (4 quads)");
+		sprintf(Buff, "LM RCS 4-X");
 	}
 	else if (n == RTCC_ENGINETYPE_LOX_DUMP)
 	{

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -5954,10 +5954,23 @@ void ApolloRTCCMFD::menuCalcManPAD()
 	switch (G->manpadopt)
 	{
 	case 0:
-		G->ManeuverPAD(true);
-		break;
 	case 1:
-		G->ManeuverPAD(false);
+		if (GC->MissionPlanningActive)
+		{
+			bool ManPADMPTInput(void *id, char *str, void *data);
+			oapiOpenInputBox("Enter MPT (CSM or LEM) and maneuver number (1-15):", ManPADMPTInput, 0, 20, (void*)this);
+		}
+		else
+		{
+			if (G->manpadopt == 0)
+			{
+				G->ManeuverPAD(true);
+			}
+			else
+			{
+				G->ManeuverPAD(false);
+			}
+		}
 		break;
 	case 2:
 		G->TPIPAD();
@@ -5968,6 +5981,47 @@ void ApolloRTCCMFD::menuCalcManPAD()
 	case 4:
 		G->PDI_PAD();
 		break;
+	}
+}
+
+bool ManPADMPTInput(void *id, char *str, void *data)
+{
+	std::string mptname;
+	char Buff[128];
+	int mpt, num;
+	if (sscanf(str, "%s %d", Buff, &num) == 2)
+	{
+		mptname.assign(Buff);
+		if (mptname == "CSM")
+		{
+			mpt = RTCC_MPT_CSM;
+		}
+		else if (mptname == "LEM")
+		{
+			mpt = RTCC_MPT_LM;
+		}
+		else return false;
+
+		if (num <= 0 || num > 15) return false;
+
+		((ApolloRTCCMFD*)data)->set_ManPADMPTInput(mpt, num);
+		return true;
+	}
+	return false;
+}
+
+void ApolloRTCCMFD::set_ManPADMPTInput(int mpt, int num)
+{
+	G->ManPADMPT = mpt;
+	G->ManPADMPTManeuver = num;
+
+	if (G->manpadopt == 0)
+	{
+		G->ManeuverPAD(true);
+	}
+	else
+	{
+		G->ManeuverPAD(false);
 	}
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -200,6 +200,7 @@ public:
 	void menuCycleTwoImpulseOption();
 	void menuSwitchHeadsUp();
 	void menuCalcManPAD();
+	void set_ManPADMPTInput(int mpt, int num);
 	void menuSetManPADPage();
 	void menuCalcEntryPAD();
 	void menuSetEntryPADPage();

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -299,6 +299,7 @@ public:
 	void menuLOICalc();
 	void menuSetLandmarkTrkPage();
 	void menuSetLmkTime();
+	void menuSetLmkElevation();
 	void menuSetLmkLat();
 	void menuSetLmkLng();
 	void menuLmkUseLandingSite();

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -896,13 +896,20 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 	{
 		if (G->manpadopt == 0 || G->manpadopt == 1)
 		{
+			skp->SetPen(pen2);
+			skp->Line(6 * W / 16, 2 * H / 14, 6 * W / 16, 39 * H / 56);
+			skp->Line(0, 39 * H / 56, 6 * W / 16, 39 * H / 56);
+
+			ThrusterName(Buffer, G->manpadenginetype);
+			skp->Text(1 * W / 16, 3 * H / 14, Buffer, strlen(Buffer));
+
 			if (G->HeadsUp)
 			{
-				skp->Text((int)(0.5 * W / 8), 6 * H / 14, "Heads Up", 8);
+				skp->Text(1 * W / 16, 4 * H / 14, "Heads Up", 8);
 			}
 			else
 			{
-				skp->Text((int)(0.5 * W / 8), 6 * H / 14, "Heads Down", 10);
+				skp->Text(1 * W / 16, 4 * H / 14, "Heads Down", 10);
 			}
 
 			if (G->manpad_ullage_opt)
@@ -913,49 +920,58 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			{
 				sprintf_s(Buffer, "2 quads, %.1f s", G->manpad_ullage_dt);
 			}
-			skp->Text(1 * W / 16, 8 * H / 14, Buffer, strlen(Buffer));
+			skp->Text(1 * W / 16, 5 * H / 14, Buffer, strlen(Buffer));
 
-			//TBD: Find a new place for this?
-			//skp->Text((int)(0.5 * W / 8), 8 * H / 14, "REFSMMAT:", 9);
-			//REFSMMATName(Buffer, G->REFSMMATcur);
-			//skp->Text((int)(0.5 * W / 8), 9 * H / 14, Buffer, strlen(Buffer));
+			GET_Display2(Buffer, G->P30TIG);
+			skp->Text(1 * W / 16, 6 * H / 14, Buffer, strlen(Buffer));
+
+			sprintf(Buffer, "%+07.1f", G->dV_LVLH.x / 0.3048);
+			skp->Text(1 * W / 16, 7 * H / 14, Buffer, strlen(Buffer));
+			sprintf(Buffer, "%+07.1f", G->dV_LVLH.y / 0.3048);
+			skp->Text(1 * W / 16, 8 * H / 14, Buffer, strlen(Buffer));
+			sprintf(Buffer, "%+07.1f", G->dV_LVLH.z / 0.3048);
+			skp->Text(1 * W / 16, 9 * H / 14, Buffer, strlen(Buffer));
 
 			if (G->manpadopt == 0)
 			{
 				skp->Text(5 * W / 8, (int)(0.5 * H / 14), "P30 Maneuver", 12);
 
-				if (G->vesselisdocked == false)
+				if (GC->MissionPlanningActive == false)
 				{
-					skp->Text((int)(0.5 * W / 8), 2 * H / 14, "CSM", 3);
+					if (G->vesselisdocked == false)
+					{
+						skp->Text(1 * W / 16, 2 * H / 14, "CSM", 3);
+					}
+					else
+					{
+						skp->Text(1 * W / 16, 2 * H / 14, "CSM/LM", 6);
+					}
 				}
 				else
 				{
-					skp->Text((int)(0.5 * W / 8), 2 * H / 14, "CSM/LM", 6);
+					skp->Text(1 * W / 16, 2 * H / 14, GC->manpad.remarks, strlen(GC->manpad.remarks));
 				}
 
-				ThrusterName(Buffer, G->manpadenginetype);
-				skp->Text(1 * W / 16, 4 * H / 14, Buffer, strlen(Buffer));
-
-				if (G->vesselisdocked)
+				if (GC->MissionPlanningActive || G->vesselisdocked)
 				{
 					sprintf(Buffer, "LM Weight: %5.0f", GC->manpad.LMWeight);
-					skp->Text((int)(0.5 * W / 8), 10 * H / 14, Buffer, strlen(Buffer));
+					skp->Text(1 * W / 16, 10 * H / 14, Buffer, strlen(Buffer));
 				}
 
-				skp->Text((int)(0.5 * W / 8), 18 * H / 23, "Set Stars:", 10);
-				skp->Text((int)(0.5 * W / 8), 19 * H / 23, GC->manpad.SetStars, strlen(GC->manpad.SetStars));
+				skp->Text(1 * W / 16, 18 * H / 23, "Set Stars:", 10);
+				skp->Text(1 * W / 16, 19 * H / 23, GC->manpad.SetStars, strlen(GC->manpad.SetStars));
 
 				sprintf(Buffer, "R %03.0f", OrbMech::round(GC->manpad.GDCangles.x));
-				skp->Text((int)(0.5 * W / 8), 20 * H / 23, Buffer, strlen(Buffer));
+				skp->Text(1 * W / 16, 20 * H / 23, Buffer, strlen(Buffer));
 				sprintf(Buffer, "P %03.0f", OrbMech::round(GC->manpad.GDCangles.y));
-				skp->Text((int)(0.5 * W / 8), 21 * H / 23, Buffer, strlen(Buffer));
+				skp->Text(1 * W / 16, 21 * H / 23, Buffer, strlen(Buffer));
 				sprintf(Buffer, "Y %03.0f", OrbMech::round(GC->manpad.GDCangles.z));
-				skp->Text((int)(0.5 * W / 8), 22 * H / 23, Buffer, strlen(Buffer));
+				skp->Text(1 * W / 16, 22 * H / 23, Buffer, strlen(Buffer));
 
 				int hh, mm;
 				double secs;
 
-				OrbMech::SStoHHMMSS(G->P30TIG, hh, mm, secs, 0.01);
+				OrbMech::SStoHHMMSS(GC->manpad.GETI, hh, mm, secs, 0.01);
 
 				skp->Text(7 * W / 8, 3 * H / 26, "N47", 3);
 				skp->Text(7 * W / 8, 4 * H / 26, "N48", 3);
@@ -986,11 +1002,11 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+07.2f SEC", secs);
 				skp->Text((int)(3.5 * W / 8), 8 * H / 26, Buffer, strlen(Buffer));
 
-				sprintf(Buffer, "%+07.1f DVX", G->dV_LVLH.x / 0.3048);
+				sprintf(Buffer, "%+07.1f DVX", GC->manpad.dV.x);
 				skp->Text((int)(3.5 * W / 8), 9 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+07.1f DVY", G->dV_LVLH.y / 0.3048);
+				sprintf(Buffer, "%+07.1f DVY", GC->manpad.dV.y);
 				skp->Text((int)(3.5 * W / 8), 10 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+07.1f DVZ", G->dV_LVLH.z / 0.3048);
+				sprintf(Buffer, "%+07.1f DVZ", GC->manpad.dV.z);
 				skp->Text((int)(3.5 * W / 8), 11 * H / 26, Buffer, strlen(Buffer));
 
 				sprintf(Buffer, "XXX%03.0f R", GC->manpad.Att.x);
@@ -1058,22 +1074,26 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			{
 				skp->Text(5 * W / 8, (int)(0.5 * H / 14), "P30 LM Maneuver", 15);
 
-				ThrusterName(Buffer, G->manpadenginetype);
-				skp->Text(1 * W / 16, 4 * H / 14, Buffer, strlen(Buffer));
-
-				if (G->vesselisdocked == false)
+				if (GC->MissionPlanningActive == false)
 				{
-					skp->Text((int)(0.5 * W / 8), 2 * H / 14, "LM", 3);
+					if (G->vesselisdocked == false)
+					{
+						skp->Text((int)(0.5 * W / 8), 2 * H / 14, "LM", 3);
+					}
+					else
+					{
+						skp->Text((int)(0.5 * W / 8), 2 * H / 14, "LM/CSM", 6);
+					}
 				}
 				else
 				{
-					skp->Text((int)(0.5 * W / 8), 2 * H / 14, "LM/CSM", 6);
+					skp->Text(1 * W / 16, 2 * H / 14, GC->lmmanpad.remarks, strlen(GC->lmmanpad.remarks));
 				}
 
 				sprintf(Buffer, "LM Weight: %5.0f", GC->lmmanpad.LMWeight);
 				skp->Text((int)(0.5 * W / 8), 10 * H / 14, Buffer, strlen(Buffer));
 
-				if (G->vesselisdocked)
+				if (GC->MissionPlanningActive || G->vesselisdocked)
 				{
 					sprintf(Buffer, "CSM Weight: %5.0f", GC->lmmanpad.CSMWeight);
 					skp->Text((int)(0.5 * W / 8), 11 * H / 14, Buffer, strlen(Buffer));
@@ -1082,7 +1102,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				int hh, mm;
 				double secs;
 
-				OrbMech::SStoHHMMSS(G->P30TIG, hh, mm, secs, 0.01);
+				OrbMech::SStoHHMMSS(GC->lmmanpad.GETI, hh, mm, secs, 0.01);
 
 				sprintf(Buffer, "%+06d HRS GETI", hh);
 				skp->Text((int)(3.5 * W / 8), 5 * H / 26, Buffer, strlen(Buffer));
@@ -1091,11 +1111,11 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+07.2f SEC", secs);
 				skp->Text((int)(3.5 * W / 8), 7 * H / 26, Buffer, strlen(Buffer));
 
-				sprintf(Buffer, "%+07.1f DVX", G->dV_LVLH.x / 0.3048);
+				sprintf(Buffer, "%+07.1f DVX", GC->lmmanpad.dV.x);
 				skp->Text((int)(3.5 * W / 8), 8 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+07.1f DVY", G->dV_LVLH.y / 0.3048);
+				sprintf(Buffer, "%+07.1f DVY", GC->lmmanpad.dV.y);
 				skp->Text((int)(3.5 * W / 8), 9 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+07.1f DVZ", G->dV_LVLH.z / 0.3048);
+				sprintf(Buffer, "%+07.1f DVZ", GC->lmmanpad.dV.z);
 				skp->Text((int)(3.5 * W / 8), 10 * H / 26, Buffer, strlen(Buffer));
 
 				sprintf(Buffer, "%+07.1f HA", min(9999.9, GC->lmmanpad.HA));

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -982,7 +982,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+06.0f WGT", GC->manpad.Weight);
 				skp->Text((int)(3.5 * W / 8), 3 * H / 26, Buffer, strlen(Buffer));
 
-				if (G->manpadenginetype == RTCC_ENGINETYPE_CSMSPS)
+				if (strncmp(GC->manpad.PropGuid, "SPS", 3) == 0)
 				{
 					sprintf(Buffer, "%+07.2f PTRIM", GC->manpad.pTrim);
 					skp->Text((int)(3.5 * W / 8), 4 * H / 26, Buffer, strlen(Buffer));
@@ -1021,7 +1021,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+07.1f HP", GC->manpad.HP);
 				skp->Text((int)(3.5 * W / 8), 16 * H / 26, Buffer, strlen(Buffer));
 
-				sprintf(Buffer, "%+07.1f VT", GC->manpad.Vt);// length(G->dV_LVLH) / 0.3048);
+				sprintf(Buffer, "%+07.1f VT", GC->manpad.Vt);
 				skp->Text((int)(3.5 * W / 8), 17 * H / 26, Buffer, strlen(Buffer));
 
 				OrbMech::SStoHHMMSS(GC->manpad.burntime, hh, mm, secs);
@@ -1030,8 +1030,6 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text((int)(3.5 * W / 8), 18 * H / 26, Buffer, strlen(Buffer));
 				sprintf(Buffer, "%+07.1f VC", GC->manpad.Vc);
 				skp->Text((int)(3.5 * W / 8), 19 * H / 26, Buffer, strlen(Buffer));
-
-				//skp->Text(4 * W / 8, 13 * H / 20, "SXT star check", 14);
 
 				if (GC->manpad.Star == 0)
 				{
@@ -1123,7 +1121,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+07.1f HP", GC->lmmanpad.HP);
 				skp->Text((int)(3.5 * W / 8), 12 * H / 26, Buffer, strlen(Buffer));
 
-				sprintf(Buffer, "%+07.1f DVR", length(G->dV_LVLH) / 0.3048);
+				sprintf(Buffer, "%+07.1f DVR", length(GC->lmmanpad.dV) / 0.3048);
 				skp->Text((int)(3.5 * W / 8), 13 * H / 26, Buffer, strlen(Buffer));
 
 				OrbMech::SStoHHMMSS(GC->lmmanpad.burntime, hh, mm, secs);
@@ -1170,10 +1168,20 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			skp->Text(4 * W / 8, (int)(0.5 * H / 14), "Terminal Phase Initiate", 23);
 
+			GET_Display2(Buffer, G->P30TIG);
+			skp->Text(1 * W / 16, 6 * H / 14, Buffer, strlen(Buffer));
+
+			sprintf(Buffer, "%+07.1f", G->dV_LVLH.x / 0.3048);
+			skp->Text(1 * W / 16, 7 * H / 14, Buffer, strlen(Buffer));
+			sprintf(Buffer, "%+07.1f", G->dV_LVLH.y / 0.3048);
+			skp->Text(1 * W / 16, 8 * H / 14, Buffer, strlen(Buffer));
+			sprintf(Buffer, "%+07.1f", G->dV_LVLH.z / 0.3048);
+			skp->Text(1 * W / 16, 9 * H / 14, Buffer, strlen(Buffer));
+
 			int hh, mm; // ss;
 			double secs;
 
-			OrbMech::SStoHHMMSS(G->P30TIG, hh, mm, secs, 0.01);
+			OrbMech::SStoHHMMSS(GC->TPI_PAD.GETI, hh, mm, secs, 0.01);
 
 			skp->Text(7 * W / 8, 3 * H / 20, "N37", 3);
 
@@ -1184,11 +1192,11 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			sprintf(Buffer, "%+07.2f SEC", secs);
 			skp->Text(3 * W / 8, 5 * H / 20, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+07.1f DVX", G->dV_LVLH.x / 0.3048);
+			sprintf(Buffer, "%+07.1f DVX", GC->TPI_PAD.Vg.x);
 			skp->Text(3 * W / 8, 6 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+07.1f DVY", G->dV_LVLH.y / 0.3048);
+			sprintf(Buffer, "%+07.1f DVY", GC->TPI_PAD.Vg.y);
 			skp->Text(3 * W / 8, 7 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+07.1f DVZ", G->dV_LVLH.z / 0.3048);
+			sprintf(Buffer, "%+07.1f DVZ", GC->TPI_PAD.Vg.z);
 			skp->Text(3 * W / 8, 8 * H / 20, Buffer, strlen(Buffer));
 
 			if (GC->TPI_PAD.Backup_dV.x > 0)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -938,18 +938,18 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 
 				if (G->vesselisdocked)
 				{
-					sprintf(Buffer, "LM Weight: %5.0f", G->manpad.LMWeight);
+					sprintf(Buffer, "LM Weight: %5.0f", GC->manpad.LMWeight);
 					skp->Text((int)(0.5 * W / 8), 10 * H / 14, Buffer, strlen(Buffer));
 				}
 
 				skp->Text((int)(0.5 * W / 8), 18 * H / 23, "Set Stars:", 10);
-				skp->Text((int)(0.5 * W / 8), 19 * H / 23, G->manpad.SetStars, strlen(G->manpad.SetStars));
+				skp->Text((int)(0.5 * W / 8), 19 * H / 23, GC->manpad.SetStars, strlen(GC->manpad.SetStars));
 
-				sprintf(Buffer, "R %03.0f", OrbMech::round(G->manpad.GDCangles.x));
+				sprintf(Buffer, "R %03.0f", OrbMech::round(GC->manpad.GDCangles.x));
 				skp->Text((int)(0.5 * W / 8), 20 * H / 23, Buffer, strlen(Buffer));
-				sprintf(Buffer, "P %03.0f", OrbMech::round(G->manpad.GDCangles.y));
+				sprintf(Buffer, "P %03.0f", OrbMech::round(GC->manpad.GDCangles.y));
 				skp->Text((int)(0.5 * W / 8), 21 * H / 23, Buffer, strlen(Buffer));
-				sprintf(Buffer, "Y %03.0f", OrbMech::round(G->manpad.GDCangles.z));
+				sprintf(Buffer, "Y %03.0f", OrbMech::round(GC->manpad.GDCangles.z));
 				skp->Text((int)(0.5 * W / 8), 22 * H / 23, Buffer, strlen(Buffer));
 
 				int hh, mm;
@@ -963,14 +963,14 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text(7 * W / 8, 9 * H / 26, "N81", 3);
 				skp->Text(7 * W / 8, 15 * H / 26, "N44", 3);
 
-				sprintf(Buffer, "%+06.0f WGT", G->manpad.Weight);
+				sprintf(Buffer, "%+06.0f WGT", GC->manpad.Weight);
 				skp->Text((int)(3.5 * W / 8), 3 * H / 26, Buffer, strlen(Buffer));
 
 				if (G->manpadenginetype == RTCC_ENGINETYPE_CSMSPS)
 				{
-					sprintf(Buffer, "%+07.2f PTRIM", G->manpad.pTrim);
+					sprintf(Buffer, "%+07.2f PTRIM", GC->manpad.pTrim);
 					skp->Text((int)(3.5 * W / 8), 4 * H / 26, Buffer, strlen(Buffer));
-					sprintf(Buffer, "%+07.2f YTRIM", G->manpad.yTrim);
+					sprintf(Buffer, "%+07.2f YTRIM", GC->manpad.yTrim);
 					skp->Text((int)(3.5 * W / 8), 5 * H / 26, Buffer, strlen(Buffer));
 				}
 				else
@@ -993,31 +993,31 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+07.1f DVZ", G->dV_LVLH.z / 0.3048);
 				skp->Text((int)(3.5 * W / 8), 11 * H / 26, Buffer, strlen(Buffer));
 
-				sprintf(Buffer, "XXX%03.0f R", G->manpad.Att.x);
+				sprintf(Buffer, "XXX%03.0f R", GC->manpad.Att.x);
 				skp->Text((int)(3.5 * W / 8), 12 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "XXX%03.0f P", G->manpad.Att.y);
+				sprintf(Buffer, "XXX%03.0f P", GC->manpad.Att.y);
 				skp->Text((int)(3.5 * W / 8), 13 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "XXX%03.0f Y", G->manpad.Att.z);
+				sprintf(Buffer, "XXX%03.0f Y", GC->manpad.Att.z);
 				skp->Text((int)(3.5 * W / 8), 14 * H / 26, Buffer, strlen(Buffer));
 
-				sprintf(Buffer, "%+07.1f HA", min(9999.9, G->manpad.HA));
+				sprintf(Buffer, "%+07.1f HA", min(9999.9, GC->manpad.HA));
 				skp->Text((int)(3.5 * W / 8), 15 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+07.1f HP", G->manpad.HP);
+				sprintf(Buffer, "%+07.1f HP", GC->manpad.HP);
 				skp->Text((int)(3.5 * W / 8), 16 * H / 26, Buffer, strlen(Buffer));
 
-				sprintf(Buffer, "%+07.1f VT", G->manpad.Vt);// length(G->dV_LVLH) / 0.3048);
+				sprintf(Buffer, "%+07.1f VT", GC->manpad.Vt);// length(G->dV_LVLH) / 0.3048);
 				skp->Text((int)(3.5 * W / 8), 17 * H / 26, Buffer, strlen(Buffer));
 
-				OrbMech::SStoHHMMSS(G->manpad.burntime, hh, mm, secs);
+				OrbMech::SStoHHMMSS(GC->manpad.burntime, hh, mm, secs);
 
 				sprintf(Buffer, "XXX%d:%02.0f BT (MIN:SEC)", mm, secs);
 				skp->Text((int)(3.5 * W / 8), 18 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+07.1f VC", G->manpad.Vc);
+				sprintf(Buffer, "%+07.1f VC", GC->manpad.Vc);
 				skp->Text((int)(3.5 * W / 8), 19 * H / 26, Buffer, strlen(Buffer));
 
 				//skp->Text(4 * W / 8, 13 * H / 20, "SXT star check", 14);
 
-				if (G->manpad.Star == 0)
+				if (GC->manpad.Star == 0)
 				{
 					sprintf(Buffer, "N/A     SXTS");
 					skp->Text((int)(3.5 * W / 8), 20 * H / 26, Buffer, strlen(Buffer));
@@ -1028,14 +1028,14 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				}
 				else
 				{
-					sprintf(Buffer, "XXXX%02d SXTS", G->manpad.Star);
+					sprintf(Buffer, "XXXX%02d SXTS", GC->manpad.Star);
 					skp->Text((int)(3.5 * W / 8), 20 * H / 26, Buffer, strlen(Buffer));
-					sprintf(Buffer, "%+07.2f SFT", G->manpad.Shaft);
+					sprintf(Buffer, "%+07.2f SFT", GC->manpad.Shaft);
 					skp->Text((int)(3.5 * W / 8), 21 * H / 26, Buffer, strlen(Buffer));
-					sprintf(Buffer, "%+07.3f TRN", G->manpad.Trun);
+					sprintf(Buffer, "%+07.3f TRN", GC->manpad.Trun);
 					skp->Text((int)(3.5 * W / 8), 22 * H / 26, Buffer, strlen(Buffer));
 				}
-				if (G->manpad.BSSStar == 0)
+				if (GC->manpad.BSSStar == 0)
 				{
 					sprintf(Buffer, "N/A     BSS");
 					skp->Text((int)(3.5 * W / 8), 23 * H / 26, Buffer, strlen(Buffer));
@@ -1046,11 +1046,11 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				}
 				else
 				{
-					sprintf(Buffer, "XXXX%02d BSS", G->manpad.BSSStar);
+					sprintf(Buffer, "XXXX%02d BSS", GC->manpad.BSSStar);
 					skp->Text((int)(3.5 * W / 8), 23 * H / 26, Buffer, strlen(Buffer));
-					sprintf(Buffer, "%+07.2f SPA", G->manpad.SPA);
+					sprintf(Buffer, "%+07.2f SPA", GC->manpad.SPA);
 					skp->Text((int)(3.5 * W / 8), 24 * H / 26, Buffer, strlen(Buffer));
-					sprintf(Buffer, "%+07.3f SXP", G->manpad.SXP);
+					sprintf(Buffer, "%+07.3f SXP", GC->manpad.SXP);
 					skp->Text((int)(3.5 * W / 8), 25 * H / 26, Buffer, strlen(Buffer));
 				}
 			}
@@ -1070,12 +1070,12 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 					skp->Text((int)(0.5 * W / 8), 2 * H / 14, "LM/CSM", 6);
 				}
 
-				sprintf(Buffer, "LM Weight: %5.0f", G->lmmanpad.LMWeight);
+				sprintf(Buffer, "LM Weight: %5.0f", GC->lmmanpad.LMWeight);
 				skp->Text((int)(0.5 * W / 8), 10 * H / 14, Buffer, strlen(Buffer));
 
 				if (G->vesselisdocked)
 				{
-					sprintf(Buffer, "CSM Weight: %5.0f", G->lmmanpad.CSMWeight);
+					sprintf(Buffer, "CSM Weight: %5.0f", GC->lmmanpad.CSMWeight);
 					skp->Text((int)(0.5 * W / 8), 11 * H / 14, Buffer, strlen(Buffer));
 				}
 
@@ -1098,32 +1098,32 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+07.1f DVZ", G->dV_LVLH.z / 0.3048);
 				skp->Text((int)(3.5 * W / 8), 10 * H / 26, Buffer, strlen(Buffer));
 
-				sprintf(Buffer, "%+07.1f HA", min(9999.9, G->lmmanpad.HA));
+				sprintf(Buffer, "%+07.1f HA", min(9999.9, GC->lmmanpad.HA));
 				skp->Text((int)(3.5 * W / 8), 11 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+07.1f HP", G->lmmanpad.HP);
+				sprintf(Buffer, "%+07.1f HP", GC->lmmanpad.HP);
 				skp->Text((int)(3.5 * W / 8), 12 * H / 26, Buffer, strlen(Buffer));
 
 				sprintf(Buffer, "%+07.1f DVR", length(G->dV_LVLH) / 0.3048);
 				skp->Text((int)(3.5 * W / 8), 13 * H / 26, Buffer, strlen(Buffer));
 
-				OrbMech::SStoHHMMSS(G->lmmanpad.burntime, hh, mm, secs);
+				OrbMech::SStoHHMMSS(GC->lmmanpad.burntime, hh, mm, secs);
 
 				sprintf(Buffer, "XXX%d:%02.0f BT", mm, secs);
 				skp->Text((int)(3.5 * W / 8), 14 * H / 26, Buffer, strlen(Buffer));
 
-				sprintf(Buffer, "XXX%03.0f R", G->lmmanpad.Att.x);
+				sprintf(Buffer, "XXX%03.0f R", GC->lmmanpad.Att.x);
 				skp->Text((int)(3.5 * W / 8), 15 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "XXX%03.0f P", G->lmmanpad.Att.y);
+				sprintf(Buffer, "XXX%03.0f P", GC->lmmanpad.Att.y);
 				skp->Text((int)(3.5 * W / 8), 16 * H / 26, Buffer, strlen(Buffer));
 
-				sprintf(Buffer, "%+07.1f DVX AGS N86", G->lmmanpad.dV_AGS.x);
+				sprintf(Buffer, "%+07.1f DVX AGS N86", GC->lmmanpad.dV_AGS.x);
 				skp->Text((int)(3.5 * W / 8), 17 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+07.1f DVY AGS", G->lmmanpad.dV_AGS.y);
+				sprintf(Buffer, "%+07.1f DVY AGS", GC->lmmanpad.dV_AGS.y);
 				skp->Text((int)(3.5 * W / 8), 18 * H / 26, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+07.1f DVZ AGS", G->lmmanpad.dV_AGS.z);
+				sprintf(Buffer, "%+07.1f DVZ AGS", GC->lmmanpad.dV_AGS.z);
 				skp->Text((int)(3.5 * W / 8), 19 * H / 26, Buffer, strlen(Buffer));
 
-				if (G->lmmanpad.BSSStar == 0)
+				if (GC->lmmanpad.BSSStar == 0)
 				{
 					sprintf(Buffer, "N/A     BSS");
 					skp->Text((int)(3.5 * W / 8), 20 * H / 26, Buffer, strlen(Buffer));
@@ -1134,15 +1134,15 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				}
 				else
 				{
-					sprintf(Buffer, "XXXX%02d BSS", G->lmmanpad.BSSStar);
+					sprintf(Buffer, "XXXX%02d BSS", GC->lmmanpad.BSSStar);
 					skp->Text((int)(3.5 * W / 8), 20 * H / 26, Buffer, strlen(Buffer));
-					sprintf(Buffer, "%+07.2f SPA", G->lmmanpad.SPA);
+					sprintf(Buffer, "%+07.2f SPA", GC->lmmanpad.SPA);
 					skp->Text((int)(3.5 * W / 8), 21 * H / 26, Buffer, strlen(Buffer));
-					sprintf(Buffer, "%+07.3f SXP", G->lmmanpad.SXP);
+					sprintf(Buffer, "%+07.3f SXP", GC->lmmanpad.SXP);
 					skp->Text((int)(3.5 * W / 8), 22 * H / 26, Buffer, strlen(Buffer));
 				}
 
-				sprintf(Buffer, "IMU Attitude: %06.2lf %06.2lf %06.2lf", G->lmmanpad.IMUAtt.x*DEG, G->lmmanpad.IMUAtt.y*DEG, G->lmmanpad.IMUAtt.z*DEG);
+				sprintf(Buffer, "IMU Attitude: %06.2lf %06.2lf %06.2lf", GC->lmmanpad.IMUAtt.x*DEG, GC->lmmanpad.IMUAtt.y*DEG, GC->lmmanpad.IMUAtt.z*DEG);
 				skp->Text(1 * W / 16, 24 * H / 26, Buffer, strlen(Buffer));
 			}
 		}
@@ -1171,43 +1171,43 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			sprintf(Buffer, "%+07.1f DVZ", G->dV_LVLH.z / 0.3048);
 			skp->Text(3 * W / 8, 8 * H / 20, Buffer, strlen(Buffer));
 
-			if (G->TPI_PAD.Backup_dV.x > 0)
+			if (GC->TPI_PAD.Backup_dV.x > 0)
 			{
-				sprintf(Buffer, "F%04.1f/%02.0f DVX LOS/BT", abs(G->TPI_PAD.Backup_dV.x), G->TPI_PAD.Backup_bT.x);
+				sprintf(Buffer, "F%04.1f/%02.0f DVX LOS/BT", abs(GC->TPI_PAD.Backup_dV.x), GC->TPI_PAD.Backup_bT.x);
 			}
 			else
 			{
-				sprintf(Buffer, "A%04.1f/%02.0f DVX LOS/BT", abs(G->TPI_PAD.Backup_dV.x), G->TPI_PAD.Backup_bT.x);
+				sprintf(Buffer, "A%04.1f/%02.0f DVX LOS/BT", abs(GC->TPI_PAD.Backup_dV.x), GC->TPI_PAD.Backup_bT.x);
 			}
 			skp->Text(3 * W / 8, 9 * H / 20, Buffer, strlen(Buffer));
-			if (G->TPI_PAD.Backup_dV.y > 0)
+			if (GC->TPI_PAD.Backup_dV.y > 0)
 			{
-				sprintf(Buffer, "R%04.1f/%02.0f DVY LOS/BT", abs(G->TPI_PAD.Backup_dV.y), G->TPI_PAD.Backup_bT.y);
+				sprintf(Buffer, "R%04.1f/%02.0f DVY LOS/BT", abs(GC->TPI_PAD.Backup_dV.y), GC->TPI_PAD.Backup_bT.y);
 			}
 			else
 			{
-				sprintf(Buffer, "L%04.1f/%02.0f DVY LOS/BT", abs(G->TPI_PAD.Backup_dV.y), G->TPI_PAD.Backup_bT.y);
+				sprintf(Buffer, "L%04.1f/%02.0f DVY LOS/BT", abs(GC->TPI_PAD.Backup_dV.y), GC->TPI_PAD.Backup_bT.y);
 			}
 			skp->Text(3 * W / 8, 10 * H / 20, Buffer, strlen(Buffer));
-			if (G->TPI_PAD.Backup_dV.z > 0)
+			if (GC->TPI_PAD.Backup_dV.z > 0)
 			{
-				sprintf(Buffer, "D%04.1f/%02.0f DVZ LOS/BT", abs(G->TPI_PAD.Backup_dV.z), G->TPI_PAD.Backup_bT.z);
+				sprintf(Buffer, "D%04.1f/%02.0f DVZ LOS/BT", abs(GC->TPI_PAD.Backup_dV.z), GC->TPI_PAD.Backup_bT.z);
 			}
 			else
 			{
-				sprintf(Buffer, "U%04.1f/%02.0f DVZ LOS/BT", abs(G->TPI_PAD.Backup_dV.z), G->TPI_PAD.Backup_bT.z);
+				sprintf(Buffer, "U%04.1f/%02.0f DVZ LOS/BT", abs(GC->TPI_PAD.Backup_dV.z), GC->TPI_PAD.Backup_bT.z);
 			}
 			skp->Text(3 * W / 8, 11 * H / 20, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "X%04.1f/%02.1f dH TPI/ddH", G->TPI_PAD.dH_TPI, G->TPI_PAD.dH_Max);
+			sprintf(Buffer, "X%04.1f/%02.1f dH TPI/ddH", GC->TPI_PAD.dH_TPI, GC->TPI_PAD.dH_Max);
 			skp->Text(3 * W / 8, 12 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "X%06.2f R", G->TPI_PAD.R);
+			sprintf(Buffer, "X%06.2f R", GC->TPI_PAD.R);
 			skp->Text(3 * W / 8, 13 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+07.1f RDOT at TPI", G->TPI_PAD.Rdot);
+			sprintf(Buffer, "%+07.1f RDOT at TPI", GC->TPI_PAD.Rdot);
 			skp->Text(3 * W / 8, 14 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "X%06.2f EL minus 5 min", G->TPI_PAD.EL);
+			sprintf(Buffer, "X%06.2f EL minus 5 min", GC->TPI_PAD.EL);
 			skp->Text(3 * W / 8, 15 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "X%06.2f AZ", G->TPI_PAD.AZ);
+			sprintf(Buffer, "X%06.2f AZ", GC->TPI_PAD.AZ);
 			skp->Text(3 * W / 8, 16 * H / 20, Buffer, strlen(Buffer));
 
 		}
@@ -1215,41 +1215,41 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			skp->Text(4 * W / 8, (int)(0.5 * H / 14), "TLI PAD", 7);
 
-			GET_Display(Buffer, G->tlipad.TB6P);
+			GET_Display(Buffer, GC->tlipad.TB6P);
 			sprintf(Buffer, "%s TB6p", Buffer);
 			skp->Text(3 * W / 8, 3 * H / 20, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "XXX%03.0f R", G->tlipad.IgnATT.x);
+			sprintf(Buffer, "XXX%03.0f R", GC->tlipad.IgnATT.x);
 			skp->Text(3 * W / 8, 4 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "XXX%03.0f P", G->tlipad.IgnATT.y);
+			sprintf(Buffer, "XXX%03.0f P", GC->tlipad.IgnATT.y);
 			skp->Text(3 * W / 8, 5 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "XXX%03.0f Y", G->tlipad.IgnATT.z);
+			sprintf(Buffer, "XXX%03.0f Y", GC->tlipad.IgnATT.z);
 			skp->Text(3 * W / 8, 6 * H / 20, Buffer, strlen(Buffer));
 
 			double secs;
 			int mm, hh;
-			OrbMech::SStoHHMMSS(G->tlipad.BurnTime, hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->tlipad.BurnTime, hh, mm, secs);
 
 			sprintf(Buffer, "XXX%d:%02.0f BT", mm, secs);
 			skp->Text(3 * W / 8, 7 * H / 20, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%07.1f DVC", G->tlipad.dVC);
+			sprintf(Buffer, "%07.1f DVC", GC->tlipad.dVC);
 			skp->Text(3 * W / 8, 8 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+06.0f VI", G->tlipad.VI);
+			sprintf(Buffer, "%+06.0f VI", GC->tlipad.VI);
 			skp->Text(3 * W / 8, 9 * H / 20, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "XXX%03.0f R", G->tlipad.SepATT.x);
+			sprintf(Buffer, "XXX%03.0f R", GC->tlipad.SepATT.x);
 			skp->Text(3 * W / 8, 10 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "XXX%03.0f P SEP", G->tlipad.SepATT.y);
+			sprintf(Buffer, "XXX%03.0f P SEP", GC->tlipad.SepATT.y);
 			skp->Text(3 * W / 8, 11 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "XXX%03.0f Y", G->tlipad.SepATT.z);
+			sprintf(Buffer, "XXX%03.0f Y", GC->tlipad.SepATT.z);
 			skp->Text(3 * W / 8, 12 * H / 20, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "XXX%03.0f R", G->tlipad.ExtATT.x);
+			sprintf(Buffer, "XXX%03.0f R", GC->tlipad.ExtATT.x);
 			skp->Text(3 * W / 8, 13 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "XXX%03.0f P EXTRACTION", G->tlipad.ExtATT.y);
+			sprintf(Buffer, "XXX%03.0f P EXTRACTION", GC->tlipad.ExtATT.y);
 			skp->Text(3 * W / 8, 14 * H / 20, Buffer, strlen(Buffer));
-			sprintf(Buffer, "XXX%03.0f Y", G->tlipad.ExtATT.z);
+			sprintf(Buffer, "XXX%03.0f Y", GC->tlipad.ExtATT.z);
 			skp->Text(3 * W / 8, 15 * H / 20, Buffer, strlen(Buffer));
 		}
 		else
@@ -1289,7 +1289,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			int hh, mm; // ss;
 			double secs;
 
-			OrbMech::SStoHHMMSS(G->pdipad.GETI, hh, mm, secs, 0.01);
+			OrbMech::SStoHHMMSS(GC->pdipad.GETI, hh, mm, secs, 0.01);
 
 			skp->Text(3 * W / 8, 5 * H / 20, "HRS", 3);
 			skp->Text((int)(4.5 * W / 8), 5 * H / 20, "TIG", 3);
@@ -1305,38 +1305,38 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			sprintf(Buffer, "%+07.2f", secs);
 			skp->Text(6 * W / 8, 7 * H / 20, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->pdipad.t_go, hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->pdipad.t_go, hh, mm, secs);
 			skp->Text(3 * W / 8, 8 * H / 20, "TGO", 3);
 			skp->Text((int)(4.5 * W / 8), 8 * H / 20, "N61", 3);
 			sprintf(Buffer, "XX%02d:%02.0f", mm, secs);
 			skp->Text(6 * W / 8, 8 * H / 20, Buffer, strlen(Buffer));
 
 			skp->Text(3 * W / 8, 9 * H / 20, "CROSSRANGE", 10);
-			sprintf(Buffer, "%07.1f", G->pdipad.CR);
+			sprintf(Buffer, "%07.1f", GC->pdipad.CR);
 			skp->Text(6 * W / 8, 9 * H / 20, Buffer, strlen(Buffer));
 
 			skp->Text(3 * W / 8, 10 * H / 20, "R", 1);
 			skp->Text((int)(4.5 * W / 8), 10 * H / 20, "FDAI", 4);
-			sprintf(Buffer, "XXX%03.0f", G->pdipad.Att.x);
+			sprintf(Buffer, "XXX%03.0f", GC->pdipad.Att.x);
 			skp->Text(6 * W / 8, 10 * H / 20, Buffer, strlen(Buffer));
 
 			skp->Text(3 * W / 8, 11 * H / 20, "P", 1);
 			skp->Text((int)(4.5 * W / 8), 11 * H / 20, "AT TIG", 6);
-			sprintf(Buffer, "XXX%03.0f", G->pdipad.Att.y);
+			sprintf(Buffer, "XXX%03.0f", GC->pdipad.Att.y);
 			skp->Text(6 * W / 8, 11 * H / 20, Buffer, strlen(Buffer));
 
 			skp->Text(3 * W / 8, 12 * H / 20, "Y", 1);
-			sprintf(Buffer, "XXX%03.0f", G->pdipad.Att.z);
+			sprintf(Buffer, "XXX%03.0f", GC->pdipad.Att.z);
 			skp->Text(6 * W / 8, 12 * H / 20, Buffer, strlen(Buffer));
 
 			skp->Text(3 * W / 8, 13 * H / 20, "DEDA 231 IF RQD", 15);
-			sprintf(Buffer, "%+06.0f", G->pdipad.DEDA231);
+			sprintf(Buffer, "%+06.0f", GC->pdipad.DEDA231);
 			skp->Text(6 * W / 8, 13 * H / 20, Buffer, strlen(Buffer));
 		}
 	}
 	else if (screen == 10)
 	{
-		if (G->entrypadopt == 0)
+		if (GC->entrypadopt == 0)
 		{
 			skp->Text(5 * W / 8, 1 * H / 28, "Earth Entry PAD", 15);
 
@@ -1344,97 +1344,97 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 
 			skp->Text(7 * W / 16, 3 * H / 32, "PREBURN", 7);
 
-			sprintf(Buffer, "XX%+05.1f dV TO", G->earthentrypad.dVTO[0]);
+			sprintf(Buffer, "XX%+05.1f dV TO", GC->earthentrypad.dVTO[0]);
 			skp->Text(3 * W / 8, 4 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "XXX%03.0f R 0.05G", G->earthentrypad.Att400K[0].x);
+			sprintf(Buffer, "XXX%03.0f R 0.05G", GC->earthentrypad.Att400K[0].x);
 			skp->Text(3 * W / 8, 5 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "XXX%03.0f P 0.05G", G->earthentrypad.Att400K[0].y);
+			sprintf(Buffer, "XXX%03.0f P 0.05G", GC->earthentrypad.Att400K[0].y);
 			skp->Text(3 * W / 8, 6 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "XXX%03.0f Y 0.05G", G->earthentrypad.Att400K[0].z);
+			sprintf(Buffer, "XXX%03.0f Y 0.05G", GC->earthentrypad.Att400K[0].z);
 			skp->Text(3 * W / 8, 7 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+07.1f RTGO .05G", G->earthentrypad.RTGO[0]);
+			sprintf(Buffer, "%+07.1f RTGO .05G", GC->earthentrypad.RTGO[0]);
 			skp->Text(3 * W / 8, 8 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+06.0f VIO  .05G", G->earthentrypad.VIO[0]);
+			sprintf(Buffer, "%+06.0f VIO  .05G", GC->earthentrypad.VIO[0]);
 			skp->Text(3 * W / 8, 9 * H / 32, Buffer, strlen(Buffer));
 
 			double secs;
 			int mm, hh;
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.Ret05[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.Ret05[0], hh, mm, secs);
 
 			sprintf(Buffer, "XX%02d:%02.0f RET  .05G", mm, secs);
 			skp->Text(3 * W / 8, 10 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+07.2f LAT", G->earthentrypad.Lat[0]);
+			sprintf(Buffer, "%+07.2f LAT", GC->earthentrypad.Lat[0]);
 			skp->Text(3 * W / 8, 11 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+07.2f LONG", G->earthentrypad.Lng[0]);
+			sprintf(Buffer, "%+07.2f LONG", GC->earthentrypad.Lng[0]);
 			skp->Text(3 * W / 8, 12 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.Ret2[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.Ret2[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RET  .2G", mm, secs);
 			skp->Text(3 * W / 8, 13 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+07.1lf DRE (55°)  N66", G->earthentrypad.DRE[0]);
+			sprintf(Buffer, "%+07.1lf DRE (55°)  N66", GC->earthentrypad.DRE[0]);
 			skp->Text(3 * W / 8, 14 * H / 32, Buffer, strlen(Buffer));
 
 			sprintf(Buffer, "RR55/55 BANK AN");
 			skp->Text(3 * W / 8, 15 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.RetRB[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.RetRB[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RET RB", mm, secs);
 			skp->Text(3 * W / 8, 16 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.RetBBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.RetBBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETBBO", mm, secs);
 			skp->Text(3 * W / 8, 17 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.RetEBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.RetEBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETEBO", mm, secs);
 			skp->Text(3 * W / 8, 18 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.RetDrog[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.RetDrog[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETDROG", mm, secs);
 			skp->Text(3 * W / 8, 19 * H / 32, Buffer, strlen(Buffer));
 
 			skp->Text(7 * W / 16, 20 * H / 32, "POSTBURN", 8);
 
-			sprintf(Buffer, "XXX%03.0f R 0.05G", G->earthentrypad.PB_R400K[0]);
+			sprintf(Buffer, "XXX%03.0f R 0.05G", GC->earthentrypad.PB_R400K[0]);
 			skp->Text(3 * W / 8, 21 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+07.1f RTGO .05G", G->earthentrypad.PB_RTGO[0]);
+			sprintf(Buffer, "%+07.1f RTGO .05G", GC->earthentrypad.PB_RTGO[0]);
 			skp->Text(3 * W / 8, 22 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+06.0f VIO  .05G", G->earthentrypad.PB_VIO[0]);
+			sprintf(Buffer, "%+06.0f VIO  .05G", GC->earthentrypad.PB_VIO[0]);
 			skp->Text(3 * W / 8, 23 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.PB_Ret05[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.PB_Ret05[0], hh, mm, secs);
 
 			sprintf(Buffer, "XX%02d:%02.0f RET  .05G", mm, secs);
 			skp->Text(3 * W / 8, 24 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.PB_Ret2[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.PB_Ret2[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RET  .2G", mm, secs);
 			skp->Text(3 * W / 8, 25 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+07.1lf DRE +/- 100nm  N66", G->earthentrypad.PB_DRE[0]);
+			sprintf(Buffer, "%+07.1lf DRE +/- 100nm  N66", GC->earthentrypad.PB_DRE[0]);
 			skp->Text(3 * W / 8, 26 * H / 32, Buffer, strlen(Buffer));
 
 			sprintf(Buffer, "RR55/55 BANK AN");
 			skp->Text(3 * W / 8, 27 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.PB_RetRB[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.PB_RetRB[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RET RB", mm, secs);
 			skp->Text(3 * W / 8, 28 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.PB_RetBBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.PB_RetBBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETBBO", mm, secs);
 			skp->Text(3 * W / 8, 29 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.PB_RetEBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.PB_RetEBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETEBO", mm, secs);
 			skp->Text(3 * W / 8, 30 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->earthentrypad.PB_RetDrog[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->earthentrypad.PB_RetDrog[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETDROG", mm, secs);
 			skp->Text(3 * W / 8, 31 * H / 32, Buffer, strlen(Buffer));
 
@@ -1478,7 +1478,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			skp->SetFont(font2);
 
 			skp->Text(1 * W / 16, 4 * H / 28, "Sxt Star Check at", 17);
-			if (G->EntryPADSxtStarCheckAttOpt)
+			if (GC->EntryPADSxtStarCheckAttOpt)
 			{
 				skp->Text(1 * W / 16, 5 * H / 28, "Entry Attitude", 14);
 			}
@@ -1494,80 +1494,80 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text((int)(0.5 * W / 8), 7 * H / 14, Buffer, strlen(Buffer));
 			}
 
-			sprintf(Buffer, "XXX%03.0f R 0.05G", G->lunarentrypad.Att05[0].x);
+			sprintf(Buffer, "XXX%03.0f R 0.05G", GC->lunarentrypad.Att05[0].x);
 			skp->Text(3 * W / 8, 5 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "XXX%03.0f P 0.05G", G->lunarentrypad.Att05[0].y);
+			sprintf(Buffer, "XXX%03.0f P 0.05G", GC->lunarentrypad.Att05[0].y);
 			skp->Text(3 * W / 8, 6 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "XXX%03.0f Y 0.05G", G->lunarentrypad.Att05[0].z);
+			sprintf(Buffer, "XXX%03.0f Y 0.05G", GC->lunarentrypad.Att05[0].z);
 			skp->Text(3 * W / 8, 7 * H / 32, Buffer, strlen(Buffer));
 
-			GET_Display(Buffer, G->lunarentrypad.GETHorCheck[0]);
+			GET_Display(Buffer, GC->lunarentrypad.GETHorCheck[0]);
 			skp->Text(3 * W / 8, 8 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "XXX%03.0f P HOR CK", G->lunarentrypad.PitchHorCheck[0]);
+			sprintf(Buffer, "XXX%03.0f P HOR CK", GC->lunarentrypad.PitchHorCheck[0]);
 			skp->Text(3 * W / 8, 9 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+07.2f LAT", G->lunarentrypad.Lat[0]);
+			sprintf(Buffer, "%+07.2f LAT", GC->lunarentrypad.Lat[0]);
 			skp->Text(3 * W / 8, 10 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+07.2f LONG", G->lunarentrypad.Lng[0]);
+			sprintf(Buffer, "%+07.2f LONG", GC->lunarentrypad.Lng[0]);
 			skp->Text(3 * W / 8, 11 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "XXX%04.1f MAX G", G->lunarentrypad.MaxG[0]);
+			sprintf(Buffer, "XXX%04.1f MAX G", GC->lunarentrypad.MaxG[0]);
 			skp->Text(3 * W / 8, 12 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+06.0f V400k", G->lunarentrypad.V400K[0]);
+			sprintf(Buffer, "%+06.0f V400k", GC->lunarentrypad.V400K[0]);
 			skp->Text(3 * W / 8, 13 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+07.2f y400k", G->lunarentrypad.Gamma400K[0]);
+			sprintf(Buffer, "%+07.2f y400k", GC->lunarentrypad.Gamma400K[0]);
 			skp->Text(3 * W / 8, 14 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+07.1f RTGO .05G", G->lunarentrypad.RTGO[0]);
+			sprintf(Buffer, "%+07.1f RTGO .05G", GC->lunarentrypad.RTGO[0]);
 			skp->Text(3 * W / 8, 15 * H / 32, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+06.0f VIO  .05G", G->lunarentrypad.VIO[0]);
+			sprintf(Buffer, "%+06.0f VIO  .05G", GC->lunarentrypad.VIO[0]);
 			skp->Text(3 * W / 8, 16 * H / 32, Buffer, strlen(Buffer));
 
-			GET_Display(Buffer, G->lunarentrypad.RRT[0]);
+			GET_Display(Buffer, GC->lunarentrypad.RRT[0]);
 			sprintf(Buffer, "%s RRT", Buffer);
 			skp->Text(3 * W / 8, 17 * H / 32, Buffer, strlen(Buffer));
 
 			double secs;
 			int mm, hh;
 
-			OrbMech::SStoHHMMSS(G->lunarentrypad.RET05[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->lunarentrypad.RET05[0], hh, mm, secs);
 
 			sprintf(Buffer, "XX%02d:%02.0f RET  .05G", mm, secs);
 			skp->Text(3 * W / 8, 18 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+07.2lf DL MAX", G->lunarentrypad.DLMax[0]);
+			sprintf(Buffer, "%+07.2lf DL MAX", GC->lunarentrypad.DLMax[0]);
 			skp->Text(3 * W / 8, 19 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+07.2lf DL MIN", G->lunarentrypad.DLMin[0]);
+			sprintf(Buffer, "%+07.2lf DL MIN", GC->lunarentrypad.DLMin[0]);
 			skp->Text(3 * W / 8, 20 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+06.0lf VL MAX", G->lunarentrypad.VLMax[0]);
+			sprintf(Buffer, "%+06.0lf VL MAX", GC->lunarentrypad.VLMax[0]);
 			skp->Text(3 * W / 8, 21 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "%+06.0lf VL MIN", G->lunarentrypad.VLMin[0]);
+			sprintf(Buffer, "%+06.0lf VL MIN", GC->lunarentrypad.VLMin[0]);
 			skp->Text(3 * W / 8, 22 * H / 32, Buffer, strlen(Buffer));
 
-			sprintf(Buffer, "XXX%04.2f DO", G->lunarentrypad.DO[0]);
+			sprintf(Buffer, "XXX%04.2f DO", GC->lunarentrypad.DO[0]);
 			skp->Text(3 * W / 8, 23 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->lunarentrypad.RETVCirc[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->lunarentrypad.RETVCirc[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RET V CIRC", mm, secs);
 			skp->Text(3 * W / 8, 24 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->lunarentrypad.RETBBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->lunarentrypad.RETBBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETBBO", mm, secs);
 			skp->Text(3 * W / 8, 25 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->lunarentrypad.RETEBO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->lunarentrypad.RETEBO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETEBO", mm, secs);
 			skp->Text(3 * W / 8, 26 * H / 32, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(G->lunarentrypad.RETDRO[0], hh, mm, secs);
+			OrbMech::SStoHHMMSS(GC->lunarentrypad.RETDRO[0], hh, mm, secs);
 			sprintf(Buffer, "XX%02d:%02.0f RETDRO", mm, secs);
 			skp->Text(3 * W / 8, 27 * H / 32, Buffer, strlen(Buffer));
 
-			if (G->lunarentrypad.SXTS[0] == 0)
+			if (GC->lunarentrypad.SXTS[0] == 0)
 			{
 				sprintf(Buffer, "N/A     SXTS");
 				skp->Text(3 * W / 8, 28 * H / 32, Buffer, strlen(Buffer));
@@ -1578,15 +1578,15 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			}
 			else
 			{
-				sprintf(Buffer, "XXXX%02d SXTS", G->lunarentrypad.SXTS[0]);
+				sprintf(Buffer, "XXXX%02d SXTS", GC->lunarentrypad.SXTS[0]);
 				skp->Text(3 * W / 8, 28 * H / 32, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+07.2f SFT", G->lunarentrypad.SFT[0]);
+				sprintf(Buffer, "%+07.2f SFT", GC->lunarentrypad.SFT[0]);
 				skp->Text(3 * W / 8, 29 * H / 32, Buffer, strlen(Buffer));
-				sprintf(Buffer, "%+07.3f TRN", G->lunarentrypad.TRN[0]);
+				sprintf(Buffer, "%+07.3f TRN", GC->lunarentrypad.TRN[0]);
 				skp->Text(3 * W / 8, 30 * H / 32, Buffer, strlen(Buffer));
 			}
 
-			sprintf(Buffer, "XXXX%s LIFT VECTOR", G->lunarentrypad.LiftVector[0]);
+			sprintf(Buffer, "XXXX%s LIFT VECTOR", GC->lunarentrypad.LiftVector[0]);
 			skp->Text(3 * W / 8, 31 * H / 32, Buffer, strlen(Buffer));
 
 			skp->Text(1 * W / 16, 12 * H / 21, "Splashdown:", 11);
@@ -1703,36 +1703,45 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		PrintCSMVessel(Buffer);
 		skp->Text(1 * W / 8, 2 * H / 14, Buffer, strlen(Buffer));
 
-		GET_Display(Buffer, G->LmkTime);
-		skp->Text(1 * W / 8, 4 * H / 14, Buffer, strlen(Buffer));
-		sprintf(Buffer, "%.3f°", G->LmkLat*DEG);
-		skp->Text(1 * W / 8, 6 * H / 14, Buffer, strlen(Buffer));
-		sprintf(Buffer, "%.3f°", G->LmkLng*DEG);
-		skp->Text(1 * W / 8, 8 * H / 14, Buffer, strlen(Buffer));
-
-		GET_Display(Buffer2, G->landmarkpad.T1[0]);
-		sprintf(Buffer, "T1: %s (HOR)", Buffer2);
-		skp->Text(4 * W / 8, 6 * H / 14, Buffer, strlen(Buffer));
-		GET_Display(Buffer2, G->landmarkpad.T2[0]);
-		sprintf(Buffer, "T2: %s (35°)", Buffer2);
-		skp->Text(4 * W / 8, 7 * H / 14, Buffer, strlen(Buffer));
-
-		if (G->landmarkpad.CRDist[0] > 0)
+		if (GC->LmkTime <= 0.0)
 		{
-			sprintf(Buffer, "%.1f NM North", G->landmarkpad.CRDist[0]);
+			sprintf(Buffer, "Present Time");
 		}
 		else
 		{
-			sprintf(Buffer, "%.1f NM South", abs(G->landmarkpad.CRDist[0]));
+			GET_Display(Buffer, GC->LmkTime);
+		}
+		skp->Text(1 * W / 8, 4 * H / 14, Buffer, strlen(Buffer));
+		sprintf(Buffer, "%.3f°", GC->LmkElevation*DEG);
+		skp->Text(1 * W / 8, 6 * H / 14, Buffer, strlen(Buffer));
+		sprintf(Buffer, "%.3f°", GC->LmkLat*DEG);
+		skp->Text(1 * W / 8, 8 * H / 14, Buffer, strlen(Buffer));
+		sprintf(Buffer, "%.3f°", GC->LmkLng*DEG);
+		skp->Text(1 * W / 8, 10 * H / 14, Buffer, strlen(Buffer));
+
+		GET_Display(Buffer2, GC->landmarkpad.T1[0]);
+		sprintf(Buffer, "T1: %s (HOR)", Buffer2);
+		skp->Text(4 * W / 8, 6 * H / 14, Buffer, strlen(Buffer));
+		GET_Display(Buffer2, GC->landmarkpad.T2[0]);
+		sprintf(Buffer, "T2: %s (%.0lf°)", Buffer2, GC->LmkElevation*DEG);
+		skp->Text(4 * W / 8, 7 * H / 14, Buffer, strlen(Buffer));
+
+		if (GC->landmarkpad.CRDist[0] > 0)
+		{
+			sprintf(Buffer, "%.1f NM North", GC->landmarkpad.CRDist[0]);
+		}
+		else
+		{
+			sprintf(Buffer, "%.1f NM South", abs(GC->landmarkpad.CRDist[0]));
 		}
 
 		skp->Text(4 * W / 8, 8 * H / 14, Buffer, strlen(Buffer));
 		skp->Text(4 * W / 8, 9 * H / 14, "N89", 3);
-		sprintf(Buffer, "Lat %+07.3f°", G->landmarkpad.Lat[0]);
+		sprintf(Buffer, "Lat %+07.3f°", GC->landmarkpad.Lat[0]);
 		skp->Text(4 * W / 8, 10 * H / 14, Buffer, strlen(Buffer));
-		sprintf(Buffer, "Long/2 %+07.3f°", G->landmarkpad.Lng05[0]);
+		sprintf(Buffer, "Long/2 %+07.3f°", GC->landmarkpad.Lng05[0]);
 		skp->Text(4 * W / 8, 11 * H / 14, Buffer, strlen(Buffer));
-		sprintf(Buffer, "Alt %+07.2f NM", G->landmarkpad.Alt[0]);
+		sprintf(Buffer, "Alt %+07.2f NM", GC->landmarkpad.Alt[0]);
 		skp->Text(4 * W / 8, 12 * H / 14, Buffer, strlen(Buffer));
 	}
 	else if (screen == 14)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
@@ -450,10 +450,10 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 	{
 		{ "Choose CSM", 0, 'E' },
 		{ "T1 guess", 0, 'T' },
+		{ "T2 elevation", 0, ' ' },
 		{ "Landmark Latitude", 0, 'A' },
 		{ "Landmark Longitude", 0, 'O' },
 		{ "Load landing site coordinates", 0, 'D' },
-		{ "", 0, ' ' },
 
 		{ "Calculate PAD", 0, 'C' },
 		{ "", 0, ' ' },
@@ -467,10 +467,10 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 
 	RegisterFunction("CSM", OAPI_KEY_E, &ApolloRTCCMFD::set_CSMVessel);
 	RegisterFunction("TIM", OAPI_KEY_T, &ApolloRTCCMFD::menuSetLmkTime);
+	RegisterFunction("EL", OAPI_KEY_F, &ApolloRTCCMFD::menuSetLmkElevation);
 	RegisterFunction("LAT", OAPI_KEY_A, &ApolloRTCCMFD::menuSetLmkLat);
 	RegisterFunction("LNG", OAPI_KEY_O, &ApolloRTCCMFD::menuSetLmkLng);
 	RegisterFunction("LLS", OAPI_KEY_D, &ApolloRTCCMFD::menuLmkUseLandingSite);
-	RegisterFunction("", OAPI_KEY_F, &ApolloRTCCMFD::menuVoid);
 
 	RegisterFunction("CLC", OAPI_KEY_C, &ApolloRTCCMFD::menuLmkPADCalc);
 	RegisterFunction("", OAPI_KEY_G, &ApolloRTCCMFD::menuVoid);


### PR DESCRIPTION
PADs: CSM Maneuver, LM Maneuver, TLI, PDI, TPI, Lunar Entry, Earth Orbit Entry and Landmark Tracking PADs are now in simulation wide memory, which means you can look at the CSM Maneuver PAD you calculated in the CSM while you are in the LM. Previously in the LM you would have a separate instance of the PAD.

Landmark Tracking PAD: Cleanup of input parameters and add capability to adjust the elevation angle at T2, not all missions used 35° for all landmark tracking.

Map Update PAD: Always bring state vector to input time. With MPT active an input time beyond the end of the ephemeris returned a state vector at the end of the ephemeris, not at the desired time, potentially giving AOS/LOS data on the wrong revolution. That is now corrected.