### PR TITLE
RTCC Encke free-flight integrator corrections

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -4872,7 +4872,7 @@ void ApolloRTCCMFD::menuMPTInitM50M55Vehicle()
 void ApolloRTCCMFD::CheckoutMonitorCalc()
 {
 	bool CheckoutMonitorCalcInput(void* id, char *str, void *data);
-	oapiOpenInputBox("Format: U02, CSM or LEM, Indicator (GMT,GET,MVI,MVE,RAD,ALT,FPA), Parameter, Threshold Time (opt.), Reference (ECI,ECT,MCI,MCT) (opt.), FT (opt.);", CheckoutMonitorCalcInput, 0, 50, (void*)this);
+	oapiOpenInputBox("Format: U02, CSM or LEM, Indicator (GMT,GET,MVI,MVE,RAD,ALT,FPA,LAT,LNG), Parameter, Threshold Time (opt.), Reference (ECI,ECT,MCI,MCT) (opt.), FT (opt.);", CheckoutMonitorCalcInput, 0, 50, (void*)this);
 }
 
 bool CheckoutMonitorCalcInput(void *id, char *str, void *data)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/CoastNumericalIntegrator.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/CoastNumericalIntegrator.cpp
@@ -438,7 +438,7 @@ VECTOR3 CoastIntegrator2::adfunc(VECTOR3 R)
 			//Get Earth rotation matrix only during initialization. For the Moon the libration matrix is updated by the PLEFEM call below
 			if (P == BODY_EARTH)
 			{
-				pRTCC->ELVCNV(CurrentTime(), RTCC_COORDINATES_ECT, RTCC_COORDINATES_ECI, Rot);
+				pRTCC->ELVCNV(CurrentTime(), RTCC_COORDINATES_ECI, RTCC_COORDINATES_ECT, Rot);
 			}
 		}
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/EnckeIntegrator.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/EnckeIntegrator.h
@@ -144,7 +144,7 @@ private:
 	double VAR;
 	//Maximum time to integrate
 	double TMAX;
-	//Stop condition (1 = time, 2 = radial distance, 3 = altitude above Earth or moon, 4 = flight-path angle, 5 = first reference switch, 6 = first ascending node relative to the Earth)
+	//Stop condition (1 = time, 2 = radial distance, 3 = altitude above Earth or moon, 4 = flight-path angle, 5 = first reference switch, 6 = first ascending node relative to the Earth, 7 = longitude, 8 = latitude)
 	int ISTOPS;
 	//Reference frame of desired stopping parameter (0 = Earth, 1 = Moon, 2 = both)
 	int StopParamRefFrame;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCCTables.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCCTables.h
@@ -376,7 +376,7 @@ struct EMSMISSInputTable
 	int ManCutoffIndicator;
 	//Descent burn indicator
 	bool DescentBurnIndicator = false;
-	//Cut-off indicator (1 = Time, 2 = radial distance, 3 = altitude above Earth or moon, 4 = flight-path angle, 5 = first reference switch)
+	//Cut-off indicator (1 = Time, 2 = radial distance, 3 = altitude above Earth or moon, 4 = flight-path angle, 5 = first reference switch, 6 = first ascending node relative to the Earth, 7 = longitude, 8 = latitude)
 	int CutoffIndicator = 1;
 	//Integration direction indicator (+X-forward, -X-backward)
 	double IsForwardIntegration = 1.0;


### PR DESCRIPTION
-Use smaller step size while integrating in the Earth atmosphere. The Apollo 11 LOI-1 mission scenario has a peculiar behavior. The current trajectory leads to a reentry, but a bit steeper than normal. The integrator step size is derived from the AGC calculations for it, which doesn't take drag into account. Very close to Earth this means the step size is 80 seconds. Deep in the atmosphere this is way too large, which leads to the trajectory being propelled backwards(!) during the deep dip into the atmosphere at an extremely high speed. So fast in fact that the Kepler routine returns a NaN (I will improve this in a separate PR), thus crashing the simulation. This happens currently if you try to initialize a trajectory update with the MPT in this scenario.

The correction is to use 10 seconds as a fixed integration step when below entry interface radius.

-Correct a coordinate system conversion bug. Slightly embarassing this was the case, but only had a noticable effect on Skylab missions with the 1950 coordinate system.

-Checkout Monitor additions: Latitude and longitude are now options for the checkout monitor, as the Encke integrator now has these as stop conditions.