### PR TITLE
Fix bug in MCC line-of-sight to ground station calculation

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.cpp
@@ -2398,21 +2398,34 @@ void umbra(VECTOR3 R, VECTOR3 V, VECTOR3 sun, OBJHANDLE planet, bool rise, doubl
 
 bool sight(VECTOR3 R1, VECTOR3 R2, double R_E)
 {
+	//Returns true if position vectors R1 and R2 have a line-of-sight, considering the body radius R_E
 	VECTOR3 R1n, R2n;
 	bool los;
-	double tau_min;
+	double r12, r22, tau_min, dot_r1r2;
 
+	//Preliminary calculations
+	//Normalized position vectors
 	R1n = R1 / R_E;
 	R2n = R2 / R_E;
+	//Squares of radius magnitudes
+	r12 = dotp(R1n, R1n);
+	r22 = dotp(R2n, R2n);
+	//Dot product between normalized vectors
+	dot_r1r2 = dotp(R1n, R2n);
 
-	tau_min = (length(R1n)*length(R1n) - dotp(R1n, R2n)) / (length(R1n)*length(R1n) + length(R2n)*length(R2n) - 2.0*dotp(R1n,R2n));
+	//Location on line connecting R1 and R2 where the distance from the center of the body to the line is minimized
+	tau_min = (r12 - dot_r1r2) / (r12 + r22 - 2.0*dot_r1r2);
+	//Default to no line-of-sight
 	los = false;
-	if (tau_min < 0 || tau_min>1)
+	//Is there a line of sight?
+	if (tau_min < 0.0 || tau_min > 1.0)
 	{
+		//Yes, because both vectors have to be in the same quadrant
 		los = true;
 	}
-	else if ((1.0 - tau_min)*length(R1n)*length(R1n) + dotp(R1n, R2n)*tau_min >= 1.0)
+	else if ((1.0 - tau_min)*r12 + dot_r1r2 * tau_min >= 1.0)
 	{
+		//Yes, because minimum distance from center of body to line connecting R1 and R2 is greater than R_E (R1 and R2 having been normalized)
 		los = true;
 	}
 	return los;


### PR DESCRIPTION
When a vessel is below the mean lunar radius (e.g. LM landed on the Moon at most landing sites), a calculation error occurs (cosine of -NaN) that disables the check on the Moon being in the way of the line-of-sight to ground stations on Earth. This occurs whenever you are below the mean radius, which doesn't cause any harm in usual circumstances, but a landing site on the far side of the Moon would still show a signal strength on the meters. This gets fixed by making use of the same line-of-sight function that was already used to determine if the Earth is pointing in the wrong direction for having a line-of-sight from vessel to ground station. This function was also improved in efficiency in this PR.

To test this PR, make sure that AOS/LOS, both in messages from the MCC but more importantly the S-Band signal strength in CSM and LM, are still happening correctly. Both in orbit and landed.

Scenario with a LM landed on the far side attached:

[Apollo 17 Tsiolkovsky_117_55_00.scn.txt](https://github.com/user-attachments/files/16228196/Apollo.17.Tsiolkovsky_117_55_00.scn.txt)
