### PR TITLE
Slightly reduce S-IVB cutoff transients

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_saturn/sivbsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/sivbsystems.cpp
@@ -773,13 +773,13 @@ void SIVBSystems::Timestep(double simdt)
 		ThrustTimer += simdt;
 		if (ThrustTimer < 0.25)
 		{
-			// 95% of thrust dies in the first .25 second
-			ThrustLevel = 1.0 - (ThrustTimer*3.3048);
+			// 86% of thrust dies in the first .25 second
+			ThrustLevel = 1.0 - (ThrustTimer*3.456);
 		}
 		else if (ThrustTimer < 1.5)
 		{
 			// The remainder dies over the next 1.25 second
-			ThrustLevel = 0.1738 - ((ThrustTimer - 0.25)*0.1390);
+			ThrustLevel = 0.136 - ((ThrustTimer - 0.25)*0.1088);
 		}
 		else
 		{


### PR DESCRIPTION
Due to the addition of S-IVB propulsive venting (also after TLI) there is now a tendency of a TLI overburn. This is made worse by some LVDC deficiencies right now, which will be fixed eventually but are difficult. As part of the analysis I checked how realistic the S-IVB cutoff transient is and, compared to an average S-IVB, it also causes part of the overburn behavior. Here is the table I assembled from flight evaluation reports, which includes a clear trend for the average behavior, but also some cases that are strangely far off the average:

S-IVB Shutdown Transients in lbf-s (EOI and TLI)

8:   41236 41469
10: 45720 47356
11: 42332 53743
12: 45344 45729
13: 44319 46235 Predicted: 48019 48459
14: 44300 45629 Predicted: 46020 46920
15: 42482 43927 Predicted: 40314 41029
16: 46073 46667 Predicted: 47854 48341
17: 46401 46260 Predicted: 47638 48383

Based on this I have adjusted the cutoff transient behavior which will, on average, lead to 1.3 ft/s less DV for TLI and 0.5 ft/s for Earth orbit insertion. I don't think the EOI DV is all that relevant, but fine tuning the TLI behavior is important.

The exact impulse numbers are 52022 lbf-sec before this PR and  46240 lbf-sec with the new behavior.

The acceleration at TLI cutoff is quite high, so a small change was already enough to improve the behavior sufficiently:

![image](https://github.com/user-attachments/assets/ee0f3164-c517-44c2-b836-1617fadb5106)
