### PR TITLE
Fix some switches that could not process single mouse button presses …

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemswitches.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemswitches.cpp
@@ -1307,7 +1307,7 @@ bool EngineStartButton::CheckMouseClick(int event, int mx, int my) {
 	if (mx < x || my < y) return false;
 	if (mx >(x + width) || my >(y + height)) return false;
 
-	if (event == PANEL_MOUSE_LBDOWN)
+	if (event & PANEL_MOUSE_LBDOWN)
 	{
 		Push();
 	}
@@ -1318,7 +1318,7 @@ bool EngineStartButton::CheckMouseClickVC(int event, VECTOR3 &p) {
 
 	int OldState = state;
 
-	if (event == PANEL_MOUSE_LBDOWN)
+	if (event & PANEL_MOUSE_LBDOWN)
 	{
 		Push();
 	}
@@ -1403,7 +1403,7 @@ bool EngineStopButton::CheckMouseClick(int event, int mx, int my) {
 	if (mx < x || my < y) return false;
 	if (mx >(x + width) || my >(y + height)) return false;
 
-	if (event == PANEL_MOUSE_LBDOWN)
+	if (event & PANEL_MOUSE_LBDOWN)
 	{
 		Push();
 	}
@@ -1414,7 +1414,7 @@ bool EngineStopButton::CheckMouseClickVC(int event, VECTOR3 &p) {
 
 	int OldState = state;
 
-	if (event == PANEL_MOUSE_LBDOWN)
+	if (event & PANEL_MOUSE_LBDOWN)
 	{
 		Push();
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
@@ -955,10 +955,10 @@ bool PushSwitch::CheckMouseClick(int event, int mx, int my) {
 	SHORT ctrlState = GetKeyState(VK_SHIFT);
 	SetHeld((ctrlState & 0x8000) != 0);
 
-	if (event == PANEL_MOUSE_LBDOWN) {
+	if (event & PANEL_MOUSE_LBDOWN) {
 		SwitchTo(1, true);
 		Sclick.play();
-	} else if (event == PANEL_MOUSE_LBUP && !IsHeld()) {
+	} else if (event & PANEL_MOUSE_LBUP && !IsHeld()) {
 		SwitchTo(0, true);
 	}
 	return true;
@@ -976,11 +976,11 @@ bool PushSwitch::CheckMouseClickVC(int event, VECTOR3 &p) {
 	SHORT ctrlState = GetKeyState(VK_SHIFT);
 	SetHeld((ctrlState & 0x8000) != 0);
 
-	if (event == PANEL_MOUSE_LBDOWN) {
+	if (event & PANEL_MOUSE_LBDOWN) {
 		SwitchTo(1, true);
 		Sclick.play();
 	}
-	else if (event == PANEL_MOUSE_LBUP && !IsHeld()) {
+	else if (event & PANEL_MOUSE_LBUP && !IsHeld()) {
 		SwitchTo(0, true);
 	}
 	return true;


### PR DESCRIPTION
…correctly when the same panel area also allows continuous holding of the mouse button, which is a different mouse event code

More detailed explanation: The LM CDR engine start and stop buttons as well as the +X translation buttons were broken on the 2D panel.

A single left mouse button click corresponds to mouse code 1, continuously holding the left mouse button is code 16. These events are only processed if they are enabled for a specific panel area. If both are enabled then on the first timestep of clicking the code 17 is used (1 + 16, so both) and after that code 17.

Recently for LM panel 5 (which is a single panel area) the continuous mouse click event got enabled, where previously it was only processing single clicks. The problem is that the CDR engine start and stop buttons and +X translation button used this code to check on the mouse event code:

event == PANEL_MOUSE_LBDOWN (code 1)

With continuous click processing enabled the event never becomes 1, it will always be first 17 and afterwards 16. The solution is to instead process:

event & PANEL_MOUSE_LBDOWN

Which will detect whenever the event contains 1 (which is the case with 17). More classes should probably get this changed, but this fixes the three broken buttons.