### PR TITLE
LDPP accidentally stored a position vector instead of a velocity for …

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -3424,8 +3424,7 @@ int ARCore::subThread()
 				gmt = GC->rtcc->RTCCPresentTimeGMT();
 			}
 
-			EphemerisData EPHEM;
-			if (GC->rtcc->EMSFFV(gmt, GC->rtcc->med_k16.Vehicle, EPHEM))
+			if (GC->rtcc->EMSFFV(gmt, GC->rtcc->med_k16.Vehicle, sv))
 			{
 				Result = DONE;
 				break;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LDPP.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LDPP.cpp
@@ -192,7 +192,7 @@ void LDPP::Mode1_1()
 		if (opt.IDO == 1)
 		{
 			//Circularization at an apsis maneuver
-			dt = opt.TH[1] - sv_CSM.GMT;
+			dt = max(0.0, opt.TH[1] - sv_CSM.GMT);
 			sv_CSM = coast(sv_CSM, dt);
 			for (int iii = 0; iii < 2; iii++)
 			{
@@ -507,7 +507,7 @@ void LDPP::Mode3()
 	//Save maneuver
 	sv_CSM = SaveElements(sv_CSM, 0, DV);
 	//Advance to next threshold time
-	dt = opt.TH[1] - sv_CSM.GMT;
+	dt = max(0.0, opt.TH[1] - sv_CSM.GMT);
 	sv_CSM = coast(sv_CSM, dt);
 
 	//Advance to desired apsis
@@ -641,6 +641,7 @@ void LDPP::Mode5()
 
 	TH = 0.0;
 	iter = 0;
+	stop = false;
 
 	do
 	{
@@ -674,7 +675,7 @@ void LDPP::Mode5()
 		sv_CSM = SaveElements(sv_CSM, 0, DV);
 
 		//Maneuver 2
-		dt = opt.TH[1] - sv_CSM.GMT;
+		dt = max(0.0, opt.TH[1] - sv_CSM.GMT);
 		sv_CSM = coast(sv_CSM, dt);
 		if (opt.IDO == -1)
 		{
@@ -715,7 +716,7 @@ void LDPP::Mode5()
 		sv_CSM = SaveElements(sv_CSM, 1, DV);
 
 		//Maneuver 3
-		dt = opt.TH[2] - sv_CSM.GMT;
+		dt = max(0.0, opt.TH[2] - sv_CSM.GMT);
 		sv_CSM = coast(sv_CSM, dt);
 		if (opt.IDO == 1)
 		{
@@ -1722,10 +1723,10 @@ int LDPP::DOIManeuver(int i_DOI, bool Integrated)
 
 	//DOI
 	//Advance to threshold
-	dt = opt.TH[3] - sv_CSM.GMT;
+	dt = max(0.0, opt.TH[3] - sv_CSM.GMT);
 	sv_CSM = coast(sv_CSM, dt, Integrated);
 	//Calculate DOI time
-	LLTPR(opt.TH[3], sv_CSM, sv_DOI, DV_apo, t_IGN, t_TD, Integrated);
+	LLTPR(sv_CSM.GMT, sv_CSM, sv_DOI, DV_apo, t_IGN, t_TD, Integrated);
 	t_DOI = sv_DOI.GMT;
 	//Assign to CSM
 	sv_CSM = sv_DOI;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LDPP.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LDPP.cpp
@@ -1814,7 +1814,7 @@ void LDPP::OutputCalculations()
 		outp.DeltaV_LVLH[ii] = DeltaV_LVLH[ii];
 		outp.T_M[ii] = t_M[ii];
 		outp.sv_before[ii] = LoadElements(ii, true);
-		outp.V_after[ii] = LDPP_SV_E[ii][1][0];
+		outp.V_after[ii] = LDPP_SV_E[ii][1][1];
 	}
 	if (opt.MODE == 7)
 	{


### PR DESCRIPTION
…the transfer of maneuvers to finite burns; fix RTCC MFD bug in using the LDPP with MPT enabled

Scenario with a MCC calculation that gets stuck a few minutes later: 
[bad calculation.scn.txt](https://github.com/user-attachments/files/16481136/bad.calculation.scn.txt)
