### PR TITLE
Print error message to log if an invalid/empty checklist is about to cause a crash

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/checklistController.cpp
@@ -760,8 +760,13 @@ void ChecklistController::timestep(double missiontime, SaturnEvents eventControl
 	}
 
 	// Flashing
-	if (active.program.group != -1 && active.sequence->checkExec(missiontime + 1, active.startTime, lastItemTime, eventController, true)) {
-		active.sequence->setFlashing(&conn, flashing);
+	if (active.program.group != -1) {
+		if (active.set.size() == 0) {
+			oapiWriteLogError("Invalid/empty checklist group! Something is wrong with your scenario.");
+		}
+		else if (active.sequence->checkExec(missiontime + 1, active.startTime, lastItemTime, eventController, true)) {
+			active.sequence->setFlashing(&conn, flashing);
+		}
 	}
 
 	// Even on "non executing" timesteps, we want to allow to complete at least one checklist item


### PR DESCRIPTION
Apparently it is possible, for unknown reasons, for users' save files to become corrupted in such a way that their active checklist group/sequence is invalid or contains zero items. This causes many problems and will crash the sim with a memory access violation due to how we iterate through the set of ChecklistItem. However, in the event that this is about to happen, it will at least help non-dev users understand the cause of the crash if we print an error message to the log file before the crash occurs. 

I would ideally like to fix the problem so that it doesn't crash the sim, but right now I don't see any easy way to do that. In any case, the problem is due to a corrupted save file and adjusting its checklist state in the file might be easier for the time being.

The error message will look like this: 
![Checklist crash error message](https://github.com/user-attachments/assets/7105ae74-c85a-457f-b458-49d8e02ae85d)
