### PR TITLE
Better handling of near parabolic orbits in Moon-centered Return-to-Earth conic subprocessor

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -3050,8 +3050,8 @@ public:
 	double PIGMHA(double hour);
 	//Universal Cartesian to Kepler Coordinates
 	void PIMCKC(VECTOR3 R, VECTOR3 V, int body, double &a, double &e, double &i, double &l, double &g, double &h);
-	//Time from perifocal pass to radius (TRW routine TFPCR)
-	void PITFPC(double MUE, int K, double AORP, double ECC, double rad, double &TIME, double &P, bool erunits = true);
+	//Time from perifocal pass to radius
+	void PITFPC(double MUE, int K, double AINV, double p, double rad, double &TIME, double &PER, double &e) const;
 	//Determine time of arrival at specific height in orbit
 	int PITCIR(AEGHeader header, AEGDataBlock in, double R_CIR, AEGDataBlock &out);
 	//Generate orbit normal and ascending node vectors from elements, and vice versa

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/EntryCalculations.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/EntryCalculations.h
@@ -416,7 +416,7 @@ protected:
 	void DVMINQ(int FLAG, int QE, int Q0, double beta_r, double &DV, int &QA, double &V_a, double &beta_a);
 	void FCUA(int FLAG, VECTOR3 R_a, double &beta_r, double &DV, double &U_r, double &V_a, double &beta_a);
 	void MSDS(double VR_a, double VT_a, double beta_r, double theta, double &delta, double &phi, double &phi_z, double &lambda, double &theta_z);
-	bool RUBR(int QA, int QE, double R_a, double U_0, double U_r, double beta_r, double &A, double &DV, double &e, double &T, double &V_a, double &beta_a);
+	bool RUBR(int QA, int QE, double R_a, double U_0, double U_r, double beta_r, double &AINV, double &DV, double &e, double &T, double &V_a, double &beta_a);
 	void VELCOM(double T, double R_a, double &beta_r, double &dt, double &p, bool &QA, int &sw6, double &U_r, double &VR_a, double &VT_a, double &beta_a, double &eta_ar, double &DV);
 	void VARMIN();
 	void TCOMP(double dv, double delta, double &T, double &TP);
@@ -686,9 +686,9 @@ private:
 	int MCDRIV(VECTOR3 Y_0, VECTOR3 V_0, double t_0, double var, bool q_m, double Incl, double INTER, bool KIP, double t_zmin, VECTOR3 &V_a, VECTOR3 &R_EI, VECTOR3 &V_EI, double &T_EI, bool &NIR, double &Incl_apo, double &y_p, bool &q_d);
 	void SEARCH(RTEMoonSEARCHArray &arr, double dv);
 	bool FINDUX(VECTOR3 X_x, double t_x, double r_r, double u_r, double beta_r, double i_r, double INTER, bool q_a, double mu, VECTOR3 &U_x, VECTOR3 &R_EI, VECTOR3 &V_EI, double &T_EI, double &Incl_apo) const;
-	void INRFV(VECTOR3 R_1, VECTOR3 V_2, double r_2, double mu, bool k3, double &a, double &e, double &p, double &theta, VECTOR3 &V_1, VECTOR3 &R_2, double &dt_2, bool &q_m, bool &k_1, double &beta_1, double &beta_2) const;
+	void INRFV(VECTOR3 R_1, VECTOR3 V_2, double r_2, double mu, bool k3, double &ainv, double &e, double &p, double &theta, VECTOR3 &V_1, VECTOR3 &R_2, double &dt_2, bool &q_m, bool &k_1, double &beta_1, double &beta_2) const;
 	void STORE(int opt, double &dv, double &i_r, double &INTER, double &t_z, bool &q_m);
-	void PSTATE(double a_H, double e_H, double p_H, double t_0, double T_x, VECTOR3 Y_0, VECTOR3 &Y_a_apo, VECTOR3 V_x, double theta, double beta_a, double beta_x, double T_a, VECTOR3 &V_a, double &t_x_aaapo, VECTOR3 &Y_x_apo, double &Dy_0, double &deltat, VECTOR3 &X_mx, VECTOR3 &U_mx) const;
+	void PSTATE(double ainv_H, double e_H, double p_H, double t_0, double T_x, VECTOR3 Y_0, VECTOR3 &Y_a_apo, VECTOR3 V_x, double theta, double beta_a, double beta_x, double T_a, VECTOR3 &V_a, double &t_x_aaapo, VECTOR3 &Y_x_apo, double &Dy_0, double &deltat, VECTOR3 &X_mx, VECTOR3 &U_mx) const;
 
 	int hMoon;
 	double mu_E, mu_M, w_E, R_E, R_M;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_intermediate_library_programs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_intermediate_library_programs.cpp
@@ -678,74 +678,58 @@ void RTCC::PIMCKC(VECTOR3 R, VECTOR3 V, int body, double &a, double &e, double &
 	}
 }
 
-void RTCC::PITFPC(double MU, int K, double AORP, double ECC, double rad, double &TIME, double &P, bool erunits)
+void RTCC::PITFPC(double MU, int K, double AINV, double p, double rad, double &TIME, double &PER, double &e) const
 {
 	//INPUT:
 	//MU: gravitational constant
-	//K: outward leg (0.) and return lef (1.) flag. k is input as a floating point number
-	//AORP: semimajor axis or semilatus rectum (abs(e-1) < 0.00001 is the deciding number)
-	//ECC: eccentricity
+	//K: outward leg (0.) and return lef (1.) flag
+	//AINV: inverse of semimajor axis
+	//p: semi-latus rectum
 	//rad: radial distance from focus
 	//erunits: Input units are Earth radii
 	//OUTPUT:
 	//TIME: Time from periapsis to the desired radial distance
-	//P: Orbital period, only calculared if orbit is eccentric
+	//P: Orbital period, only calculated if orbit is elliptic
+	//e = Eccentricity
 
-	double eps;
+	const double tol = 1e-12;
 
-	if (erunits)
+	//Calculate eccentricity
+	e = sqrt(1.0 - p * AINV);
+	//Set period to zero
+	PER = 0.0;
+
+	if (e > (1.0 + tol))
 	{
-		eps = 1.e-5;
-	}
-	else
-	{
-		eps = 63.78165;
-	}
+		//Hyperbolic
+		double coshE, a, E;
 
-	//Parabolic case
-	if (abs(ECC - 1.0) < 0.00001)
-	{
-		double C3;
-
-		//Calculate characteristic energy
-		C3 = MU * (ECC*ECC - 1.0) / AORP;
-		if (abs(C3) < eps)
-		{
-			//Calculate true anomaly at given distance r
-			double eta_apo = acos(abs(AORP) / rad - 1.0);
-			double TEMP1 = tan(eta_apo / 2.0);
-			//Calculate time
-			TIME = abs(AORP) / 2.0*sqrt(abs(AORP) / MU)*(TEMP1 + 1.0 / 3.0*pow(TEMP1, 3.0));
-
-			if (K != 0)
-			{
-				TIME = -TIME;
-			}
-			return;
-		}
-		else
-		{
-			//Calculate semi major axis, use non parabolic calculations
-			AORP = AORP / (1.0 - ECC * ECC);
-		}
-	}
-
-	double E;
-
-	//Elliptical case
-	if (ECC < 1.0)
-	{
-		E = acos(1.0 / ECC * (1.0 - rad / AORP));
-		P = PI2 * AORP*sqrt(AORP / MU);
-		TIME = AORP * sqrt(AORP / MU)*(E - ECC * sin(E));
-	}
-	//Hyperbolic case
-	else
-	{
-		double coshE;
-		coshE = 1.0 / ECC * (1.0 - rad / AORP);
+		a = 1.0 / AINV;
+		coshE = 1.0 / e * (1.0 - rad * AINV);
 		E = log(coshE + sqrt(coshE*coshE - 1.0));
-		TIME = AORP * sqrt(abs(AORP) / MU)*(E - ECC * (exp(E) - exp(-E)) / 2.0);
+		TIME = a * sqrt(abs(a) / MU)*(E - e * (exp(E) - exp(-E)) / 2.0);
+	}
+	else if (e < (1.0 - tol))
+	{
+		//Elliptical
+		double a, E;
+
+		a = 1.0 / AINV;
+		E = acos(1.0 / e * (1.0 - rad * AINV));
+		PER = PI2 * a * sqrt(a / MU);
+		TIME = a * sqrt(a / MU)*(E - e * sin(E));
+	}
+	else
+	{
+		//Parabolic
+		double eta_apo, TEMP1;
+
+		//Calculate true anomaly at given distance r
+		eta_apo = acos(p / rad - 1.0);
+		//Temporary variable
+		TEMP1 = tan(eta_apo / 2.0);
+		//Time
+		TIME = p / 2.0*sqrt(p / MU)*(TEMP1 + 1.0 / 3.0*pow(TEMP1, 3.0));
 	}
 
 	if (K != 0)


### PR DESCRIPTION
This is a change deep down in the moon-centered RTE logic, removing most code handling near parabolic orbits as a special case. This PR streamlines that logic a lot, only one place has to differentiate between the different orbit types now. As this change is so deep down on the RTE logic this PR could use a bunch of testing, any sort of Abort Scan Table calculations that are in the lunar sphere of influence.

Attached is a scenario 33 seconds before a TEI calculation that fails in the current NASSP build, but is fixed in this PR.

[A10 Pre TEI mcc bug 0002.scn.txt](https://github.com/user-attachments/files/17247734/A10.Pre.TEI.mcc.bug.0002.scn.txt)
