### PR TITLE
Rework spacecraft attitude controls when using keyboard

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/rhc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/rhc.cpp
@@ -62,20 +62,20 @@ void RHC::Timestep(int* rhc_pos, bool normdc, bool normac, bool dirdcab, bool di
 	//Proportional Rate
 	if (normac)
 	{
-		// Proportional rate scales from 1° to 10° deflection.
+		// Proportional rate scales from 1.5° to 10° deflection.
 		for (int i = 0; i < 3; i++)
 		{
 			if (deflection.data[i] >= 0.0)
 			{
-				PropRate.data[i] = min(1.0, max(0.0, (deflection.data[i] - 1.0) / 9.0));
+				PropRate.data[i] = min(1.0, max(0.0, (deflection.data[i] - 1.5) / 8.5));
 			}
 			else
 			{
-				PropRate.data[i] = min(0.0, max(-1.0, (deflection.data[i] + 1.0) / 9.0));
+				PropRate.data[i] = min(0.0, max(-1.0, (deflection.data[i] + 1.5) / 8.5));
 			}
 		}
 
-		//sprintf(oapiDebugString(), "Proportional Rate: X/Y/Z = %f / %f / %f", PropRate.x, PropRate.y, PropRate.z);
+		//sprintf(oapiDebugString(), "Proportional Rate: X/Y/Z = %f / %f / %f | %f° / %f° / %f°", PropRate.x, PropRate.y, PropRate.z, deflection.x, deflection.y, deflection.z);
 	}
 	else
 	{

--- a/Orbitersdk/samples/ProjectApollo/src_csm/rhc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/rhc.cpp
@@ -27,6 +27,7 @@ See http://nassp.sourceforge.net/license/ for more details.
 #include "nasspsound.h"
 #include "toggleswitch.h"
 #include "rhc.h"
+#include <cmath>
 
 RHC::RHC()
 {
@@ -52,16 +53,29 @@ void RHC::Reset()
 void RHC::Timestep(int* rhc_pos, bool normdc, bool normac, bool dirdcab, bool dirdcredun)
 {
 	//Map to -11.5° to 11.5°
-	for (int i = 0;i < 3;i++)
+	for (int i = 0; i < 3; i++)
 	{
-		deflection.data[i] = ((double)(rhc_pos[i] - 32768))*23.0 / 65536.0;
+		deflection.data[i] = ((double)(rhc_pos[i] - 32768)) * 23.0 / 65536.0;
 	}
 
 
 	//Proportional Rate
 	if (normac)
 	{
-		PropRate = deflection / 11.5;
+		// Proportional rate scales from 1° to 10° deflection.
+		for (int i = 0; i < 3; i++)
+		{
+			if (deflection.data[i] >= 0.0)
+			{
+				PropRate.data[i] = min(1.0, max(0.0, (deflection.data[i] - 1.0) / 9.0));
+			}
+			else
+			{
+				PropRate.data[i] = min(0.0, max(-1.0, (deflection.data[i] + 1.0) / 9.0));
+			}
+		}
+
+		//sprintf(oapiDebugString(), "Proportional Rate: X/Y/Z = %f / %f / %f", PropRate.x, PropRate.y, PropRate.z);
 	}
 	else
 	{

--- a/Orbitersdk/samples/ProjectApollo/src_csm/rhc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/rhc.cpp
@@ -78,7 +78,7 @@ void RHC::Timestep(int* rhc_pos, bool normdc, bool normac, bool dirdcab, bool di
 			}
 		}
 
-		sprintf(oapiDebugString(), "Proportional Rate: X/Y/Z = %f / %f / %f | %f° / %f° / %f°", PropRate.x, PropRate.y, PropRate.z, deflection.x, deflection.y, deflection.z);
+		//sprintf(oapiDebugString(), "Proportional Rate: X/Y/Z = %f / %f / %f | %f° / %f° / %f°", PropRate.x, PropRate.y, PropRate.z, deflection.x, deflection.y, deflection.z);
 	}
 	else
 	{

--- a/Orbitersdk/samples/ProjectApollo/src_csm/rhc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/rhc.cpp
@@ -62,23 +62,7 @@ void RHC::Timestep(int* rhc_pos, bool normdc, bool normac, bool dirdcab, bool di
 	//Proportional Rate
 	if (normac)
 	{
-		// Proportional rate scales from 0° to 10° deflection.
-		// The command only activates once we pass the breakout switches at 1.5°,
-		// but this isn't an issue because we also need to overcome the SCS
-		// rate deadband value before any thruster activity will be commanded by the system.
-		for (int i = 0; i < 3; i++)
-		{
-			if (deflection.data[i] >= 0.0)
-			{
-				PropRate.data[i] = min(1.0, max(0.0, (deflection.data[i]) / 10.0));
-			}
-			else
-			{
-				PropRate.data[i] = min(0.0, max(-1.0, (deflection.data[i]) / 10.0));
-			}
-		}
-
-		//sprintf(oapiDebugString(), "Proportional Rate: X/Y/Z = %f / %f / %f | %f° / %f° / %f°", PropRate.x, PropRate.y, PropRate.z, deflection.x, deflection.y, deflection.z);
+		PropRate = deflection / 11.5;
 	}
 	else
 	{

--- a/Orbitersdk/samples/ProjectApollo/src_csm/rhc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/rhc.cpp
@@ -62,20 +62,23 @@ void RHC::Timestep(int* rhc_pos, bool normdc, bool normac, bool dirdcab, bool di
 	//Proportional Rate
 	if (normac)
 	{
-		// Proportional rate scales from 1.5° to 10° deflection.
+		// Proportional rate scales from 0° to 10° deflection.
+		// The command only activates once we pass the breakout switches at 1.5°,
+		// but this isn't an issue because we also need to overcome the SCS
+		// rate deadband value before any thruster activity will be commanded by the system.
 		for (int i = 0; i < 3; i++)
 		{
 			if (deflection.data[i] >= 0.0)
 			{
-				PropRate.data[i] = min(1.0, max(0.0, (deflection.data[i] - 1.5) / 8.5));
+				PropRate.data[i] = min(1.0, max(0.0, (deflection.data[i]) / 10.0));
 			}
 			else
 			{
-				PropRate.data[i] = min(0.0, max(-1.0, (deflection.data[i] + 1.5) / 8.5));
+				PropRate.data[i] = min(0.0, max(-1.0, (deflection.data[i]) / 10.0));
 			}
 		}
 
-		//sprintf(oapiDebugString(), "Proportional Rate: X/Y/Z = %f / %f / %f | %f° / %f° / %f°", PropRate.x, PropRate.y, PropRate.z, deflection.x, deflection.y, deflection.z);
+		sprintf(oapiDebugString(), "Proportional Rate: X/Y/Z = %f / %f / %f | %f° / %f° / %f°", PropRate.x, PropRate.y, PropRate.z, deflection.x, deflection.y, deflection.z);
 	}
 	else
 	{

--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -740,7 +740,7 @@ void Saturn::SystemsInit() {
 	thc_rzx_id = -1; // Disabled
 	thc_pov_id = -1; // Disabled
 	thc_debug = -1;
-	rhc_debug = -1;
+	rhc_debug = 1;
 	rhc_thctoggle = false;
 	rhc_thctoggle_id = -1;
 	rhc_auto = false;
@@ -1997,22 +1997,31 @@ void Saturn::JoystickTimestep()
 		// Use Orbiter's attitude control as RHC
 		} else {
 			// Roll
-			if (GetManualControlLevel(THGROUP_ATT_BANKLEFT) > 0) {
-				rhc_x_pos = (int) ((1. - GetManualControlLevel(THGROUP_ATT_BANKLEFT)) * 32768.);
-			} else if (GetManualControlLevel(THGROUP_ATT_BANKRIGHT) > 0) {
-				rhc_x_pos = (int) (32768. + GetManualControlLevel(THGROUP_ATT_BANKRIGHT) * 32768.);
+			double rollLeft = rhc_keyboard_deflection[THGROUP_ATT_BANKLEFT - THGROUP_ATT_PITCHUP];
+			double rollRight = rhc_keyboard_deflection[THGROUP_ATT_BANKRIGHT - THGROUP_ATT_PITCHUP];
+			if (rollLeft > 0) {
+				rhc_x_pos = (int)((1.0 - rollLeft) * 32768);
+			}
+			else if (rollRight > 0) {
+				rhc_x_pos = (int)(32768 + rollRight * 32768);
 			}
 			// Pitch
-			if (GetManualControlLevel(THGROUP_ATT_PITCHDOWN) > 0) {
-				rhc_y_pos = (int) ((1. - GetManualControlLevel(THGROUP_ATT_PITCHDOWN)) * 32768.);
-			} else if (GetManualControlLevel(THGROUP_ATT_PITCHUP) > 0) {
-				rhc_y_pos = (int) (32768. + GetManualControlLevel(THGROUP_ATT_PITCHUP) * 32768.);
+			double pitchDown = rhc_keyboard_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP];
+			double pitchUp = rhc_keyboard_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP];
+			if (pitchDown > 0) {
+				rhc_y_pos = (int)((1.0 - pitchDown) * 32768);
+			}
+			else if (pitchUp > 0) {
+				rhc_y_pos = (int)(32768 + pitchUp * 32768);
 			}
 			// Yaw
-			if (GetManualControlLevel(THGROUP_ATT_YAWLEFT) > 0) {
-				rhc_rot_pos = (int) ((1. - GetManualControlLevel(THGROUP_ATT_YAWLEFT)) * 32768.);
-			} else if (GetManualControlLevel(THGROUP_ATT_YAWRIGHT) > 0) {
-				rhc_rot_pos = (int) (32768. + GetManualControlLevel(THGROUP_ATT_YAWRIGHT) * 32768.);
+			double yawLeft = rhc_keyboard_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP];
+			double yawRight = rhc_keyboard_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP];
+			if (yawLeft > 0) {
+				rhc_rot_pos = (int)((1.0 - yawLeft) * 32768);
+			}
+			else if (yawRight > 0) {
+				rhc_rot_pos = (int)(32768 + yawRight * 32768);
 			}
 		}
 
@@ -2059,7 +2068,7 @@ void Saturn::JoystickTimestep()
 		if (secs.rcsc.GetCMTransferMotor1() || secs.rcsc.GetCMTransferMotor2()) sm_sep = true;
 
 		if ((rhc_directv1 > SP_MIN_DCVOLTAGE || rhc_directv2 > SP_MIN_DCVOLTAGE)) {
-			if (rhc_x_pos < 2738) {
+			if (rhc1.GetMinusRollHardStopSwitch()) {
 				// MINUS ROLL
 				if (!sm_sep) {						
 					SetRCSState(RCS_SM_QUAD_A, 2, 1);
@@ -2107,7 +2116,7 @@ void Saturn::JoystickTimestep()
 				rjec.SetDirectRollActive(true); 
 				rflag = 1;
 			}
-			if (rhc_x_pos > 62798) {
+			if (rhc1.GetPlusRollHardStopSwitch()) {
 				// PLUS ROLL
 				if (!sm_sep) {
 					SetRCSState(RCS_SM_QUAD_A, 2, 0); 
@@ -2155,7 +2164,7 @@ void Saturn::JoystickTimestep()
 				rjec.SetDirectRollActive(true); 
 				rflag = 1;
 			}
-			if (rhc_y_pos < 2738) {
+			if (rhc1.GetMinusPitchHardStopSwitch()) {
 				// MINUS PITCH
 				if (!sm_sep) {
 					SetRCSState(RCS_SM_QUAD_C, 4, 1);
@@ -2195,7 +2204,7 @@ void Saturn::JoystickTimestep()
 				rjec.SetDirectPitchActive(true); 
 				pflag = 1;
 			}
-			if (rhc_y_pos > 62798) {
+			if (rhc1.GetPlusPitchHardStopSwitch()) {
 				// PLUS PITCH
 				if (!sm_sep) {
 					SetRCSState(RCS_SM_QUAD_C, 4, 0);
@@ -2235,7 +2244,7 @@ void Saturn::JoystickTimestep()
 				rjec.SetDirectPitchActive(true); 
 				pflag = 1;
 			}
-			if (rhc_rot_pos < 2738) {
+			if (rhc1.GetMinusYawHardStopSwitch()) {
 				// MINUS YAW
 				if (!sm_sep) {
 					SetRCSState(RCS_SM_QUAD_B, 4, 1);
@@ -2275,7 +2284,7 @@ void Saturn::JoystickTimestep()
 				rjec.SetDirectYawActive(true);
 				yflag = 1;
 			}
-			if (rhc_rot_pos > 62798) {
+			if (rhc1.GetPlusYawHardStopSwitch()) {
 				// PLUS YAW
 				if (!sm_sep) {
 					SetRCSState(RCS_SM_QUAD_D, 3, 1);
@@ -2364,7 +2373,7 @@ void Saturn::JoystickTimestep()
 		}
 		
 		if (rhc_debug != -1) { 
-			sprintf(oapiDebugString(),"RHC: X/Y/Z = %d / %d / %d | rzx_id %d rot_id %d", rhc_x_pos, rhc_y_pos, rhc_rot_pos, rhc_rzx_id, rhc_rot_id); 
+			sprintf(oapiDebugString(),"RHC: X/Y/Z = %d / %d / %d | rzx_id %d rot_id %d", rhc_x_pos, rhc_y_pos, rhc_rot_pos, rhc_rzx_id, rhc_rot_id);
 		}
 
 		//

--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -740,7 +740,7 @@ void Saturn::SystemsInit() {
 	thc_rzx_id = -1; // Disabled
 	thc_pov_id = -1; // Disabled
 	thc_debug = -1;
-	rhc_debug = 1;
+	rhc_debug = -1;
 	rhc_thctoggle = false;
 	rhc_thctoggle_id = -1;
 	rhc_auto = false;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satsystems.cpp
@@ -2031,10 +2031,8 @@ void Saturn::JoystickTimestep()
 
 		// X and Y are well-duh kinda things. X=0 for full-left, Y = 0 for full-down
 		// Set bits according to joystick state. 32768 is center, so 16384 is the left half.
-		// The real RHC had a 12 degree travel. Our joystick travels 32768 points to full deflection.
-		// This means 2730 points per degree travel. The RHC breakout switches trigger at 1.5 degrees deflection and
-		// stop at 11. So from 36863 to 62798, we trigger plus, and from 28673 to 2738 we trigger minus.
-		// The last degree of travel is reserved for the DIRECT control switches.
+		// The real RHC had a 11.5 degree travel. Our joystick travels 32768 points to full deflection.
+		// The RHC breakout switches trigger at 1.5 degrees deflection and soft stop at 10.
 		if (rhc_voltage1 > SP_MIN_DCVOLTAGE || rhc_voltage2 > SP_MIN_DCVOLTAGE) { // NORMAL
 			// CMC
 			if (rhc1.GetMinusRollBreakoutSwitch()) {

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -1199,6 +1199,11 @@ void Saturn::initSaturn()
 	LastFuelWeight = numeric_limits<double>::infinity(); // Ensure update at first opportunity
 	currentCoG = _V(0, 0, 0);
 
+	// New keyboard control values
+	for (auto i = 0; i < 6; ++i) {
+		rhc_keyboard_deflection[i] = 0.0;
+	}
+
 	// call only once 
 	if (!InitSaturnCalled) {
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3493,21 +3493,27 @@ int Saturn::clbkConsumeDirectKey(char *kstate)
 	// I'm using the Orbiter thruster group enum for this but the attitude thruster group
 	// starts at a non-zero value. So I subtract the first enum from each entry
 	// to get a zero-based index.
-	// The value of 0.9565 represents 95.65 percent deflection of the stick's full range,
-	// or 10.99975 degrees, just shy of the direct coil switch.
-	if (!KEYMOD_CONTROL(kstate) && !KEYMOD_SHIFT(kstate) && GetAttitudeMode() == ATTITUDEMODE::ATTMODE_ROT) {
+	// Only override these keys if the user is holding no modifier keys, Alt only, or Ctrl + Alt.
+	if (GetAttitudeMode() == ATTITUDEMODE::ATTMODE_ROT && !(KEYMOD_CONTROL(kstate) && !KEYMOD_ALT(kstate)) && !KEYMOD_SHIFT(kstate)) {
+		// Possible deflection amounts are:
+		// No key modifiers: 10.5 degrees (max proportional rate, but not hardover)
+		// Alt: 11.5 degrees (full deflection, triggering direct switches)
+		// Ctrl + Alt: 1.6 degrees (triggering breakout switches)
+		double deflectionDegrees = KEYMOD_ALT(kstate) ? KEYMOD_CONTROL(kstate) ? 1.6 : 11.5 : 10.5;
+		double deflectionPercent = deflectionDegrees / 11.5;
+
 		rhc_keyboard_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP] =
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD2) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD2) ? deflectionPercent : 0.0;
 		rhc_keyboard_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP] =
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD8) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD8) ? deflectionPercent : 0.0;
 		rhc_keyboard_deflection[THGROUP_ATT_BANKLEFT - THGROUP_ATT_PITCHUP] =
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD4) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD4) ? deflectionPercent : 0.0;
 		rhc_keyboard_deflection[THGROUP_ATT_BANKRIGHT - THGROUP_ATT_PITCHUP] =
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD6) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD6) ? deflectionPercent : 0.0;
 		rhc_keyboard_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP] =
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD1) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD1) ? deflectionPercent : 0.0;
 		rhc_keyboard_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP] =
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD3) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD3) ? deflectionPercent : 0.0;
 
 		// Prevent Orbiter from acting upon the attitude control keys
 		RESETKEY(kstate, OAPI_KEY_NUMPAD2);
@@ -3527,7 +3533,7 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 
 	if (enableVESIM) vesim.clbkConsumeBufferedKey(key, down, kstate);
 
-	if (KEYMOD_SHIFT(kstate)){
+	if (KEYMOD_SHIFT(kstate) && !KEYMOD_CONTROL(kstate) && !KEYMOD_ALT(kstate)){
 		// Do DSKY stuff
 		DSKYPushSwitch* dskyKeyChanged = nullptr;
 		switch (key) {
@@ -3632,6 +3638,7 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 		}
 		return 0;
 	}
+
 	if (KEYMOD_CONTROL(kstate)) {
 		switch (key) {
 			case OAPI_KEY_D:
@@ -3641,6 +3648,7 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 		}
 		return 0;
 	}
+
 	if (KEYMOD_ALT(kstate))
 	{
 		if (down) {

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3489,6 +3489,35 @@ int Saturn::clbkConsumeDirectKey(char *kstate)
 		}
 	}
 
+	// Override attitude controls, but only if that wouldn't interfere with our DSKY shortcuts.
+	// I'm using the Orbiter thruster group enum for this but the attitude thruster group
+	// starts at a non-zero value. So I subtract the first enum from each entry
+	// to get a zero-based index.
+	// The value of 0.9565 represents 95.65 percent deflection of the stick's full range,
+	// or 10.99975 degrees, just shy of the direct coil switch.
+	if (!KEYMOD_CONTROL(kstate) && !KEYMOD_SHIFT(kstate) && GetAttitudeMode() == ATTITUDEMODE::ATTMODE_ROT) {
+		rhc_keyboard_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP] =
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD2) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+		rhc_keyboard_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP] =
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD8) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+		rhc_keyboard_deflection[THGROUP_ATT_BANKLEFT - THGROUP_ATT_PITCHUP] =
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD4) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+		rhc_keyboard_deflection[THGROUP_ATT_BANKRIGHT - THGROUP_ATT_PITCHUP] =
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD6) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+		rhc_keyboard_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP] =
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD1) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+		rhc_keyboard_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP] =
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD3) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.9565 : 0.0;
+
+		// Prevent Orbiter from acting upon the attitude control keys
+		RESETKEY(kstate, OAPI_KEY_NUMPAD2);
+		RESETKEY(kstate, OAPI_KEY_NUMPAD8);
+		RESETKEY(kstate, OAPI_KEY_NUMPAD4);
+		RESETKEY(kstate, OAPI_KEY_NUMPAD6);
+		RESETKEY(kstate, OAPI_KEY_NUMPAD1);
+		RESETKEY(kstate, OAPI_KEY_NUMPAD3);
+	}
+
 	return 0;
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3496,10 +3496,10 @@ int Saturn::clbkConsumeDirectKey(char *kstate)
 	// Only override these keys if the user is holding no modifier keys, Alt only, or Ctrl + Alt.
 	if (GetAttitudeMode() == ATTITUDEMODE::ATTMODE_ROT && !(KEYMOD_CONTROL(kstate) && !KEYMOD_ALT(kstate)) && !KEYMOD_SHIFT(kstate)) {
 		// Possible deflection amounts are:
-		// No key modifiers: 10.5 degrees (max proportional rate, but not hardover)
-		// Alt: 11.5 degrees (full deflection, triggering direct switches)
-		// Ctrl + Alt: 1.6 degrees (triggering breakout switches)
-		double deflectionDegrees = KEYMOD_ALT(kstate) ? KEYMOD_CONTROL(kstate) ? 1.6 : 11.5 : 10.5;
+		// No key modifiers: 10.5° (max proportional rate, but not hardover)
+		// Alt: 11.5° (full deflection, triggering direct switches)
+		// Ctrl + Alt: 1.51° (triggering breakout switches)
+		double deflectionDegrees = KEYMOD_ALT(kstate) ? KEYMOD_CONTROL(kstate) ? 1.51 : 11.5 : 10.5;
 		double deflectionPercent = deflectionDegrees / 11.5;
 
 		rhc_keyboard_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP] =

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -4356,6 +4356,7 @@ protected:
 	THRUSTER_HANDLE th_att_cm[12], th_att_cm_sys1[6], th_att_cm_sys2[6];    // CM RCS  
 	THRUSTER_HANDLE th_o2_vent;
 	bool th_att_cm_commanded[12];
+	double rhc_keyboard_deflection[6];	// Holds deflection values (0.0 to 1.0) for each Orbiter attitude direction
 
 	PSTREAM_HANDLE dyemarker;
 	PSTREAM_HANDLE wastewaterdump;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/scs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/scs.cpp
@@ -836,7 +836,7 @@ void GDC::Timestep(double simdt) {
 			pitchrate = pitchBmag->GetRates().y*cos(Attitude.x) - yawBmag->GetRates().z*sin(Attitude.x);
 			if (A9K3)
 			{
-				//Assumption: secant amplifier gets saturated at +/-80° yaw
+				//Assumption: secant amplifier gets saturated at +/-80Â° yaw
 				pitchrate *= min(5.75877, max(-5.75877, 1.0 / cos(Attitude.z)));
 			}
 		}
@@ -850,7 +850,7 @@ void GDC::Timestep(double simdt) {
 			//GDC align
 			//Factor 3.33 because:
 			//ASCP output: 19.1V * sin(error)
-			//BMAG output: 0.1V per °/s (so 5.729 V per rad/s)
+			//BMAG output: 0.1V per Â°/s (so 5.729 V per rad/s)
 			//ASCP output basically needs to be convered to an attitude rate in rad/s, so the factor should be 19.1 divided by 5.729
 			//Source: Apollo SCS Detailed Training Program
 			if (E0_503PR)
@@ -1095,7 +1095,7 @@ void GDC::LoadState(FILEHANDLE scn){
 ASCP::ASCP(Sound &clicksound) : ClickSound(clicksound)
 
 {
-	// These are the nominal values for a 72° launch azimuth.
+	// These are the nominal values for a 72Â° launch azimuth.
 	output.x = 162;
 	output.y = 90;
 	output.z = 0;
@@ -2386,7 +2386,7 @@ void EDA::Timestep(double simdt)
 	VECTOR3 bmag1rates = sat->bmag1.GetRates();
 	VECTOR3 bmag2rates = sat->bmag2.GetRates();
 	VECTOR3 imuatt = sat->imu.GetTotalAttitude();
-	VECTOR3 cmcerr = _V(sat->gdc.fdai_err_x, sat->gdc.fdai_err_y, sat->gdc.fdai_err_z) * 5.0 / 0.3 / 384.0*RAD;	//Converted from -384/384 to radians (-16.66°/16.66°)
+	VECTOR3 cmcerr = _V(sat->gdc.fdai_err_x, sat->gdc.fdai_err_y, sat->gdc.fdai_err_z) * 5.0 / 0.3 / 384.0*RAD;	//Converted from -384/384 to radians (-16.66Â°/16.66Â°)
 
 	double rate, err;
 
@@ -2426,11 +2426,11 @@ void EDA::Timestep(double simdt)
 	{
 		//Disable logic
 		rate = (T3QS76 ? 0.0 : bmag1rates.y) + (T3QS64 ? 0.0 : bmag2rates.y);
-		//Scale factor for 1°/s
+		//Scale factor for 1Â°/s
 		rate /= (1.0*RAD);
-		//Scale to 5°/s
+		//Scale to 5Â°/s
 		if (T3QS71) rate /= 5.0;
-		//Scale to 10°/s
+		//Scale to 10Â°/s
 		if (T3QS72) rate /= 2.0;
 		FDAI1AttitudeRate.x = rate;
 	}
@@ -2444,11 +2444,11 @@ void EDA::Timestep(double simdt)
 	{
 		//Disable logic
 		rate = (T3QS77 ? 0.0 : bmag1rates.y) + (T3QS65 ? 0.0 : bmag2rates.y);
-		//Scale factor for 1°/s
+		//Scale factor for 1Â°/s
 		rate /= (1.0*RAD);
-		//Scale to 5°/s
+		//Scale to 5Â°/s
 		if (T3QS71) rate /= 5.0;
-		//Scale to 10°/s
+		//Scale to 10Â°/s
 		if (T3QS72) rate /= 2.0;
 		FDAI2AttitudeRate.x = rate;
 	}
@@ -2478,9 +2478,9 @@ void EDA::Timestep(double simdt)
 	if (E1_307)
 	{
 		err = (T3QS73 ? 0.0 : -sat->gdc.GetPitchBodyError()) + (T3QS55 ? 0.0 : -sat->ascp.GetPitchEulerAttitudeSetError()) + (T3QS59 ? 0.0 : cmcerr.y) + (T3QS57 ? 0.0 : NormalizeAngle(-sat->bmag1.GetAttitudeError().y));
-		//Scale factor for 15°/s
+		//Scale factor for 15Â°/s
 		err /= (15.0*RAD);
-		//Scale to 5°/s
+		//Scale to 5Â°/s
 		if (T3QS67) err *= 3.0;
 		FDAI1AttitudeError.y = 41.0*err;
 	}
@@ -2493,9 +2493,9 @@ void EDA::Timestep(double simdt)
 	if (E2_307)
 	{
 		err = (T3QS74 ? 0.0 : -sat->gdc.GetPitchBodyError()) + (T3QS56 ? 0.0 : -sat->ascp.GetPitchEulerAttitudeSetError()) + (T3QS60 ? 0.0 : cmcerr.y) + (T3QS58 ? 0.0 : NormalizeAngle(-sat->bmag1.GetAttitudeError().y));
-		//Scale factor for 15°/s
+		//Scale factor for 15Â°/s
 		err /= (15.0*RAD);
-		//Scale to 5°/s
+		//Scale to 5Â°/s
 		if (T3QS67) err *= 3.0;
 		FDAI2AttitudeError.y = 41.0*err;
 	}
@@ -2549,11 +2549,11 @@ void EDA::Timestep(double simdt)
 	{
 		//Disable logic
 		rate = (T2QS76 ? 0.0 : -bmag1rates.z) + (T2QS64 ? 0.0 : -bmag2rates.z) + (T2QS68 ? 0.0 : -bmag1rates.x*tan(21.0*RAD)) + (T2QS63 ? 0.0 : -bmag2rates.x*tan(21.0*RAD));
-		//Scale factor for 1°/s
+		//Scale factor for 1Â°/s
 		rate /= (1.0*RAD);
-		//Scale to 5°/s
+		//Scale to 5Â°/s
 		if (T2QS71) rate /= 5.0;
-		//Scale to 10°/s
+		//Scale to 10Â°/s
 		if (T2QS72) rate /= 2.0;
 		FDAI1AttitudeRate.y = rate;
 	}
@@ -2567,11 +2567,11 @@ void EDA::Timestep(double simdt)
 	{
 		//Disable logic
 		rate = (T2QS77 ? 0.0 : -bmag1rates.z) + (T2QS65 ? 0.0 : -bmag2rates.z) + (T2QS69 ? 0.0 : -bmag1rates.x*tan(21.0*RAD)) + (T2QS66 ? 0.0 : -bmag2rates.x*tan(21.0*RAD));
-		//Scale factor for 1°/s
+		//Scale factor for 1Â°/s
 		rate /= (1.0*RAD);
-		//Scale to 5°/s
+		//Scale to 5Â°/s
 		if (T2QS71) rate /= 5.0;
-		//Scale to 10°/s
+		//Scale to 10Â°/s
 		if (T2QS72) rate /= 2.0;
 		FDAI2AttitudeRate.y = rate;
 	}
@@ -2601,9 +2601,9 @@ void EDA::Timestep(double simdt)
 	if (E1_307)
 	{
 		err = (T2QS73 ? 0.0 : sat->gdc.GetYawBodyError()) + (T2QS55 ? 0.0 : sat->ascp.GetYawEulerAttitudeSetError()) + (T2QS59 ? 0.0 : cmcerr.z) + (T2QS57 ? 0.0 : NormalizeAngle(sat->bmag1.GetAttitudeError().z));
-		//Scale factor for 15°/s
+		//Scale factor for 15Â°/s
 		err /= (15.0*RAD);
-		//Scale to 5°/s
+		//Scale to 5Â°/s
 		if (T2QS67) err *= 3.0;
 		//FDAI error is -scaled -41 to 41
 		FDAI1AttitudeError.z = 41.0*err;
@@ -2617,9 +2617,9 @@ void EDA::Timestep(double simdt)
 	if (E2_307)
 	{
 		err = (T2QS74 ? 0.0 : sat->gdc.GetYawBodyError()) + (T2QS56 ? 0.0 : sat->ascp.GetYawEulerAttitudeSetError()) + (T2QS60 ? 0.0 : cmcerr.z) + (T2QS58 ? 0.0 : NormalizeAngle(sat->bmag1.GetAttitudeError().z));
-		//Scale factor for 15°/s
+		//Scale factor for 15Â°/s
 		err /= (15.0*RAD);
-		//Scale to 5°/s
+		//Scale to 5Â°/s
 		if (T2QS67) err *= 3.0;
 		//FDAI error is -scaled -41 to 41
 		FDAI2AttitudeError.z = 41.0*err;
@@ -2674,11 +2674,11 @@ void EDA::Timestep(double simdt)
 	{
 		//Disable logic
 		rate = (T1QS64 ? 0.0 : bmag1rates.x) + (T1QS68 ? 0.0 : bmag2rates.x);
-		//Scale factor for 1°/s
+		//Scale factor for 1Â°/s
 		rate /= (1.0*RAD);
-		//Scale to 5°/s
+		//Scale to 5Â°/s
 		if (T1QS71) rate /= 5.0;
-		//Scale to 50°/s
+		//Scale to 50Â°/s
 		if (T1QS72) rate /= 10.0;
 		FDAI1AttitudeRate.z = rate;
 	}
@@ -2691,11 +2691,11 @@ void EDA::Timestep(double simdt)
 	{
 		//Disable logic
 		rate = (T1QS65 ? 0.0 : bmag1rates.x) + (T1QS63 ? 0.0 : bmag2rates.x);
-		//Scale factor for 1°/s
+		//Scale factor for 1Â°/s
 		rate /= (1.0*RAD);
-		//Scale to 5°/s
+		//Scale to 5Â°/s
 		if (T1QS71) rate /= 5.0;
-		//Scale to 50°/s
+		//Scale to 50Â°/s
 		if (T1QS72) rate /= 10.0;
 		FDAI2AttitudeRate.z = rate;
 	}
@@ -2724,11 +2724,11 @@ void EDA::Timestep(double simdt)
 	if (E1_307)
 	{
 		err = (T1QS55 ? 0.0 : ((T1QS73 ? 0.0 : sat->gdc.GetRollBodyMinusEulerError()) + sat->ascp.GetRollEulerAttitudeSetError())) + (T1QS59 ? 0.0 : cmcerr.x) + (T1QS57 ? 0.0 : NormalizeAngle(sat->bmag1.GetAttitudeError().x));
-		//Scale factor for 50°/s
+		//Scale factor for 50Â°/s
 		err /= (50.0*RAD);
-		//Scale to 5.0°/s
+		//Scale to 5.0Â°/s
 		if (T1QS67) err *= 10.0;
-		//Scale to 12.5°/s (for CDU)
+		//Scale to 12.5Â°/s (for CDU)
 		if (!T1QS75) err *= 4.0;
 		//error is -scaled -41 to 41
 		FDAI1AttitudeError.x = 41.0*err;
@@ -2742,11 +2742,11 @@ void EDA::Timestep(double simdt)
 	if (E2_307)
 	{
 		err = (T1QS56 ? 0.0 : ((T1QS73 ? 0.0 : sat->gdc.GetRollBodyMinusEulerError()) + sat->ascp.GetRollEulerAttitudeSetError())) + (T1QS60 ? 0.0 : cmcerr.x) + (T1QS58 ? 0.0 : NormalizeAngle(sat->bmag1.GetAttitudeError().x));
-		//Scale factor for 50°/s
+		//Scale factor for 50Â°/s
 		err /= (50.0*RAD);
-		//Scale to 5.0°/s
+		//Scale to 5.0Â°/s
 		if (T1QS67) err *= 10.0;
-		//Scale to 12.5°/s (for CDU)
+		//Scale to 12.5Â°/s (for CDU)
 		if (!T1QS76) err *= 4.0;
 		//FDAI error is -scaled -41 to 41
 		FDAI2AttitudeError.x = 41.0*err;
@@ -4044,7 +4044,7 @@ void ECA::TimeStep(double simdt) {
 
 		//Roll to yaw cross coupling
 		if (T1QS26)
-			rate_damp.z += -rate_damp.x * 0.38386; //tan(21.0°)
+			rate_damp.z += -rate_damp.x * 0.38386; //tan(21.0Â°)
 
 		// PSEUDORATE FEEDBACK
 		if (E1_506 && !T1QS44 && sat->ManualAttRollSwitch.GetState() == THREEPOSSWITCH_CENTER){
@@ -4106,9 +4106,9 @@ void ECA::TimeStep(double simdt) {
 		rate_err.y = cmd_rate.y - (rate_damp.y + pseudorate.y);
 		rate_err.z = cmd_rate.z - (rate_damp.z + pseudorate.z);
 		
-		 sprintf(oapiDebugString(),"SCS: RATE CMD r%.3f p%.3f y%.3f ERR r%.3f p%.3f y%.3f",
-			cmd_rate.x * DEG, cmd_rate.y * DEG, cmd_rate.z * DEG, 
-			rate_err.x * DEG, rate_err.y * DEG, rate_err.z * DEG);
+		//sprintf(oapiDebugString(),"SCS: RATE CMD r%.3f p%.3f y%.3f ERR r%.3f p%.3f y%.3f",
+		//	cmd_rate.x * DEG, cmd_rate.y * DEG, cmd_rate.z * DEG, 
+		//	rate_err.x * DEG, rate_err.y * DEG, rate_err.z * DEG);
 		// sprintf(oapiDebugString(),"SCS PITCH err %.4f rate %.3f cmd %.3f pseudo %.3f rate error %.3f", errors.y*DEG, pitchrate * DEG, cmd_rate.y * DEG, pseudorate.y * DEG, rate_err.y * DEG);
 		// sprintf(oapiDebugString(),"SCS ROLL rate %.3f cmd %.3f pseudo %.3f rate_err %.3f errors %.3f", rollrate * DEG, cmd_rate.x * DEG, pseudorate.x * DEG, rate_err.x * DEG, errors.x * DEG);
 		// sprintf(oapiDebugString(),"SCS YAW rate %.3f cmd %.3f pseudo %.3f rate_err %.3f errors %.3f", yawrate * DEG, cmd_rate.z * DEG, pseudorate.z * DEG, rate_err.z * DEG, errors.z * DEG);
@@ -4332,7 +4332,7 @@ void ECA::TimeStep(double simdt) {
 		YawAutoTVCIntegrator.Reset();
 	}
 
-	//sprintf(oapiDebugString(), "MTVC Pitch: S18_2 %d thc_cw %d T3QS1 %d E2_507 %d E1_509 %d E2_509 %d RHC1 %f Rate: %f Pos: %f°", S18_2, thc_cw, T3QS1, E2_507, E1_509, E2_509, sat->rhc1.GetPitchPropRate(), rhc_rate.y, pitchMTVCPosition*DEG);
+	//sprintf(oapiDebugString(), "MTVC Pitch: S18_2 %d thc_cw %d T3QS1 %d E2_507 %d E1_509 %d E2_509 %d RHC1 %f Rate: %f Pos: %fÂ°", S18_2, thc_cw, T3QS1, E2_507, E1_509, E2_509, sat->rhc1.GetPitchPropRate(), rhc_rate.y, pitchMTVCPosition*DEG);
 
 	// If accel thrust fired and is no longer needed, kill it.
 	if(accel_roll_flag == 0 && accel_roll_trigger){

--- a/Orbitersdk/samples/ProjectApollo/src_csm/scs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/scs.cpp
@@ -3941,7 +3941,7 @@ void ECA::TimeStep(double simdt) {
 		else
 			cmd_rate.z = errors.z;
 		
-		//Attitude error gain (TODO: Is this actually rate error gain? It's driven by the RATE switch.)
+		// Attitude error gain
 		if (R1K25)
 			cmd_rate.x *= 0.5;
 		else

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -832,18 +832,20 @@ int LEM::clbkConsumeDirectKey(char* kstate)
 	// I'm using the Orbiter thruster group enum for this but the attitude thruster group
 	// starts at a non-zero value. So I subtract the first enum from each entry
 	// to get a zero-based index.
-		aca_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP] = 
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD2) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
-		aca_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP] =
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD8) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
-		aca_deflection[THGROUP_ATT_BANKLEFT - THGROUP_ATT_PITCHUP] = 
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD4) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
-		aca_deflection[THGROUP_ATT_BANKRIGHT - THGROUP_ATT_PITCHUP] = 
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD6) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
-		aca_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP] = 
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD1) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
-		aca_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP] =
-			KEYDOWN(kstate, OAPI_KEY_NUMPAD3) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
+	// The value of 0.923 represents 92.3 percent deflection of the stick's full range,
+	// or 11.999 degrees, just shy of the hardover deflection switch.
+	aca_keyboard_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP] = 
+		KEYDOWN(kstate, OAPI_KEY_NUMPAD2) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
+	aca_keyboard_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP] =
+		KEYDOWN(kstate, OAPI_KEY_NUMPAD8) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
+	aca_keyboard_deflection[THGROUP_ATT_BANKLEFT - THGROUP_ATT_PITCHUP] = 
+		KEYDOWN(kstate, OAPI_KEY_NUMPAD4) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
+	aca_keyboard_deflection[THGROUP_ATT_BANKRIGHT - THGROUP_ATT_PITCHUP] = 
+		KEYDOWN(kstate, OAPI_KEY_NUMPAD6) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
+	aca_keyboard_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP] = 
+		KEYDOWN(kstate, OAPI_KEY_NUMPAD1) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
+	aca_keyboard_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP] =
+		KEYDOWN(kstate, OAPI_KEY_NUMPAD3) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
 
 	// Prevent Orbiter from acting upon the attitude control keys.
 	RESETKEY(kstate, OAPI_KEY_NUMPAD2);

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -834,7 +834,7 @@ int LEM::clbkConsumeDirectKey(char* kstate)
 	// to get a zero-based index.
 	// The value of 0.923 represents 92.3 percent deflection of the stick's full range,
 	// or 11.999 degrees, just shy of the hardover deflection switch.
-	if (!KEYMOD_CONTROL(kstate) && !KEYMOD_SHIFT(kstate)) {
+	if (!KEYMOD_CONTROL(kstate) && !KEYMOD_SHIFT(kstate) && GetAttitudeMode() == ATTITUDEMODE::ATTMODE_ROT) {
 		aca_keyboard_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP] = 
 			KEYDOWN(kstate, OAPI_KEY_NUMPAD2) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
 		aca_keyboard_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP] =

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -835,9 +835,9 @@ int LEM::clbkConsumeDirectKey(char* kstate)
 	// Only override these keys if the user is holding no modifier keys, Alt only, or Ctrl + Alt.
 	if (GetAttitudeMode() == ATTITUDEMODE::ATTMODE_ROT && !(KEYMOD_CONTROL(kstate) && !KEYMOD_ALT(kstate)) && !KEYMOD_SHIFT(kstate)) {
 		// Possible deflection amounts are:
-		// No key modifiers: 11.5 degrees (max proportional rate, but not hardover)
-		// Alt: 13 degrees (full deflection, triggering hardover switches)
-		// Ctrl + Alt: 0.75 degrees (triggering out-of-detent switches, but not commanding thrust)
+		// No key modifiers: 11.5° (max proportional rate, but not hardover)
+		// Alt: 13° (full deflection, triggering hardover switches)
+		// Ctrl + Alt: 0.75° (triggering out-of-detent switches, but not commanding thrust)
 		double deflectionDegrees = KEYMOD_ALT(kstate) ? KEYMOD_CONTROL(kstate) ? 0.75 : 13.0 : 11.5;
 		double deflectionPercent = deflectionDegrees / 13.0;
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -828,12 +828,35 @@ int LEM::clbkConsumeDirectKey(char* kstate)
 		}
 	}
 
+	// Override attitude controls
+	// I'm using the Orbiter thruster group enum for this but the attitude thruster group
+	// starts at a non-zero value. So I subtract the first enum from each entry
+	// to get a zero-based index.
+		aca_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP] = 
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD2) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
+		aca_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP] =
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD8) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
+		aca_deflection[THGROUP_ATT_BANKLEFT - THGROUP_ATT_PITCHUP] = 
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD4) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
+		aca_deflection[THGROUP_ATT_BANKRIGHT - THGROUP_ATT_PITCHUP] = 
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD6) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
+		aca_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP] = 
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD1) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
+		aca_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP] =
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD3) ? (KEYMOD_CONTROL(kstate)) ? 1.0 : 0.923 : 0.0;
+
+	// Prevent Orbiter from acting upon the attitude control keys.
+	RESETKEY(kstate, OAPI_KEY_NUMPAD2);
+	RESETKEY(kstate, OAPI_KEY_NUMPAD8);
+	RESETKEY(kstate, OAPI_KEY_NUMPAD4);
+	RESETKEY(kstate, OAPI_KEY_NUMPAD6);
+	RESETKEY(kstate, OAPI_KEY_NUMPAD1);
+	RESETKEY(kstate, OAPI_KEY_NUMPAD3);
+
 	return 0;
 }
 
 int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
-
-	// rewrote to get key events rather than monitor key state - LazyD
 
 	if (enableVESIM) vesim.clbkConsumeBufferedKey(key, down, keystate);
 
@@ -907,13 +930,6 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 			if (dskyKeyChanged != nullptr) {
 				dskyKeyChanged->SetHeld(true);
 				dskyKeyChanged->SetState(PUSHBUTTON_PUSHED);
-			}
-
-			switch (key) {
-			case OAPI_KEY_K:
-				//kill rotation
-				SetAngularVel(_V(0, 0, 0));
-				break;
 			}
 		} else {
 			// KEY UP

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -828,32 +828,34 @@ int LEM::clbkConsumeDirectKey(char* kstate)
 		}
 	}
 
-	// Override attitude controls
+	// Override attitude controls, but only if that wouldn't interfere with our DSKY/DEDA shortcuts.
 	// I'm using the Orbiter thruster group enum for this but the attitude thruster group
 	// starts at a non-zero value. So I subtract the first enum from each entry
 	// to get a zero-based index.
 	// The value of 0.923 represents 92.3 percent deflection of the stick's full range,
 	// or 11.999 degrees, just shy of the hardover deflection switch.
-	aca_keyboard_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP] = 
-		KEYDOWN(kstate, OAPI_KEY_NUMPAD2) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
-	aca_keyboard_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP] =
-		KEYDOWN(kstate, OAPI_KEY_NUMPAD8) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
-	aca_keyboard_deflection[THGROUP_ATT_BANKLEFT - THGROUP_ATT_PITCHUP] = 
-		KEYDOWN(kstate, OAPI_KEY_NUMPAD4) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
-	aca_keyboard_deflection[THGROUP_ATT_BANKRIGHT - THGROUP_ATT_PITCHUP] = 
-		KEYDOWN(kstate, OAPI_KEY_NUMPAD6) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
-	aca_keyboard_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP] = 
-		KEYDOWN(kstate, OAPI_KEY_NUMPAD1) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
-	aca_keyboard_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP] =
-		KEYDOWN(kstate, OAPI_KEY_NUMPAD3) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
+	if (!KEYMOD_CONTROL(kstate) && !KEYMOD_SHIFT(kstate)) {
+		aca_keyboard_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP] = 
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD2) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
+		aca_keyboard_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP] =
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD8) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
+		aca_keyboard_deflection[THGROUP_ATT_BANKLEFT - THGROUP_ATT_PITCHUP] = 
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD4) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
+		aca_keyboard_deflection[THGROUP_ATT_BANKRIGHT - THGROUP_ATT_PITCHUP] = 
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD6) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
+		aca_keyboard_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP] = 
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD1) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
+		aca_keyboard_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP] =
+			KEYDOWN(kstate, OAPI_KEY_NUMPAD3) ? (KEYMOD_ALT(kstate)) ? 1.0 : 0.923 : 0.0;
 
-	// Prevent Orbiter from acting upon the attitude control keys.
-	RESETKEY(kstate, OAPI_KEY_NUMPAD2);
-	RESETKEY(kstate, OAPI_KEY_NUMPAD8);
-	RESETKEY(kstate, OAPI_KEY_NUMPAD4);
-	RESETKEY(kstate, OAPI_KEY_NUMPAD6);
-	RESETKEY(kstate, OAPI_KEY_NUMPAD1);
-	RESETKEY(kstate, OAPI_KEY_NUMPAD3);
+		// Prevent Orbiter from acting upon the attitude control keys
+		RESETKEY(kstate, OAPI_KEY_NUMPAD2);
+		RESETKEY(kstate, OAPI_KEY_NUMPAD8);
+		RESETKEY(kstate, OAPI_KEY_NUMPAD4);
+		RESETKEY(kstate, OAPI_KEY_NUMPAD6);
+		RESETKEY(kstate, OAPI_KEY_NUMPAD1);
+		RESETKEY(kstate, OAPI_KEY_NUMPAD3);
+	}
 
 	return 0;
 }

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -676,6 +676,11 @@ void LEM::Init()
 	RegisterConnector(VIRTUAL_CONNECTOR_PORT, &lm_rr_to_csm_connector);
 	RegisterConnector(VIRTUAL_CONNECTOR_PORT, &lm_vhf_to_csm_csm_connector);
 
+	// New keyboard control values
+	for (auto i = 0; i < 6; ++i) {
+		aca_keyboard_deflection[i] = 0.0;
+	}
+
 	// Do this stuff only once
 	if(!InitLEMCalled){
 		SystemsInit();

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -621,7 +621,7 @@ public:
 	PROPELLANT_HANDLE ph_RCSA,ph_RCSB;   // RCS Fuel A and B, replaces ph_rcslm0
 	PROPELLANT_HANDLE ph_Dsc, ph_Asc; // handles for propellant resources
 	THRUSTER_HANDLE th_hover[1];               // handles for orbiter main engines
-	double aca_deflection[6];		// Deflection values (0 to 1) for the six directions the ACA can move.
+	double aca_keyboard_deflection[6];		// Deflection values (0 to 1) for the six directions the ACA can move.
 	// There are 16 RCS. 4 clusters, 4 per cluster.
 	THRUSTER_HANDLE th_rcs[16];
 	THGROUP_HANDLE thg_hover;		          // handles for thruster groups

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -621,6 +621,7 @@ public:
 	PROPELLANT_HANDLE ph_RCSA,ph_RCSB;   // RCS Fuel A and B, replaces ph_rcslm0
 	PROPELLANT_HANDLE ph_Dsc, ph_Asc; // handles for propellant resources
 	THRUSTER_HANDLE th_hover[1];               // handles for orbiter main engines
+	double aca_deflection[6];		// Deflection values (0 to 1) for the six directions the ACA can move.
 	// There are 16 RCS. 4 clusters, 4 per cluster.
 	THRUSTER_HANDLE th_rcs[16];
 	THGROUP_HANDLE thg_hover;		          // handles for thruster groups

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -988,8 +988,8 @@ void LEM::JoystickTimestep(double simdt)
 			// No JS
 
 			// Roll
-			double rollLeft = aca_deflection[THGROUP_ATT_BANKLEFT - THGROUP_ATT_PITCHUP];
-			double rollRight = aca_deflection[THGROUP_ATT_BANKRIGHT - THGROUP_ATT_PITCHUP];
+			double rollLeft = aca_keyboard_deflection[THGROUP_ATT_BANKLEFT - THGROUP_ATT_PITCHUP];
+			double rollRight = aca_keyboard_deflection[THGROUP_ATT_BANKRIGHT - THGROUP_ATT_PITCHUP];
 			if (rollLeft > 0) {
 				rhc_pos[0] = (int)(32768 - rollLeft * 32768);
 			}
@@ -997,8 +997,8 @@ void LEM::JoystickTimestep(double simdt)
 				rhc_pos[0] = (int)(32768 + rollRight * 32768);
 			}
 			// Pitch
-			double pitchDown = aca_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP];
-			double pitchUp = aca_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP];
+			double pitchDown = aca_keyboard_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP];
+			double pitchUp = aca_keyboard_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP];
 			if (pitchDown > 0) {
 				rhc_pos[1] = (int)(32768 - pitchDown * 32768);
 			}
@@ -1006,8 +1006,8 @@ void LEM::JoystickTimestep(double simdt)
 				rhc_pos[1] = (int)(32768 + pitchUp * 32768);
 			}
 			// Yaw
-			double yawLeft = aca_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP];
-			double yawRight = aca_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP];
+			double yawLeft = aca_keyboard_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP];
+			double yawRight = aca_keyboard_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP];
 			if (yawLeft > 0) {
 				rhc_pos[2] = (int)(32768 + yawLeft * 32768);
 			}

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -1009,10 +1009,10 @@ void LEM::JoystickTimestep(double simdt)
 			double yawLeft = aca_keyboard_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP];
 			double yawRight = aca_keyboard_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP];
 			if (yawLeft > 0) {
-				rhc_pos[2] = (int)(32768 + yawLeft * 32768);
+				rhc_pos[2] = (int)(32768 - yawLeft * 32768);
 			}
 			else if (yawRight > 0) {
-				rhc_pos[2] = (int)(32768 - yawRight * 32768);
+				rhc_pos[2] = (int)(32768 + yawRight * 32768);
 			}
 		}
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -832,7 +832,7 @@ void LEM::SystemsInit()
 	thc_rzx_id = -1; // Disabled
 	thc_tjt_id = -1; // Disabled
 	thc_debug = -1;
-	rhc_debug = 1;
+	rhc_debug = -1;
 	rhc_thctoggle = false;
 	rhc_thctoggle_id = -1;
 	rhc_thctoggle_pressed = false;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -832,7 +832,7 @@ void LEM::SystemsInit()
 	thc_rzx_id = -1; // Disabled
 	thc_tjt_id = -1; // Disabled
 	thc_debug = -1;
-	rhc_debug = -1;
+	rhc_debug = 1;
 	rhc_thctoggle = false;
 	rhc_thctoggle_id = -1;
 	rhc_thctoggle_pressed = false;
@@ -988,25 +988,31 @@ void LEM::JoystickTimestep(double simdt)
 			// No JS
 
 			// Roll
-			if (GetManualControlLevel(THGROUP_ATT_BANKLEFT) > 0) {
-				rhc_pos[0] = (int)(32768 - GetManualControlLevel(THGROUP_ATT_BANKLEFT) * 32768);
+			double rollLeft = aca_deflection[THGROUP_ATT_BANKLEFT - THGROUP_ATT_PITCHUP];
+			double rollRight = aca_deflection[THGROUP_ATT_BANKRIGHT - THGROUP_ATT_PITCHUP];
+			if (rollLeft > 0) {
+				rhc_pos[0] = (int)(32768 - rollLeft * 32768);
 			}
-			else if (GetManualControlLevel(THGROUP_ATT_BANKRIGHT) > 0) {
-				rhc_pos[0] = (int)(32768 + GetManualControlLevel(THGROUP_ATT_BANKRIGHT) * 32768);
+			else if (rollRight > 0) {
+				rhc_pos[0] = (int)(32768 + rollRight * 32768);
 			}
 			// Pitch
-			if (GetManualControlLevel(THGROUP_ATT_PITCHDOWN) > 0) {
-				rhc_pos[1] = (int)(32768 - GetManualControlLevel(THGROUP_ATT_PITCHDOWN) * 32768);
+			double pitchDown = aca_deflection[THGROUP_ATT_PITCHDOWN - THGROUP_ATT_PITCHUP];
+			double pitchUp = aca_deflection[THGROUP_ATT_PITCHUP - THGROUP_ATT_PITCHUP];
+			if (pitchDown > 0) {
+				rhc_pos[1] = (int)(32768 - pitchDown * 32768);
 			}
-			else if (GetManualControlLevel(THGROUP_ATT_PITCHUP) > 0) {
-				rhc_pos[1] = (int)(32768 + GetManualControlLevel(THGROUP_ATT_PITCHUP) * 32768);
+			else if (pitchUp > 0) {
+				rhc_pos[1] = (int)(32768 + pitchUp * 32768);
 			}
 			// Yaw
-			if (GetManualControlLevel(THGROUP_ATT_YAWLEFT) > 0) {
-				rhc_pos[2] = (int)(32768 + GetManualControlLevel(THGROUP_ATT_YAWLEFT) * 32768);
+			double yawLeft = aca_deflection[THGROUP_ATT_YAWLEFT - THGROUP_ATT_PITCHUP];
+			double yawRight = aca_deflection[THGROUP_ATT_YAWRIGHT - THGROUP_ATT_PITCHUP];
+			if (yawLeft > 0) {
+				rhc_pos[2] = (int)(32768 + yawLeft * 32768);
 			}
-			else if (GetManualControlLevel(THGROUP_ATT_YAWRIGHT) > 0) {
-				rhc_pos[2] = (int)(32768 - GetManualControlLevel(THGROUP_ATT_YAWRIGHT) * 32768);
+			else if (yawRight > 0) {
+				rhc_pos[2] = (int)(32768 - yawRight * 32768);
 			}
 		}
 


### PR DESCRIPTION
As the title says, this overrides Orbiter's default attitude control handling to implement multiple different attitude/rotation controller deflection values, and changes the default deflection to be just shy of each vehicle's respective trigger point for direct thruster fire, but still commanding maximum proportional rate where applicable.

To get full deflection of the attitude controller and command direct/hardover RCS firing in the CSM/LM respectively, hold the left or right Alt key while commanding rotation. To move the ACA out of detent in the LM without commanding RCS thrust, hold Ctrl and Alt while commanding rotation.

This allows for more intuitive and nuanced control when using the keyboard, and significantly reduces unintentional thruster fire and wasted fuel, which would always occur previously because Orbiter's default behavior commands 100% stick deflection from keyboard inputs. Therefore, procedures which enable the direct RCS/hardover switches can now be followed safely by keyboard users without the side effects of reduced control fidelity and excess fuel usage, or turning off said switches to work around the issue.

Furthermore, this PR fixes an error that was discovered in the CSM RHC simulation: The direct RCS switches were implemented, but their state was not being checked by the appropriate RCS code, which was instead directly checking the input deflection value for an incorrect deflection threshold of 10.5° instead of 11°.

This PR primarily affects the keyboard control method. However, VESIM and Joystick controls will be affected by the change to the CSM RHC proportional rate scaling.

Some related info: the direct coil trigger point is 11° deflection out of a maximum 11.5° in the CSM, and 12° deflection out of a maximum 13° in the LM, per each vehicle's AOH Volume 1.