### PR TITLE
Change slewed gauge display to low-pass filtered gauge display.

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
@@ -3816,15 +3816,11 @@ double MeterSwitch::GetDisplayValue() {
 	} else {
 		double dt = oapiGetSimTime() - lastDrawTime; // oapiGetSimTime() - lastDrawTime;
 		if (dt > 0.0) {
-			if (fabs(value - displayValue) / dt > (maxValue - minValue) / minMaxTime) {
-				// discrete time LPF where y[n] = y[n-1]*(1-a) + x[n]*a
-				// assumed that 5tau is minMaxTime, i.e. time to reach 99.3% of a step input.
-				// therefore 1/tau is (5/minMaxTime) for each slice {dt}.
-				double filtConstant = max(min(GAUGE_LPF_SCALAR * dt * 5.0/minMaxTime, 1.0),0.0);
-				displayValue = displayValue*(1.0-filtConstant) + (value*filtConstant);
-			} else {
-				displayValue = value;
-			}
+			// discrete time LPF where y[n] = y[n-1]*(1-a) + x[n]*a
+			// assumed that 5tau is minMaxTime, i.e. time to reach 99.3% of a step input.
+			// therefore 1/tau is (5/minMaxTime) for each slice {dt}.
+			double filtConstant = max(min(GAUGE_LPF_SCALAR * dt * 5.0 / minMaxTime, 1.0), 0.0);
+			displayValue = displayValue * (1.0 - filtConstant) + (value * filtConstant);
 		}
 	}
 	lastDrawTime = oapiGetSimTime(); // oapiGetSimTime();

--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.cpp
@@ -3815,13 +3815,13 @@ double MeterSwitch::GetDisplayValue() {
 		displayValue = value;
 	} else {
 		double dt = oapiGetSimTime() - lastDrawTime; // oapiGetSimTime() - lastDrawTime;
-		if (dt > 0) {
+		if (dt > 0.0) {
 			if (fabs(value - displayValue) / dt > (maxValue - minValue) / minMaxTime) {
 				// discrete time LPF where y[n] = y[n-1]*(1-a) + x[n]*a
 				// assumed that 5tau is minMaxTime, i.e. time to reach 99.3% of a step input.
 				// therefore 1/tau is (5/minMaxTime) for each slice {dt}.
 				double filtConstant = max(min(GAUGE_LPF_SCALAR * dt * 5.0/minMaxTime, 1.0),0.0);
-				displayValue = displayValue*(1-filtConstant) + (value*filtConstant);
+				displayValue = displayValue*(1.0-filtConstant) + (value*filtConstant);
 			} else {
 				displayValue = value;
 			}

--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.h
@@ -74,6 +74,9 @@
 #define TIME_UPDATE_MINUTES 1
 #define TIME_UPDATE_HOURS	2
 
+// Lowpass filter for gauges assumes 5tau ~~ minMaxTime.  All 5tau components can be globally scaled by GAUGE_LPF_SCALAR if relationship does not hold well. (higher->faster)
+#define GAUGE_LPF_SCALAR 1.0
+
 class SwitchRow;
 class PanelSwitchScenarioHandler;
 class PanelSwitchCallbackInterface;

--- a/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/toggleswitch.h
@@ -75,7 +75,7 @@
 #define TIME_UPDATE_HOURS	2
 
 // Lowpass filter for gauges assumes 5tau ~~ minMaxTime.  All 5tau components can be globally scaled by GAUGE_LPF_SCALAR if relationship does not hold well. (higher->faster)
-#define GAUGE_LPF_SCALAR 1.0
+#define GAUGE_LPF_SCALAR 1.5
 
 class SwitchRow;
 class PanelSwitchScenarioHandler;


### PR DESCRIPTION
Filter time constants are derived based on the already assigned {minMaxTime} of a gauge object, where it is assumed that 5*tau ~ minMaxTime. The time constant, tau, is derived as such, for a discrete-time first-order LPF:

    y[n] = y[n-1]*(1-a) + x[n]*a
        where y[n] is the new output, y[n-1] the current output, and x[n] the current input
    a = {GAUGE_LPF_SCALAR * dt * 5.0/minMaxTime}, clamped to range of [0,1]

There is no divide-by-zero protection for the {minMaxTime} element, however, there was none before.

Should all gauges seem too sluggish/fast, there is a global scalar which can be applied to the response rate of every filter.
def {GAUGE_LPF_SCALAR} in {toggleswitch.h}. A higher value will yield a faster response.
