### PR TITLE
Fix SM entry breakup SFX playing globally

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/sm.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/sm.cpp
@@ -804,7 +804,7 @@ void SM::clbkPostCreation()
 
 {
 	soundlib.InitSoundLib(this, SOUND_DIRECTORY);
-	soundlib.LoadSound(BreakS, CRASH_SOUND);
+	soundlib.LoadSound(BreakS, CRASH_SOUND, BOTHVIEW_FADED_CLOSE);
 }
 
 void SM::clbkSaveState (FILEHANDLE scn)


### PR DESCRIPTION
This will stop the "crash" sounds playing during reentry.