### PR TITLE
Move more MCC only functions from the RTCC class to the MCC_Calculations class

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Calculations.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Calculations.cpp
@@ -119,3 +119,286 @@ bool MCC_Calculations::LongitudeCrossing(EphemerisDataTable2 &ephem, double lng,
 
 	return (dErr < 0.0);
 }
+
+bool MCC_Calculations::GETEval(double get)
+{
+	if (OrbMech::GETfromMJD(oapiGetSimMJD(), pRTCC->CalcGETBase()) > get)
+	{
+		return true;
+	}
+
+	return false;
+}
+
+double MCC_Calculations::FindOrbitalSunrise(SV sv, double t_sunrise_guess)
+{
+	SV sv1;
+	double GET_SV, dt, ttoSunrise;
+
+	OBJHANDLE hSun = oapiGetObjectByName("Sun");
+
+	GET_SV = OrbMech::GETfromMJD(sv.MJD, pRTCC->CalcGETBase());
+	dt = t_sunrise_guess - GET_SV;
+
+	sv1 = pRTCC->coast(sv, dt);
+
+	ttoSunrise = OrbMech::sunrise(pRTCC->SystemParameters.MAT_J2000_BRCS, sv1.R, sv1.V, sv1.MJD, sv1.gravref, hSun, true, false, false);
+	return t_sunrise_guess + ttoSunrise;
+}
+
+double MCC_Calculations::FindOrbitalMidnight(SV sv, double t_TPI_guess)
+{
+	SV sv1;
+	double GET_SV, dt, ttoMidnight;
+
+	OBJHANDLE hSun = oapiGetObjectByName("Sun");
+
+	GET_SV = OrbMech::GETfromMJD(sv.MJD, pRTCC->CalcGETBase());
+	dt = t_TPI_guess - GET_SV;
+
+	sv1 = pRTCC->coast(sv, dt);
+
+	ttoMidnight = OrbMech::sunrise(pRTCC->SystemParameters.MAT_J2000_BRCS, sv1.R, sv1.V, sv1.MJD, sv1.gravref, hSun, 1, 1, false);
+	return t_TPI_guess + ttoMidnight;
+}
+
+void MCC_Calculations::FindRadarAOSLOS(SV sv, double lat, double lng, double &GET_AOS, double &GET_LOS)
+{
+	VECTOR3 R_P;
+	double LmkRange, dt1, dt2;
+
+	R_P = unit(_V(cos(lng)*cos(lat), sin(lng)*cos(lat), sin(lat)))*oapiGetSize(sv.gravref);
+
+	dt1 = OrbMech::findelev_gs(pRTCC->SystemParameters.AGCEpoch, pRTCC->SystemParameters.MAT_J2000_BRCS, sv.R, sv.V, R_P, sv.MJD, 175.0*RAD, sv.gravref, LmkRange);
+	dt2 = OrbMech::findelev_gs(pRTCC->SystemParameters.AGCEpoch, pRTCC->SystemParameters.MAT_J2000_BRCS, sv.R, sv.V, R_P, sv.MJD, 5.0*RAD, sv.gravref, LmkRange);
+
+	GET_AOS = OrbMech::GETfromMJD(sv.MJD, pRTCC->CalcGETBase()) + dt1;
+	GET_LOS = OrbMech::GETfromMJD(sv.MJD, pRTCC->CalcGETBase()) + dt2;
+}
+
+int MCC_Calculations::SPSRCSDecision(double a, VECTOR3 dV_LVLH)
+{
+	double t;
+
+	t = length(dV_LVLH) / a;
+
+	if (t > 0.5)
+	{
+		return RTCC_ENGINETYPE_CSMSPS;
+	}
+	else
+	{
+		return RTCC_ENGINETYPE_CSMRCSPLUS4;
+	}
+}
+
+bool MCC_Calculations::REFSMMATDecision(VECTOR3 Att)
+{
+	if (cos(Att.z) > 0.5) //Yaw between 300° and 60°
+	{
+		return true;
+	}
+
+	return false;
+}
+
+void MCC_Calculations::PrelaunchMissionInitialization()
+{
+	//Assumes mission file has been loaded. Also GZGENCSN.MonthofLiftoff, GZGENCSN.DayofLiftoff, GZGENCSN.Year in the scenario.
+
+	char Buff[128];
+
+	//P80 MED: mission initialization
+	sprintf_s(Buff, "P80,1,CSM,%d,%d,%d;", pRTCC->GZGENCSN.MonthofLiftoff, pRTCC->GZGENCSN.DayofLiftoff, pRTCC->GZGENCSN.Year);
+	pRTCC->GMGMED(Buff);
+}
+
+void MCC_Calculations::DMissionRendezvousPlan(SV sv_A0, double &t_TPI0)
+{
+	SV sv2;
+
+	//Step 1: Find TPI0 time (25 minutes before sunrise)
+	double TPI0_guess, TPI0_sunrise_guess, TPI0_sunrise, dt_sunrise;
+	dt_sunrise = 25.0*60.0;
+	TPI0_guess = OrbMech::HHMMSSToSS(95, 0, 0);
+	TPI0_sunrise_guess = TPI0_guess + dt_sunrise;
+	TPI0_sunrise = FindOrbitalSunrise(sv_A0, TPI0_sunrise_guess);
+	t_TPI0 = TPI0_sunrise - dt_sunrise;
+
+	//Step 2: Phasing is 70 minutes before TPI0
+	pRTCC->calcParams.Phasing = t_TPI0 - 70.0*60.0;
+
+	//Step 3: Insertion is 111:42 minutes after Phasing
+	pRTCC->calcParams.Insertion = pRTCC->calcParams.Phasing + 111.0*60.0 + 42.0;
+
+	//Step 4: CSI is two minutes (rounded) after 5° AOS of the TAN pass
+	double CSI_guess, lat_TAN, lng_TAN, AOS_TAN, LOS_TAN;
+	lat_TAN = groundstations[13][0];
+	lng_TAN = groundstations[13][1];
+	CSI_guess = pRTCC->calcParams.Insertion + 40.0*60.0;
+	sv2 = pRTCC->coast(sv_A0, CSI_guess - OrbMech::GETfromMJD(sv_A0.MJD, pRTCC->CalcGETBase()));
+	FindRadarAOSLOS(sv2, lat_TAN, lng_TAN, AOS_TAN, LOS_TAN);
+	pRTCC->calcParams.CSI = (floor(AOS_TAN / 60.0) + 2.0)*60.0;
+
+	//Step 5: CDH is placed 44.4 minutes after CSI
+	pRTCC->calcParams.CDH = pRTCC->calcParams.CSI + 44.4*60.0;
+
+	//Step 6: Find TPI0 time (25 minutes before sunrise)
+	double TPI_guess, TPI_sunrise_guess, TPI_sunrise;
+	TPI_guess = OrbMech::HHMMSSToSS(98, 0, 0);
+	TPI_sunrise_guess = TPI_guess + dt_sunrise;
+	TPI_sunrise = FindOrbitalSunrise(sv_A0, TPI_sunrise_guess);
+	pRTCC->calcParams.TPI = TPI_sunrise - dt_sunrise;
+}
+
+void MCC_Calculations::FMissionRendezvousPlan(VESSEL *chaser, VESSEL *target, SV sv_A0, double t_TIG, double t_TPI, double &t_Ins, double &CSI)
+{
+	//Plan: Phasing (fixed TIG), Insertion, CSI 50 minutes after Insertion, CDH, TPI at orbital midnight (Apollo 10)
+
+	LambertMan lamopt, lamopt2;
+	TwoImpulseResuls lamres;
+	double GETbase, t_sv0, t_Phasing, t_Insertion, dt, t_CSI, ddt, T_P, dv_CSI, t_CDH, dt_TPI, t_TPI_apo;
+	VECTOR3 dV_Phasing, dV_Insertion, R_P_CDH1, V_P_CDH1;
+	SV sv_P0, sv_P_CSI, sv_Phasing, sv_Phasing_apo, sv_Insertion, sv_Insertion_apo, sv_CSI, sv_CSI_apo, sv_CDH, sv_CDH_apo, sv_P_CDH;
+
+	//Constants
+	const double dt2 = 50.0*60.0; //Insertion to CSI
+	const double DH = 15.0*1852.0;
+
+	GETbase = pRTCC->CalcGETBase();
+	t_Phasing = t_TIG;
+	dt = 7017.0; //Phasing to Insertion
+	dv_CSI = 50.0*0.3048;
+	ddt = 10.0;
+
+	sv_P0 = pRTCC->StateVectorCalc(target);
+
+	lamopt.mode = 0;
+	lamopt.N = 0;
+	lamopt.Offset = _V(-270.0*1852.0, 0.0, 60.0*1852.0 - 60000.0*0.3048);
+	lamopt.Perturbation = RTCC_LAMBERT_PERTURBED;
+	lamopt.T1 = t_Phasing;
+	lamopt.sv_P = sv_P0;
+
+	lamopt2 = lamopt;
+	lamopt2.Offset = _V(-147.0*1852.0, 0.0, 14.7*1852.0);
+
+	t_sv0 = OrbMech::GETfromMJD(sv_A0.MJD, GETbase);
+	sv_Phasing = pRTCC->coast(sv_A0, t_Phasing - t_sv0);
+
+	//Loop
+	while (abs(ddt) > 1.0)
+	{
+		//Phasing Targeting
+		t_Insertion = t_Phasing + dt;
+
+		lamopt.T2 = t_Insertion;
+		lamopt.sv_A = sv_Phasing;
+
+		pRTCC->LambertTargeting(&lamopt, lamres);
+		dV_Phasing = lamres.dV;
+
+		sv_Phasing_apo = sv_Phasing;
+		sv_Phasing_apo.V += dV_Phasing;
+
+		//Insertion Targeting
+		t_CSI = t_Insertion + dt2;
+
+		lamopt2.T1 = t_Insertion;
+		lamopt2.T2 = t_CSI;
+		lamopt2.sv_A = sv_Phasing_apo;
+
+		pRTCC->LambertTargeting(&lamopt2, lamres);
+		dV_Insertion = lamres.dV;
+
+		sv_Insertion = pRTCC->coast(sv_Phasing_apo, t_Insertion - t_Phasing);
+		sv_Insertion_apo = sv_Insertion;
+		sv_Insertion_apo.V += dV_Insertion;
+
+		sv_CSI = pRTCC->coast(sv_Insertion_apo, t_CSI - t_Insertion);
+
+		//CSI Targeting
+		sv_P_CSI = pRTCC->coast(sv_P0, t_CSI - OrbMech::GETfromMJD(sv_P0.MJD, GETbase));
+		OrbMech::CSIToDH(sv_CSI.R, sv_CSI.V, sv_P_CSI.R, sv_P_CSI.V, DH, OrbMech::mu_Moon, dv_CSI);
+		sv_CSI_apo = sv_CSI;
+		sv_CSI_apo.V = sv_CSI.V + OrbMech::ApplyHorizontalDV(sv_CSI.R, sv_CSI.V, dv_CSI);
+
+		//CDH Targeting
+		T_P = OrbMech::period(sv_CSI_apo.R, sv_CSI_apo.V, OrbMech::mu_Moon);
+		t_CDH = t_CSI + T_P / 2.0;
+		sv_CDH = pRTCC->coast(sv_CSI_apo, t_CDH - t_CSI);
+		sv_CDH_apo = sv_CDH;
+		sv_P_CDH = pRTCC->coast(sv_P_CSI, t_CDH - t_CSI);
+		OrbMech::RADUP(sv_P_CDH.R, sv_P_CDH.V, sv_CDH.R, OrbMech::mu_Moon, R_P_CDH1, V_P_CDH1);
+		sv_CDH_apo.V = OrbMech::CoellipticDV(sv_CDH.R, R_P_CDH1, V_P_CDH1, OrbMech::mu_Moon);
+
+		//Find TPI time and recycle
+		dt_TPI = OrbMech::findelev(pRTCC->SystemParameters.AGCEpoch, sv_CDH_apo.R, sv_CDH_apo.V, sv_P_CDH.R, sv_P_CDH.V, sv_CDH_apo.MJD, 26.6*RAD, sv_CDH_apo.gravref);
+		t_TPI_apo = t_CDH + dt_TPI;
+		ddt = t_TPI - t_TPI_apo;
+		dt += ddt;
+	}
+
+	t_Ins = t_Insertion;
+	CSI = t_CSI;
+
+	/*
+	//Debug prints
+	SV sv_before, sv_after;
+	MATRIX3 Rot;
+	VECTOR3 DV_LVLH;
+	double tig, r_apo, r_peri, h_apo, h_peri;
+	char Buffer[128], Buffer2[128];
+
+	for (int i = 0; i < 4; i++)
+	{
+		if (i == 0)
+		{
+			sprintf(Buffer, "Phasing");
+			tig = t_TIG;
+			sv_before = sv_Phasing;
+			sv_after = sv_Phasing_apo;
+		}
+		else if (i == 1)
+		{
+			sprintf(Buffer, "Insertion");
+			tig = t_Insertion;
+			sv_before = sv_Insertion;
+			sv_after = sv_Insertion_apo;
+		}
+		else if (i == 2)
+		{
+			sprintf(Buffer, "CSI");
+			tig = t_CSI;
+			sv_before = sv_CSI;
+			sv_after = sv_CSI_apo;
+		}
+		else if (i == 3)
+		{
+			sprintf(Buffer, "CDH");
+			tig = t_CDH;
+			sv_before = sv_CDH;
+			sv_after = sv_CDH_apo;
+		}
+
+		oapiWriteLog(Buffer);
+
+		OrbMech::format_time_HHMMSS(Buffer2, tig);
+		Rot = OrbMech::LVLH_Matrix(sv_before.R, sv_before.V);
+		DV_LVLH = mul(Rot, sv_after.V - sv_before.V) / 0.3048;
+
+		sprintf(Buffer, "TIG %s DV %.1lf %.1lf %.1lf", Buffer2, DV_LVLH.x, DV_LVLH.y, DV_LVLH.z);
+		oapiWriteLog(Buffer);
+		OrbMech::periapo(sv_after.R, sv_after.V, OrbMech::mu_Moon, r_apo, r_peri);
+		h_apo = r_apo - BZLAND.rad[0];
+		h_peri = r_peri - BZLAND.rad[0];
+		sprintf(Buffer, "HA %.2lf HP %.2lf", h_apo / 1852.0, h_peri / 1852.0);
+		oapiWriteLog(Buffer);
+	}
+
+	oapiWriteLog("TPI");
+	OrbMech::format_time_HHMMSS(Buffer2, t_TPI);
+	sprintf(Buffer, "TIG %s", Buffer2);
+	oapiWriteLog(Buffer);
+	*/
+}

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Calculations.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Calculations.h
@@ -25,6 +25,7 @@
 
 #include "../src_rtccmfd/RTCCModule.h"
 #include "../src_rtccmfd/RTCCTables.h"
+#include "../src_rtccmfd/OrbMech.h"
 
 // A class with utility calculations for the MCC class, with access to the RTCC class
 // Anything that does not belong in the RTCC class, because it does not correspond to real RTCC code
@@ -40,4 +41,17 @@ public:
 	double Sunrise(EphemerisDataTable2 &ephem, double gmt_estimate);
 	double TerminatorRise(EphemerisDataTable2 &ephem, double gmt_estimate);
 	bool LongitudeCrossing(EphemerisDataTable2 &ephem, double lng, double gmt_estimate, double &gmt_cross);
+	double FindOrbitalSunrise(SV sv, double t_sunrise_guess);
+	double FindOrbitalMidnight(SV sv, double t_TPI_guess);
+	void FindRadarAOSLOS(SV sv, double lat, double lng, double &GET_AOS, double &GET_LOS);
+	int SPSRCSDecision(double a, VECTOR3 dV_LVLH);	//0 = SPS, 1 = RCS
+	bool REFSMMATDecision(VECTOR3 Att); //true = everything ok, false = Preferred REFSMMAT necessary
+	void PrelaunchMissionInitialization();
+
+	//Mission specific rendezvous plans
+	void DMissionRendezvousPlan(SV sv_A0, double &t_TPI0);
+	void FMissionRendezvousPlan(VESSEL *chaser, VESSEL *target, SV sv_A0, double t_TIG, double t_TPI, double &t_Ins, double &CSI);
+
+	//Returns true if the current Ground Elapsed Time is greater than the input value
+	bool GETEval(double get);
 };

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_B.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_B.cpp
@@ -37,12 +37,12 @@ void MCC::MissionSequence_B()
 	switch (MissionState)
 	{
 	case MST_B_PRELAUNCH:
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(-60.0), 1, MST_B_LAUNCH);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(-60.0), 1, MST_B_LAUNCH);
 		break;
 	case MST_B_LAUNCH:
 		switch (SubState) {
 		case 0:
-			if (rtcc->GETEval2(-5.0))
+			if (mcc_calcs.GETEval(-5.0))
 			{
 				SIVB *lmsat = (SIVB *)sivb;
 				lmsat->GetIU()->GetEDS()->EnableCommandSystem();
@@ -66,7 +66,7 @@ void MCC::MissionSequence_B()
 			}
 			break;
 		case 3:
-			if (rtcc->GETEval2(0.0))
+			if (mcc_calcs.GETEval(0.0))
 			{
 				setState(MST_B_COASTING);
 			}
@@ -74,55 +74,55 @@ void MCC::MissionSequence_B()
 		}
 		break;
 	case MST_B_COASTING:
-		if (rtcc->GETEval2(8.0*3600.0 + 52.0*60.0 + 10.0))
+		if (mcc_calcs.GETEval(8.0*3600.0 + 52.0*60.0 + 10.0))
 		{
 			setState(MST_B_RCS_TESTS1);
 		}
 		break;
 	case MST_B_RCS_TESTS1:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(8.0 * 3600.0 + 52.0 * 60.0 + 30.0), 2, MST_B_RCS_TESTS2);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(8.0 * 3600.0 + 52.0 * 60.0 + 30.0), 2, MST_B_RCS_TESTS2);
 		break;
 	case MST_B_RCS_TESTS2:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(8.0 * 3600.0 + 52.0 * 60.0 + 40.0), 3, MST_B_RCS_TESTS3);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(8.0 * 3600.0 + 52.0 * 60.0 + 40.0), 3, MST_B_RCS_TESTS3);
 		break;
 	case MST_B_RCS_TESTS3:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(9.0 * 3600.0), 4, MST_B_RCS_TESTS4);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(9.0 * 3600.0), 4, MST_B_RCS_TESTS4);
 		break;
 	case MST_B_RCS_TESTS4:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(9.0 * 3600.0 + 20.0), 5, MST_B_RCS_TESTS5);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(9.0 * 3600.0 + 20.0), 5, MST_B_RCS_TESTS5);
 		break;
 	case MST_B_RCS_TESTS5:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(9.0 * 3600.0 + 46.0 * 60.0 + 5.0), 6, MST_B_RCS_TESTS6);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(9.0 * 3600.0 + 46.0 * 60.0 + 5.0), 6, MST_B_RCS_TESTS6);
 		break;
 	case MST_B_RCS_TESTS6:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(9.0 * 3600.0 + 46.0 * 60.0 + 35.0), 7, MST_B_RCS_TESTS7);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(9.0 * 3600.0 + 46.0 * 60.0 + 35.0), 7, MST_B_RCS_TESTS7);
 		break;
 	case MST_B_RCS_TESTS7:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(9.0 * 3600.0 + 47.0 * 60.0 + 20.0), 4, MST_B_RCS_TESTS8);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(9.0 * 3600.0 + 47.0 * 60.0 + 20.0), 4, MST_B_RCS_TESTS8);
 		break;
 	case MST_B_RCS_TESTS8:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(11.0 * 3600.0 + 27.0 * 60.0 + 35.0), 5, MST_B_RCS_TESTS9);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(11.0 * 3600.0 + 27.0 * 60.0 + 35.0), 5, MST_B_RCS_TESTS9);
 		break;
 	case MST_B_RCS_TESTS9:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(11.0 * 3600.0 + 28.0 * 60.0 + 20.0), 4, MST_B_RCS_TESTS10);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(11.0 * 3600.0 + 28.0 * 60.0 + 20.0), 4, MST_B_RCS_TESTS10);
 		break;
 	case MST_B_RCS_TESTS10:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(11.0 * 3600.0 + 31.0 * 60.0 + 20.0), 5, MST_B_RCS_TESTS11);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(11.0 * 3600.0 + 31.0 * 60.0 + 20.0), 5, MST_B_RCS_TESTS11);
 		break;
 	case MST_B_RCS_TESTS11:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(11.0 * 3600.0 + 31.0 * 60.0 + 30.0), 4, MST_B_RCS_TESTS12);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(11.0 * 3600.0 + 31.0 * 60.0 + 30.0), 4, MST_B_RCS_TESTS12);
 		break;
 	case MST_B_RCS_TESTS12:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(12.0 * 3600.0 + 51.0 * 60.0), 5, MST_B_RCS_TESTS13);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(12.0 * 3600.0 + 51.0 * 60.0), 5, MST_B_RCS_TESTS13);
 		break;
 	case MST_B_RCS_TESTS13:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(12.0 * 3600.0 + 51.0 * 60.0 + 20.0), 8, MST_B_RCS_TESTS14);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(12.0 * 3600.0 + 51.0 * 60.0 + 20.0), 8, MST_B_RCS_TESTS14);
 		break;
 	case MST_B_RCS_TESTS14:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(12.0 * 3600.0 + 51.0 * 60.0 + 50.0), 9, MST_B_RCS_TESTS15);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(12.0 * 3600.0 + 51.0 * 60.0 + 50.0), 9, MST_B_RCS_TESTS15);
 		break;
 	case MST_B_RCS_TESTS15:
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(12.0 * 3600.0 + 52.0 * 60.0 + 15.0), 10, MST_B_RCS_TESTS16);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(12.0 * 3600.0 + 52.0 * 60.0 + 15.0), 10, MST_B_RCS_TESTS16);
 		break;
 	case MST_B_RCS_TESTS16:
 		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, false, 4, MST_B_RCS_TESTS17);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_C.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_C.cpp
@@ -33,7 +33,7 @@ void MCC::MissionSequence_C()
 {
 	switch (MissionState) {
 	case MST_C_INSERTION:
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(56.0*60.0), 100, MST_C_DAY0STATE1);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(56.0*60.0), 100, MST_C_DAY0STATE1);
 		break;
 	case MST_C_DAY0STATE1:
 		// Await separation.
@@ -99,211 +99,211 @@ void MCC::MissionSequence_C()
 	case MST_C_DAY0STATE2:
 		// Ends with 1ST RDZ PHASING BURN
 		// The phasing burn was intended to place the spacecraft 76.5 n mi ahead of the S-IVB in 23 hours.
-		if (rtcc->GETEval2(3 * 60 * 60 + 5 * 60))
+		if (mcc_calcs.GETEval(3 * 60 * 60 + 5 * 60))
 		{
-			UpdateMacro(UTP_PADONLY, PT_AP7MNV, rtcc->GETEval2(4 * 60 * 60 + 31 * 60), 1, MST_C_DAY0STATE3);
+			UpdateMacro(UTP_PADONLY, PT_AP7MNV, mcc_calcs.GETEval(4 * 60 * 60 + 31 * 60), 1, MST_C_DAY0STATE3);
 		}
 		break;
 	case MST_C_DAY0STATE3: // S-IVB navigation update to 6-4 Deorbit Maneuver update
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(4 * 60 * 60 + 45 * 60), 101, MST_C_DAY0STATE4);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(4 * 60 * 60 + 45 * 60), 101, MST_C_DAY0STATE4);
 		break;
 	case MST_C_DAY0STATE4: // 6-4 Deorbit Maneuver update to Retro Orientation Test
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, SubStateTime > 5.0*60.0, 2, MST_C_DAY0STATE5);
 		break;
 	case MST_C_DAY0STATE5: // Retro Orientation Test update to Block Data 2
-		UpdateMacro(UTP_PADONLY, PT_RETROORIENTATION, rtcc->GETEval2(10 * 60 * 60 + 30 * 60), 102, MST_C_DAY0STATE6);
+		UpdateMacro(UTP_PADONLY, PT_RETROORIENTATION, mcc_calcs.GETEval(10 * 60 * 60 + 30 * 60), 102, MST_C_DAY0STATE6);
 		break;
 	case MST_C_DAY0STATE6: //Block Data 2 to 2nd Phasing Maneuver Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(14 * 60 * 60 + 16 * 60), 3, MST_C_DAY0STATE7);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(14 * 60 * 60 + 16 * 60), 3, MST_C_DAY0STATE7);
 		break;
 	case MST_C_DAY0STATE7: // 2nd Phasing Maneuver Update to Block Data 3
-		UpdateMacro(UTP_PADONLY, PT_AP7MNV, rtcc->GETEval2(21 * 60 * 60 + 50 * 60), 4, MST_C_DAY0STATE8);
+		UpdateMacro(UTP_PADONLY, PT_AP7MNV, mcc_calcs.GETEval(21 * 60 * 60 + 50 * 60), 4, MST_C_DAY0STATE8);
 		break;
 	case MST_C_DAY0STATE8: // Block Data 3 to Preliminary NCC1 Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(22 * 60 * 60 + 25 * 60), 5, MST_C_DAY0STATE9);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(22 * 60 * 60 + 25 * 60), 5, MST_C_DAY0STATE9);
 		break;
 	case MST_C_DAY0STATE9: // Preliminary NCC1 Update to Final NCC1 Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(25 * 60 * 60 + 30 * 60), 6, MST_C_DAY1STATE1);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(25 * 60 * 60 + 30 * 60), 6, MST_C_DAY1STATE1);
 		break;
 	case MST_C_DAY1STATE1: // Final NCC1 Update to NCC2 Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(27 * 60 * 60), 7, MST_C_DAY1STATE2);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(27 * 60 * 60), 7, MST_C_DAY1STATE2);
 		break;
 	case MST_C_DAY1STATE2: //  NCC2 Update to NSR Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(27 * 60 * 60 + 32 * 60), 8, MST_C_DAY1STATE3);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(27 * 60 * 60 + 32 * 60), 8, MST_C_DAY1STATE3);
 		break;
 	case MST_C_DAY1STATE3: // NSR Update to TPI Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(28 * 60 * 60 + 50 * 60), 9, MST_C_DAY1STATE4);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(28 * 60 * 60 + 50 * 60), 9, MST_C_DAY1STATE4);
 		break;
 	case MST_C_DAY1STATE4: // TPI Update to Final Separation Maneuver update
-		UpdateMacro(UTP_PADONLY, PT_AP7TPI, rtcc->GETEval2(30 * 60 * 60 + 9 * 60), 10, MST_C_DAY1STATE5);
+		UpdateMacro(UTP_PADONLY, PT_AP7TPI, mcc_calcs.GETEval(30 * 60 * 60 + 9 * 60), 10, MST_C_DAY1STATE5);
 		break;
 	case MST_C_DAY1STATE5: // Final Separation Maneuver update to Block Data 4
-		UpdateMacro(UTP_PADONLY, PT_AP7MNV, rtcc->GETEval2(30 * 60 * 60 + 54 * 60), 11, MST_C_DAY1STATE6);
+		UpdateMacro(UTP_PADONLY, PT_AP7MNV, mcc_calcs.GETEval(30 * 60 * 60 + 54 * 60), 11, MST_C_DAY1STATE6);
 		break;
 	case MST_C_DAY1STATE6: // Block Data 4 to SV Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(34 * 60 * 60 + 45 * 60), 12, MST_C_DAY1STATE7);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(34 * 60 * 60 + 45 * 60), 12, MST_C_DAY1STATE7);
 		break;
 	case MST_C_DAY1STATE7: // SV Update to Block Data 5
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(39 * 60 * 60 + 21 * 60), 53, MST_C_DAY1STATE8);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(39 * 60 * 60 + 21 * 60), 53, MST_C_DAY1STATE8);
 		break;
 	case MST_C_DAY1STATE8: // Block Data 5 to SV Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(44 * 60 * 60), 13, MST_C_DAY1STATE9);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(44 * 60 * 60), 13, MST_C_DAY1STATE9);
 		break;
 	case MST_C_DAY1STATE9: // SV Update to Block Data 6
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(49 * 60 * 60 + 12 * 60), 53, MST_C_DAY2STATE1);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(49 * 60 * 60 + 12 * 60), 53, MST_C_DAY2STATE1);
 		break;
 	case MST_C_DAY2STATE1: // Block Data 6 to SV Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(50 * 60 * 60 + 15 * 60), 14, MST_C_DAY2STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(50 * 60 * 60 + 15 * 60), 14, MST_C_DAY2STATE2);
 		break;
 	case MST_C_DAY2STATE2: // SV Update to Block Data 7
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(57 * 60 * 60 + 4 * 60), 53, MST_C_DAY2STATE3);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(57 * 60 * 60 + 4 * 60), 53, MST_C_DAY2STATE3);
 		break;
 	case MST_C_DAY2STATE3: // Block Data 7 to SV Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(67 * 60 * 60 + 50 * 60), 15, MST_C_DAY2STATE4);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(67 * 60 * 60 + 50 * 60), 15, MST_C_DAY2STATE4);
 		break;
 	case MST_C_DAY2STATE4: // SV Update to Block Data 8
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(68 * 60 * 60 + 37 * 60), 52, MST_C_DAY2STATE5);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(68 * 60 * 60 + 37 * 60), 52, MST_C_DAY2STATE5);
 		break;
 	case MST_C_DAY2STATE5: // Block Data 8 to SPS-3
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(72 * 60 * 60), 16, MST_C_DAY3STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(72 * 60 * 60), 16, MST_C_DAY3STATE1);
 		break;
 	case MST_C_DAY3STATE1: // SPS-3 to Block Data 9
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(77 * 60 * 60 + 5 * 60), 17, MST_C_DAY3STATE2);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(77 * 60 * 60 + 5 * 60), 17, MST_C_DAY3STATE2);
 		break;
 	case MST_C_DAY3STATE2: // Block Data 9 to Block Data 10
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(85 * 60 * 60 + 52 * 60), 18, MST_C_DAY3STATE3);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(85 * 60 * 60 + 52 * 60), 18, MST_C_DAY3STATE3);
 		break;
 	case MST_C_DAY3STATE3: // Block Data 10 to SV Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(90 * 60 * 60), 19, MST_C_DAY3STATE4);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(90 * 60 * 60), 19, MST_C_DAY3STATE4);
 		break;
 	case MST_C_DAY3STATE4: // SV Update to SV Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(94 * 60 * 60), 52, MST_C_DAY3STATE5);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(94 * 60 * 60), 52, MST_C_DAY3STATE5);
 		break;
 	case MST_C_DAY3STATE5: // SV Update to Block Data 11
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(96 * 60 * 60 + 21 * 60), 52, MST_C_DAY4STATE1);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(96 * 60 * 60 + 21 * 60), 52, MST_C_DAY4STATE1);
 		break;
 	case MST_C_DAY4STATE1: // Block Data 11 to SV Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(97 * 60 * 60 + 40 * 60), 20, MST_C_DAY4STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(97 * 60 * 60 + 40 * 60), 20, MST_C_DAY4STATE2);
 		break;
 	case MST_C_DAY4STATE2: // SV Update to Block Data 12
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(105 * 60 * 60 + 10 * 60), 52, MST_C_DAY4STATE3);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(105 * 60 * 60 + 10 * 60), 52, MST_C_DAY4STATE3);
 		break;
 	case MST_C_DAY4STATE3: // Block Data 12 to Block Data 13
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(116 * 60 * 60 + 3 * 60), 21, MST_C_DAY4STATE4);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(116 * 60 * 60 + 3 * 60), 21, MST_C_DAY4STATE4);
 		break;
 	case MST_C_DAY4STATE4: // Block Data 13 to SPS-4
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(117 * 60 * 60 + 30 * 60), 22, MST_C_DAY4STATE5);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(117 * 60 * 60 + 30 * 60), 22, MST_C_DAY4STATE5);
 		break;
 	case MST_C_DAY4STATE5: // SPS-4 to landmark tracking update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(121 * 60 * 60 + 6 * 60), 23, MST_C_DAY5STATE1);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(121 * 60 * 60 + 6 * 60), 23, MST_C_DAY5STATE1);
 		break;
 	case MST_C_DAY5STATE1: // Landmark tracking update to SV Update
-		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, rtcc->GETEval2(121 * 60 * 60 + 36 * 60), 55, MST_C_DAY5STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, mcc_calcs.GETEval(121 * 60 * 60 + 36 * 60), 55, MST_C_DAY5STATE2);
 		break;
 	case MST_C_DAY5STATE2: // SV Update to SV Update
-		UpdateMacro(UTP_PADONLY, PT_P27PAD, rtcc->GETEval2(123 * 60 * 60 + 40 * 60), 54, MST_C_DAY5STATE3);
+		UpdateMacro(UTP_PADONLY, PT_P27PAD, mcc_calcs.GETEval(123 * 60 * 60 + 40 * 60), 54, MST_C_DAY5STATE3);
 		break;
 	case MST_C_DAY5STATE3: // SV Update to Block Data 14
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(125 * 60 * 60 + 12 * 60), 52, MST_C_DAY5STATE4);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(125 * 60 * 60 + 12 * 60), 52, MST_C_DAY5STATE4);
 		break;
 	case MST_C_DAY5STATE4: // Block Data 14 to Block Data 15
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(134 * 60 * 60 + 48 * 60), 24, MST_C_DAY5STATE5);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(134 * 60 * 60 + 48 * 60), 24, MST_C_DAY5STATE5);
 		break;
 	case MST_C_DAY5STATE5: // Block Data 15 to rev 90 landmark tracking update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(139 * 60 * 60 + 40 * 60), 25, MST_C_DAY5STATE6);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(139 * 60 * 60 + 40 * 60), 25, MST_C_DAY5STATE6);
 		break;
 	case MST_C_DAY5STATE6: // Rev 90 landmark tracking update to SV Update
 		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, SubStateTime > 5.0*60.0, 56, MST_C_DAY5STATE7);
 		break;
 	case MST_C_DAY5STATE7: // SV Update to rev 91 landmark tracking
-		UpdateMacro(UTP_PADONLY, PT_P27PAD, rtcc->GETEval2(143 * 60 * 60), 54, MST_C_DAY5STATE8);
+		UpdateMacro(UTP_PADONLY, PT_P27PAD, mcc_calcs.GETEval(143 * 60 * 60), 54, MST_C_DAY5STATE8);
 		break;
 	case MST_C_DAY5STATE8: // Rev 91 landmark tracking update to SV Update
-		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, rtcc->GETEval2(143 * 60 * 60 + 20 * 60), 57, MST_C_DAY5STATE9);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, mcc_calcs.GETEval(143 * 60 * 60 + 20 * 60), 57, MST_C_DAY5STATE9);
 		break;
 	case MST_C_DAY5STATE9: // SV Update to Block Data 16
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(144 * 60 * 60 + 11 * 60), 52, MST_C_DAY5STATE10);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(144 * 60 * 60 + 11 * 60), 52, MST_C_DAY5STATE10);
 		break;
 	case MST_C_DAY5STATE10: // Block Data 16 to rev 92 landmark tracking update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(145 * 60 * 60 + 30 * 60), 26, MST_C_DAY6STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(145 * 60 * 60 + 30 * 60), 26, MST_C_DAY6STATE1);
 		break;
 	case MST_C_DAY6STATE1: // Rev 92 landmark tracking update to SV Update
-		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, rtcc->GETEval2(147 * 60 * 60 + 10 * 60), 58, MST_C_DAY6STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, mcc_calcs.GETEval(147 * 60 * 60 + 10 * 60), 58, MST_C_DAY6STATE2);
 		break;
 	case MST_C_DAY6STATE2: // SV Update to Block Data 17
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(153 * 60 * 60 + 47 * 60), 52, MST_C_DAY6STATE3);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(153 * 60 * 60 + 47 * 60), 52, MST_C_DAY6STATE3);
 		break;
 	case MST_C_DAY6STATE3: // Block Data 17 to SPS-5
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(161 * 60 * 60 + 18 * 60), 27, MST_C_DAY6STATE4);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(161 * 60 * 60 + 18 * 60), 27, MST_C_DAY6STATE4);
 		break;
 	case MST_C_DAY6STATE4: // SPS-5 to Block Data 18
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(161 * 60 * 60 + 59 * 60), 28, MST_C_DAY6STATE5);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(161 * 60 * 60 + 59 * 60), 28, MST_C_DAY6STATE5);
 		break;
 	case MST_C_DAY6STATE5: // Block Data 18 to SV Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(169 * 60 * 60), 29, MST_C_DAY7STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(169 * 60 * 60), 29, MST_C_DAY7STATE1);
 		break;
 	case MST_C_DAY7STATE1: // SV Update to Block Data 19
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(172 * 60 * 60 + 42 * 60), 52, MST_C_DAY7STATE2);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(172 * 60 * 60 + 42 * 60), 52, MST_C_DAY7STATE2);
 		break;
 	case MST_C_DAY7STATE2: // Block Data 19 to Block Data 20
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(180 * 60 * 60 + 56 * 60), 30, MST_C_DAY7STATE3);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(180 * 60 * 60 + 56 * 60), 30, MST_C_DAY7STATE3);
 		break;
 	case MST_C_DAY7STATE3: // Block Data 20 to Block Data 21
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(192 * 60 * 60 + 17 * 60), 31, MST_C_DAY8STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(192 * 60 * 60 + 17 * 60), 31, MST_C_DAY8STATE1);
 		break;
 	case MST_C_DAY8STATE1: // Block Data 21 to Block Data 22
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(201 * 60 * 60 + 55 * 60), 32, MST_C_DAY8STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(201 * 60 * 60 + 55 * 60), 32, MST_C_DAY8STATE2);
 		break;
 	case MST_C_DAY8STATE2: // Block Data 22 to SPS-6
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(205 * 60 * 60 + 25 * 60), 33, MST_C_DAY8STATE3);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(205 * 60 * 60 + 25 * 60), 33, MST_C_DAY8STATE3);
 		break;
 	case MST_C_DAY8STATE3: // SPS-6 to Block Data 23
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(210 * 60 * 60 + 11 * 60), 34, MST_C_DAY8STATE4);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(210 * 60 * 60 + 11 * 60), 34, MST_C_DAY8STATE4);
 		break;
 	case MST_C_DAY8STATE4: // Block Data 23 to rev 135 landmark tracking update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(212 * 60 * 60 + 40 * 60), 35, MST_C_DAY8STATE5);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(212 * 60 * 60 + 40 * 60), 35, MST_C_DAY8STATE5);
 		break;
 	case MST_C_DAY8STATE5: // Rev 135 landmark tracking update to SV PAD
-		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, rtcc->GETEval2(213 * 60 * 60), 59, MST_C_DAY8STATE6);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, mcc_calcs.GETEval(213 * 60 * 60), 59, MST_C_DAY8STATE6);
 		break;
 	case MST_C_DAY8STATE6: // SV PAD to P27 PAD
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(214 * 60 * 60 + 10 * 60), 61, MST_C_DAY8STATE7);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(214 * 60 * 60 + 10 * 60), 61, MST_C_DAY8STATE7);
 		break;
 	case MST_C_DAY8STATE7: //P27 PAD to rev 136 landmark tracking update
-		UpdateMacro(UTP_PADONLY, PT_P27PAD, rtcc->GETEval2(215 * 60 * 60), 36, MST_C_DAY8STATE8);
+		UpdateMacro(UTP_PADONLY, PT_P27PAD, mcc_calcs.GETEval(215 * 60 * 60), 36, MST_C_DAY8STATE8);
 		break;
 	case MST_C_DAY8STATE8: // Rev 136 landmark tracking update to SV PAD
-		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, rtcc->GETEval2(216 * 60 * 60), 60, MST_C_DAY9STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, mcc_calcs.GETEval(216 * 60 * 60), 60, MST_C_DAY9STATE1);
 		break;
 	case MST_C_DAY9STATE1: //SV PAD to SV PAD
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(217 * 60 * 60 + 30 * 60), 52, MST_C_DAY9STATE2);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(217 * 60 * 60 + 30 * 60), 52, MST_C_DAY9STATE2);
 		break;
 	case MST_C_DAY9STATE2: //SV PAD to Block Data 24
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(220 * 60 * 60 + 43 * 60), 52, MST_C_DAY9STATE3);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(220 * 60 * 60 + 43 * 60), 52, MST_C_DAY9STATE3);
 		break;
 	case MST_C_DAY9STATE3: // Block Data 24 to Block Data 25
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(230 * 60 * 60 + 24 * 60), 37, MST_C_DAY9STATE4);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(230 * 60 * 60 + 24 * 60), 37, MST_C_DAY9STATE4);
 		break;
 	case MST_C_DAY9STATE4: // Block Data 25 to SPS-7
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(233 * 60 * 60 + 27 * 60), 38, MST_C_DAY9STATE5);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(233 * 60 * 60 + 27 * 60), 38, MST_C_DAY9STATE5);
 		break;
 	case MST_C_DAY9STATE5: // SPS-7 to SV PAD
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(240 * 60 * 60 + 20 * 60), 39, MST_C_DAY10STATE1);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(240 * 60 * 60 + 20 * 60), 39, MST_C_DAY10STATE1);
 		break;
 	case MST_C_DAY10STATE1: // SV PAD to Block Data 26
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(241 * 60 * 60 + 39 * 60), 52, MST_C_DAY10STATE2);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(241 * 60 * 60 + 39 * 60), 52, MST_C_DAY10STATE2);
 		break;
 	case MST_C_DAY10STATE2: // Block Data 26 to Block Data 27
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(248 * 60 * 60 + 56 * 60), 40, MST_C_DAY10STATE3);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(248 * 60 * 60 + 56 * 60), 40, MST_C_DAY10STATE3);
 		break;
 	case MST_C_DAY10STATE3: // Block Data 27 to SV PAD
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(255 * 60 * 60), 41, MST_C_DAY10STATE4);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(255 * 60 * 60), 41, MST_C_DAY10STATE4);
 		break;
 	case MST_C_DAY10STATE4: // SV PAD to Deorbit Maneuver
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(257 * 60 * 60 + 20 * 60), 52, MST_C_DAY10STATE5);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(257 * 60 * 60 + 20 * 60), 52, MST_C_DAY10STATE5);
 		break;
 	case MST_C_DAY10STATE5: // Deorbit Maneuver PAD to Entry PAD
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(257 * 60 * 60 + 25 * 60), 42, MST_C_DAY10STATE6);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(257 * 60 * 60 + 25 * 60), 42, MST_C_DAY10STATE6);
 		break;
 	case MST_C_DAY10STATE6:
 		UpdateMacro(UTP_PADONLY, PT_AP7ENT, cm->GetStage() == CM_STAGE, 43, MST_ORBIT_ENTRY);
@@ -346,7 +346,7 @@ void MCC::MissionSequence_C()
 			{
 			case 0:
 				//Are we past the calculated TIG?
-				if (cm->GetStage() >= CM_STAGE || rtcc->GETEval2(rtcc->TimeofIgnition))
+				if (cm->GetStage() >= CM_STAGE || mcc_calcs.GETEval(rtcc->TimeofIgnition))
 				{
 					setSubState(1); //No deorbit maneuver upcoming, just wait for CM/SM sep
 				}
@@ -362,7 +362,7 @@ void MCC::MissionSequence_C()
 				}
 				break;
 			case 2:
-				if (rtcc->GETEval2(rtcc->TimeofIgnition - 1.5*3600.0))
+				if (mcc_calcs.GETEval(rtcc->TimeofIgnition - 1.5*3600.0))
 				{
 					setState(MST_C_DAY10STATE6);
 				}

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_C_PRIME.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_C_PRIME.cpp
@@ -37,7 +37,7 @@ void MCC::MissionSequence_C_Prime()
 {
 	switch (MissionState) {
 	case MST_CP_INSERTION: //Ground liftoff time update to TLI Simulation
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(1.0*3600.0 + 35.0*60.0), 1, MST_CP_EPO1);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(1.0*3600.0 + 35.0*60.0), 1, MST_CP_EPO1);
 		break;
 	case MST_CP_EPO1: //TLI Simulation to TLI+90 PAD
 		UpdateMacro(UTP_NONE, PT_NONE, true, 2, MST_CP_EPO2);
@@ -49,10 +49,10 @@ void MCC::MissionSequence_C_Prime()
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, SubStateTime > 5.0*60.0, 4, MST_CP_EPO4);
 		break;
 	case MST_CP_EPO4: //TLI PAD to TLI Evaluation
-		UpdateMacro(UTP_PADONLY, PT_TLIPAD, rtcc->GETEval2(rtcc->calcParams.TLI + 18.0), 5, MST_CP_TRANSLUNAR1);
+		UpdateMacro(UTP_PADONLY, PT_TLIPAD, mcc_calcs.GETEval(rtcc->calcParams.TLI + 18.0), 5, MST_CP_TRANSLUNAR1);
 		break;
 	case MST_CP_TRANSLUNAR1: //TLI Evaluation to Block Data 1
-		UpdateMacro(UTP_NONE, PT_NONE, true, 6, MST_CP_TRANSLUNAR2, scrubbed, rtcc->GETEval2(3.0*3600.0 + 10.0*60.0), MST_CP_EPO1);
+		UpdateMacro(UTP_NONE, PT_NONE, true, 6, MST_CP_TRANSLUNAR2, scrubbed, mcc_calcs.GETEval(3.0*3600.0 + 10.0*60.0), MST_CP_EPO1);
 		break;
 	case MST_CP_TRANSLUNAR2:
 		switch (SubState) {
@@ -73,7 +73,7 @@ void MCC::MissionSequence_C_Prime()
 		break;
 		case 2:
 		{
-			if (rtcc->GETEval2(rtcc->calcParams.TLI + 2.0*3600.0 + 5.0*60.0))
+			if (mcc_calcs.GETEval(rtcc->calcParams.TLI + 2.0*3600.0 + 5.0*60.0))
 			{
 				SlowIfDesired();
 				setState(MST_CP_TRANSLUNAR3);
@@ -83,31 +83,31 @@ void MCC::MissionSequence_C_Prime()
 		}
 		break;
 	case MST_CP_TRANSLUNAR3: //Block Data 1 to MCC1
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 5.0*3600.0), 10, MST_CP_TRANSLUNAR4);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 5.0*3600.0), 10, MST_CP_TRANSLUNAR4);
 		break;
 	case MST_CP_TRANSLUNAR4: //MCC1 to Block Data 2
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 9.0*3600.0), 20, MST_CP_TRANSLUNAR5);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 9.0*3600.0), 20, MST_CP_TRANSLUNAR5);
 		break;
 	case MST_CP_TRANSLUNAR5: //Block Data 2 to Block Data 3
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 22.0*3600.0), 11, MST_CP_TRANSLUNAR6);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 22.0*3600.0), 11, MST_CP_TRANSLUNAR6);
 		break;
 	case MST_CP_TRANSLUNAR6: //Block Data 3 to MCC2
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 24.0*3600.0), 12, MST_CP_TRANSLUNAR7);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 24.0*3600.0), 12, MST_CP_TRANSLUNAR7);
 		break;
 	case MST_CP_TRANSLUNAR7: //MCC2 to Block Data 4
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 32.0*3600.0), 21, MST_CP_TRANSLUNAR8);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 32.0*3600.0), 21, MST_CP_TRANSLUNAR8);
 		break;
 	case MST_CP_TRANSLUNAR8: //Block Data 4 to Flyby
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 41.0*3600.0), 13, MST_CP_TRANSLUNAR9);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 41.0*3600.0), 13, MST_CP_TRANSLUNAR9);
 		break;
 	case MST_CP_TRANSLUNAR9: //Flyby to Fast PC+2
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, StateTime > 5.0*60.0, 40, MST_CP_TRANSLUNAR10);
 		break;
 	case MST_CP_TRANSLUNAR10: //Fast PC+2 to MCC3
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 23.0*3600.0), 42, MST_CP_TRANSLUNAR11);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 23.0*3600.0), 42, MST_CP_TRANSLUNAR11);
 		break;
 	case MST_CP_TRANSLUNAR11: //MCC3 to MCC4
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 9.5*3600.0), 22, MST_CP_TRANSLUNAR12);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 9.5*3600.0), 22, MST_CP_TRANSLUNAR12);
 		break;
 	case MST_CP_TRANSLUNAR12: //MCC4 to PC+2
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, StateTime > 5.0*60.0, 23, MST_CP_TRANSLUNAR13);
@@ -116,10 +116,10 @@ void MCC::MissionSequence_C_Prime()
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, StateTime > 5.0*60.0, 41, MST_CP_TRANSLUNAR14);
 		break;
 	case MST_CP_TRANSLUNAR14: //Fast PC+2 to Prel. LOI-1
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 2.5*3600.0), 42, MST_CP_TRANSLUNAR15);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 2.5*3600.0), 42, MST_CP_TRANSLUNAR15);
 		break;
 	case MST_CP_TRANSLUNAR15: //Prel. LOI-1 to Prel. TEI-1
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 1.0*3600.0 - 50.0*60.0), 30, MST_CP_TRANSLUNAR16);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 1.0*3600.0 - 50.0*60.0), 30, MST_CP_TRANSLUNAR16);
 		break;
 	case MST_CP_TRANSLUNAR16: //Prel. TEI-1 to Prel. TEI-2
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, StateTime > 5.0*60.0, 50, MST_CP_TRANSLUNAR17);
@@ -128,10 +128,10 @@ void MCC::MissionSequence_C_Prime()
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, StateTime > 5.0*60.0, 51, MST_CP_TRANSLUNAR18);
 		break;
 	case MST_CP_TRANSLUNAR18: //Map Update to LOI-1
-		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, rtcc->GETEval2(rtcc->calcParams.LOI - 1.0*3600.0 - 5.0*60.0), 60, MST_CP_TRANSLUNAR19);
+		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, mcc_calcs.GETEval(rtcc->calcParams.LOI - 1.0*3600.0 - 5.0*60.0), 60, MST_CP_TRANSLUNAR19);
 		break;
 	case MST_CP_TRANSLUNAR19: //LOI-1 to TEI-2
-		if (MissionPhase == MMST_TL_COAST && rtcc->GETEval2(rtcc->calcParams.LOI))
+		if (MissionPhase == MMST_TL_COAST && mcc_calcs.GETEval(rtcc->calcParams.LOI))
 		{
 			MissionPhase = MMST_LUNAR_ORBIT;
 		}
@@ -204,36 +204,36 @@ void MCC::MissionSequence_C_Prime()
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, StateTime > 5.0*60.0, 201, MST_CP_LUNAR_ORBIT24);
 		break;
 	case MST_CP_LUNAR_ORBIT24: //Map Update 10 to TEI
-		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, rtcc->GETEval2(rtcc->calcParams.TEI), 69, MST_CP_TRANSEARTH1);
+		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, mcc_calcs.GETEval(rtcc->calcParams.TEI), 69, MST_CP_TRANSEARTH1);
 		break;
 	case MST_CP_TRANSEARTH1: //TEI to ENTRY REFSMMAT
-		if (rtcc->GETEval2(rtcc->calcParams.TEI && MissionPhase == MMST_LUNAR_ORBIT))
+		if (mcc_calcs.GETEval(rtcc->calcParams.TEI && MissionPhase == MMST_LUNAR_ORBIT))
 		{
 			MissionPhase = MMST_TE_COAST;
 		}
-		if (rtcc->GETEval2(rtcc->calcParams.TEI + 45 * 60))
+		if (mcc_calcs.GETEval(rtcc->calcParams.TEI + 45 * 60))
 		{
 			SlowIfDesired();
 			setState(MST_CP_TRANSEARTH2);
 		}
 		break;
 	case MST_CP_TRANSEARTH2: //ENTRY REFSMMAT to MCC5 Update
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TEI + 13.5 * 3600.0), 202, MST_CP_TRANSEARTH3);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TEI + 13.5 * 3600.0), 202, MST_CP_TRANSEARTH3);
 		break;
 	case MST_CP_TRANSEARTH3: //MCC5 Update to MCC6 Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TEI + 31.5 * 3600.0), 203, MST_CP_TRANSEARTH4, rtcc->calcParams.TEI + 37.0*3600.0 > rtcc->calcParams.EI - 2.0*3600.0, rtcc->GETEval2(rtcc->calcParams.EI - 3.5 * 3600.0), MST_CP_TRANSEARTH6);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TEI + 31.5 * 3600.0), 203, MST_CP_TRANSEARTH4, rtcc->calcParams.TEI + 37.0*3600.0 > rtcc->calcParams.EI - 2.0*3600.0, mcc_calcs.GETEval(rtcc->calcParams.EI - 3.5 * 3600.0), MST_CP_TRANSEARTH6);
 		break;
 	case MST_CP_TRANSEARTH4: //MCC6 Update to Prel. MCC7 Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.EI - 15.0 * 3600.0), 204, MST_CP_TRANSEARTH5, rtcc->calcParams.TEI + 34.0*3600.0 > rtcc->calcParams.EI - 15.0*3600.0, rtcc->GETEval2(rtcc->calcParams.EI - 3.5 * 3600.0), MST_CP_TRANSEARTH6);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.EI - 15.0 * 3600.0), 204, MST_CP_TRANSEARTH5, rtcc->calcParams.TEI + 34.0*3600.0 > rtcc->calcParams.EI - 15.0*3600.0, mcc_calcs.GETEval(rtcc->calcParams.EI - 3.5 * 3600.0), MST_CP_TRANSEARTH6);
 		break;
 	case MST_CP_TRANSEARTH5: //Prel. MCC7 Update to MCC7 Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.EI - 3.5 * 3600.0), 205, MST_CP_TRANSEARTH6);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.EI - 3.5 * 3600.0), 205, MST_CP_TRANSEARTH6);
 		break;
 	case MST_CP_TRANSEARTH6: //MCC7 Update to Prel. Entry PAD
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, StateTime > 5 * 60, 206, MST_CP_TRANSEARTH7);
 		break;
 	case MST_CP_TRANSEARTH7: //Prel. Entry PAD to Final Entry PAD
-		UpdateMacro(UTP_PADONLY, PT_AP11ENT, rtcc->GETEval2(rtcc->calcParams.EI - 45.0*60.0), 207, MST_CP_TRANSEARTH8);
+		UpdateMacro(UTP_PADONLY, PT_AP11ENT, mcc_calcs.GETEval(rtcc->calcParams.EI - 45.0*60.0), 207, MST_CP_TRANSEARTH8);
 		break;
 	case MST_CP_TRANSEARTH8: //Final Entry PAD to Separation
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11ENT, cm->GetStage() == CM_STAGE, 208, MST_ENTRY);
@@ -273,7 +273,7 @@ void MCC::MissionSequence_C_Prime()
 			switch (SubState) {
 			case 0:
 			{
-				if (rtcc->GETEval2(rtcc->calcParams.TEI))
+				if (mcc_calcs.GETEval(rtcc->calcParams.TEI))
 				{
 					setSubState(1);
 				}
@@ -295,7 +295,7 @@ void MCC::MissionSequence_C_Prime()
 				break;
 			case 2:
 			{
-				if (rtcc->GETEval2(rtcc->calcParams.EI - 3.5 * 60 * 60))
+				if (mcc_calcs.GETEval(rtcc->calcParams.EI - 3.5 * 60 * 60))
 				{
 					SlowIfDesired();
 					setState(MST_CP_TRANSEARTH6);
@@ -304,7 +304,7 @@ void MCC::MissionSequence_C_Prime()
 			break;
 			case 3:
 			{
-				if (rtcc->GETEval2(rtcc->calcParams.TEI + 4.0 * 60 * 60))
+				if (mcc_calcs.GETEval(rtcc->calcParams.TEI + 4.0 * 60 * 60))
 				{
 					SlowIfDesired();
 					setSubState(4);
@@ -373,7 +373,7 @@ void MCC::MissionSequence_C_Prime()
 				}
 				break;
 			case 10: // Await burn
-				if (rtcc->GETEval2(rtcc->calcParams.EI - 3.5 * 60 * 60))
+				if (mcc_calcs.GETEval(rtcc->calcParams.EI - 3.5 * 60 * 60))
 				{
 					SlowIfDesired();
 					setState(MST_CP_TRANSEARTH6);
@@ -388,7 +388,7 @@ void MCC::MissionSequence_C_Prime()
 			case 12:
 			{
 				//Wait for 10 minutes so the burn is over, then calculate Pericynthion time for return trajectory
-				if (rtcc->GETEval2(rtcc->calcParams.TEI + 10.0*60.0))
+				if (mcc_calcs.GETEval(rtcc->calcParams.TEI + 10.0*60.0))
 				{
 					EphemerisData sv = rtcc->StateVectorCalcEphem(rtcc->calcParams.src);
 					double dt = OrbMech::timetoperi(sv.R, sv.V, OrbMech::mu_Moon);
@@ -399,7 +399,7 @@ void MCC::MissionSequence_C_Prime()
 			}
 			case 13: //Flyby, go to nominal TEC procedures
 			{
-				if (rtcc->GETEval2(rtcc->calcParams.LOI + 45.0*60.0) && rtcc->GETEval2(rtcc->calcParams.TEI + 45.0*60.0))
+				if (mcc_calcs.GETEval(rtcc->calcParams.LOI + 45.0*60.0) && mcc_calcs.GETEval(rtcc->calcParams.TEI + 45.0*60.0))
 				{
 					rtcc->calcParams.TEI = rtcc->calcParams.LOI;
 					setState(MST_CP_TRANSEARTH1);
@@ -410,7 +410,7 @@ void MCC::MissionSequence_C_Prime()
 		}
 		else if (AbortMode == 7) //Lunar Orbit
 		{
-			if (rtcc->GETEval2(rtcc->calcParams.TEI))
+			if (mcc_calcs.GETEval(rtcc->calcParams.TEI))
 			{
 				setState(MST_CP_TRANSEARTH1);
 			}

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_D.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_D.cpp
@@ -41,10 +41,10 @@ void MCC::MissionSequence_D()
 	switch (MissionState)
 	{
 	case MST_D_INSERTION:	//SV Update to Separation
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(3.0 * 60.0 * 60.0 + 15.0 * 60.0), 7, MST_D_DAY1SVUPDATE);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(3.0 * 60.0 * 60.0 + 15.0 * 60.0), 7, MST_D_DAY1SVUPDATE);
 		break;
 	case MST_D_DAY1SVUPDATE:
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(4 * 60 * 60 + 6 * 60), 2, MST_D_SEPARATION);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(4 * 60 * 60 + 6 * 60), 2, MST_D_SEPARATION);
 		break;
 	case MST_D_SEPARATION:	//Separation to SPS-1
 
@@ -57,7 +57,7 @@ void MCC::MissionSequence_D()
 			break;
 		case 1:
 
-			if (SubStateTime > 5.0*60.0 && rtcc->GETEval2(4 * 60 * 60 + 25 * 60))
+			if (SubStateTime > 5.0*60.0 && mcc_calcs.GETEval(4 * 60 * 60 + 25 * 60))
 			{
 				if (sivb == NULL)
 				{
@@ -89,7 +89,7 @@ void MCC::MissionSequence_D()
 			}
 			break;
 		case 3:
-			if (rtcc->GETEval2(4 * 60 * 60 + 50 * 60))
+			if (mcc_calcs.GETEval(4 * 60 * 60 + 50 * 60))
 			{
 				SlowIfDesired();
 				setState(MST_D_DAY1STATE1);
@@ -98,265 +98,265 @@ void MCC::MissionSequence_D()
 		}
 		break;
 	case MST_D_DAY1STATE1:	//SPS-1 to Daylight Star Check
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(6 * 60 * 60 + 15 * 60), 10, MST_D_DAY1STATE2);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(6 * 60 * 60 + 15 * 60), 10, MST_D_DAY1STATE2);
 		break;
 	case MST_D_DAY1STATE2: //Daylight Star Check to SV Update
-		UpdateMacro(UTP_PADONLY, PT_STARCHKPAD, rtcc->GETEval2(7 * 60 * 60 + 20 * 60), 9, MST_D_DAY1STATE3);
+		UpdateMacro(UTP_PADONLY, PT_STARCHKPAD, mcc_calcs.GETEval(7 * 60 * 60 + 20 * 60), 9, MST_D_DAY1STATE3);
 		break;
 	case MST_D_DAY1STATE3: //SV Update to Block Data 2
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(8 * 60 * 60 + 27 * 60), 2, MST_D_DAY1STATE4);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(8 * 60 * 60 + 27 * 60), 2, MST_D_DAY1STATE4);
 		break;
 	case MST_D_DAY1STATE4: //Block Data 2 to Block Data 3
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(19 * 60 * 60 + 15 * 60), 11, MST_D_DAY2STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(19 * 60 * 60 + 15 * 60), 11, MST_D_DAY2STATE1);
 		break;
 	case MST_D_DAY2STATE1: //Block Data 3 to SPS-2 Calculation
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(20 * 60 * 60 + 37 * 60), 12, MST_D_DAY2STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(20 * 60 * 60 + 37 * 60), 12, MST_D_DAY2STATE2);
 		break;
 	case MST_D_DAY2STATE2: //SPS-2 Calculation to SPS-2 Update
 		UpdateMacro(UTP_NONE, PT_NONE, true, 13, MST_D_DAY2STATE3);
 		break;
 	case MST_D_DAY2STATE3: //SPS-2 Update to SPS-3 Calculation
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(22 * 60 * 60 + 25 * 60), 100, MST_D_DAY2STATE4);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(22 * 60 * 60 + 25 * 60), 100, MST_D_DAY2STATE4);
 		break;
 	case MST_D_DAY2STATE4: //SPS-3 Calculation to SPS-3 Update
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(23 * 60 * 60 + 55 * 60), 14, MST_D_DAY2STATE5);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(23 * 60 * 60 + 55 * 60), 14, MST_D_DAY2STATE5);
 		break;
 	case MST_D_DAY2STATE5: //SPS-3 Update to SPS-4 Calculation
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(25 * 60 * 60 + 30 * 60), 101, MST_D_DAY2STATE6);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(25 * 60 * 60 + 30 * 60), 101, MST_D_DAY2STATE6);
 		break;
 	case MST_D_DAY2STATE6: //SPS-4 Calculation to SPS-4 Update
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(26 * 60 * 60 + 50 * 60), 15, MST_D_DAY2STATE7);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(26 * 60 * 60 + 50 * 60), 15, MST_D_DAY2STATE7);
 		break;
 	case MST_D_DAY2STATE7: //SPS-4 to SV Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(28 * 60 * 60 + 50 * 60), 102, MST_D_DAY2STATE8);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(28 * 60 * 60 + 50 * 60), 102, MST_D_DAY2STATE8);
 		break;
 	case MST_D_DAY2STATE8: //SV Update to Block Data 4
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(28 * 60 * 60 + 55 * 60), 2, MST_D_DAY2STATE9);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(28 * 60 * 60 + 55 * 60), 2, MST_D_DAY2STATE9);
 		break;
 	case MST_D_DAY2STATE9: //Block Data 4 to Block Data 5
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(40 * 60 * 60 + 10 * 60), 16, MST_D_DAY3STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(40 * 60 * 60 + 10 * 60), 16, MST_D_DAY3STATE1);
 		break;
 	case MST_D_DAY3STATE1: //Block Data 5 to CMC Docked DPS Burn Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(41 * 60 * 60 + 10 * 60), 17, MST_D_DAY3STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(41 * 60 * 60 + 10 * 60), 17, MST_D_DAY3STATE2);
 		break;
 	case MST_D_DAY3STATE2: //CMC Docked DPS Burn Update to LM AOT STAR OBS PAD
 		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, true, 18, MST_D_DAY3STATE3);
 		break;
 	case MST_D_DAY3STATE3: //LM AOT STAR OBS PAD to Block Data 6
-		UpdateMacro(UTP_PADONLY, PT_AP9AOTSTARPAD, rtcc->GETEval2(47 * 60 * 60 + 10 * 60), 19, MST_D_DAY3STATE5);
+		UpdateMacro(UTP_PADONLY, PT_AP9AOTSTARPAD, mcc_calcs.GETEval(47 * 60 * 60 + 10 * 60), 19, MST_D_DAY3STATE5);
 		break;
 	case MST_D_DAY3STATE5: //Block Data 6 to LM DAP PAD
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(47 * 3600 + 50 * 60), 20, MST_D_DAY3STATE6);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(47 * 3600 + 50 * 60), 20, MST_D_DAY3STATE6);
 		break;
 	case MST_D_DAY3STATE6: //LM DAP PAD to CMC state vector updates
-		UpdateMacro(UTP_PADONLY, PT_AP10DAPDATA, rtcc->GETEval2(48 * 60 * 60), 8, MST_D_DAY3STATE7);
+		UpdateMacro(UTP_PADONLY, PT_AP10DAPDATA, mcc_calcs.GETEval(48 * 60 * 60), 8, MST_D_DAY3STATE7);
 		break;
 	case MST_D_DAY3STATE7: //CMC state vector updates to LGC Docked DPS Burn Update
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(48 * 60 * 60 + 10 * 60), 3, MST_D_DAY3STATE8);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(48 * 60 * 60 + 10 * 60), 3, MST_D_DAY3STATE8);
 		break;
 	case MST_D_DAY3STATE8: //LGC Docked DPS Burn Update to LGC Gyro Torquing Angles
 		UpdateMacro(UTP_PADWITHLGCUPLINK, PT_AP11LMMNV, SubStateTime > 3.0*60.0, 21, MST_D_DAY3STATE9);
 		break;
 	case MST_D_DAY3STATE9: //LGC Gyro Torquing Angles to LGC Gyro Torquing Angles
-		UpdateMacro(UTP_PADONLY, PT_TORQANG, rtcc->GETEval2(49 * 60 * 60 + 5 * 60), 22, MST_D_DAY3STATE10);
+		UpdateMacro(UTP_PADONLY, PT_TORQANG, mcc_calcs.GETEval(49 * 60 * 60 + 5 * 60), 22, MST_D_DAY3STATE10);
 		break;
 	case MST_D_DAY3STATE10: //LGC Gyro Torquing Angles to SPS-5 Calculation
-		UpdateMacro(UTP_PADONLY, PT_TORQANG, rtcc->GETEval2(52 * 60 * 60 + 50 * 60), 22, MST_D_DAY3STATE11);
+		UpdateMacro(UTP_PADONLY, PT_TORQANG, mcc_calcs.GETEval(52 * 60 * 60 + 50 * 60), 22, MST_D_DAY3STATE11);
 		break;
 	case MST_D_DAY3STATE11: //SPS-5 Calculation to SPS-5 Update
 		UpdateMacro(UTP_NONE, PT_NONE, true, 23, MST_D_DAY3STATE12);
 		break;
 	case MST_D_DAY3STATE12: //SPS-5 Update to SV Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(55 * 60 * 60 + 30 * 60), 103, MST_D_DAY3STATE13);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(55 * 60 * 60 + 30 * 60), 103, MST_D_DAY3STATE13);
 		break;
 	case MST_D_DAY3STATE13: //SV Update to Block Data 7
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(56 * 60 * 60 + 40 * 60), 2, MST_D_DAY3STATE14);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(56 * 60 * 60 + 40 * 60), 2, MST_D_DAY3STATE14);
 		break;
 	case MST_D_DAY3STATE14: //Block Data 7 to Block Data 8
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(67 * 60 * 60 + 30 * 60), 24, MST_D_DAY4STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(67 * 60 * 60 + 30 * 60), 24, MST_D_DAY4STATE1);
 		break;
 	case MST_D_DAY4STATE1: //Block Data 8 to EVA REFSMMAT Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(69 * 60 * 60 + 55 * 60), 25, MST_D_DAY4STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(69 * 60 * 60 + 55 * 60), 25, MST_D_DAY4STATE2);
 		break;
 	case MST_D_DAY4STATE2: //EVA REFSMMAT Update to state vector update
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(77 * 60 * 60 + 45 * 60), 26, MST_D_DAY4STATE3);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(77 * 60 * 60 + 45 * 60), 26, MST_D_DAY4STATE3);
 		break;
 	case MST_D_DAY4STATE3: //State vector update to Block Data 9
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(78 * 60 * 60 + 10 * 60), 2, MST_D_DAY4STATE4);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(78 * 60 * 60 + 10 * 60), 2, MST_D_DAY4STATE4);
 		break;
 	case MST_D_DAY4STATE4: //Block Data 9 to Block Data 10
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(87 * 60 * 60 + 15 * 60), 27, MST_D_DAY5STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(87 * 60 * 60 + 15 * 60), 27, MST_D_DAY5STATE1);
 		break;
 	case MST_D_DAY5STATE1: //Block Data 10 to CSM Rendezvous REFSMMAT update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(89 * 60 * 60 + 5 * 60), 28, MST_D_DAY5STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(89 * 60 * 60 + 5 * 60), 28, MST_D_DAY5STATE2);
 		break;
 	case MST_D_DAY5STATE2: //CSM Rendezvous REFSMMAT update to LM DAP update
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(91 * 60 * 60), 29, MST_D_DAY5STATE3);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(91 * 60 * 60), 29, MST_D_DAY5STATE3);
 		break;
 	case MST_D_DAY5STATE3: //LM DAP update to LM Rendezvous REFSMMAT update
-		UpdateMacro(UTP_PADONLY, PT_AP10DAPDATA, rtcc->GETEval2(91 * 60 * 60 + 10 * 60), 6, MST_D_DAY5STATE4);
+		UpdateMacro(UTP_PADONLY, PT_AP10DAPDATA, mcc_calcs.GETEval(91 * 60 * 60 + 10 * 60), 6, MST_D_DAY5STATE4);
 		break;
 	case MST_D_DAY5STATE4: //LM Rendezvous REFSMMAT update to gyro torquing angles update
-		UpdateMacro(UTP_PADWITHLGCUPLINK, PT_AP7NAV, rtcc->GETEval2(91 * 60 * 60 + 15 * 60), 30, MST_D_DAY5STATE5);
+		UpdateMacro(UTP_PADWITHLGCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(91 * 60 * 60 + 15 * 60), 30, MST_D_DAY5STATE5);
 		break;
 	case MST_D_DAY5STATE5: //Gyro torquing angles update to Phasing update
-		UpdateMacro(UTP_PADONLY, PT_TORQANG, rtcc->GETEval2(92 * 60 * 60 + 5 * 60), 31, MST_D_DAY5STATE6);
+		UpdateMacro(UTP_PADONLY, PT_TORQANG, mcc_calcs.GETEval(92 * 60 * 60 + 5 * 60), 31, MST_D_DAY5STATE6);
 		break;
 	case MST_D_DAY5STATE6: //Phasing update to TPI0 update
-		UpdateMacro(UTP_PADONLY, PT_AP11LMMNV, rtcc->GETEval2(94 * 60 * 60 + 30 * 60), 32, MST_D_DAY5STATE7);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMMNV, mcc_calcs.GETEval(94 * 60 * 60 + 30 * 60), 32, MST_D_DAY5STATE7);
 		break;
 	case MST_D_DAY5STATE7: //TPI0 update to Insertion update
-		UpdateMacro(UTP_PADONLY, PT_AP9LMTPI, rtcc->GETEval2(95 * 60 * 60 + 10 * 60), 33, MST_D_DAY5STATE8);
+		UpdateMacro(UTP_PADONLY, PT_AP9LMTPI, mcc_calcs.GETEval(95 * 60 * 60 + 10 * 60), 33, MST_D_DAY5STATE8);
 		break;
 	case MST_D_DAY5STATE8: //Insertion update to CSI update
-		UpdateMacro(UTP_PADONLY, PT_AP11LMMNV, rtcc->GETEval2(rtcc->calcParams.Insertion + 10.0*60.0), 34, MST_D_DAY5STATE9);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMMNV, mcc_calcs.GETEval(rtcc->calcParams.Insertion + 10.0*60.0), 34, MST_D_DAY5STATE9);
 		break;
 	case MST_D_DAY5STATE9: //CSI update to CDH update
-		UpdateMacro(UTP_PADONLY, PT_AP10CSI, rtcc->GETEval2(rtcc->calcParams.CSI + 15.0*60.0), 35, MST_D_DAY5STATE10);
+		UpdateMacro(UTP_PADONLY, PT_AP10CSI, mcc_calcs.GETEval(rtcc->calcParams.CSI + 15.0*60.0), 35, MST_D_DAY5STATE10);
 		break;
 	case MST_D_DAY5STATE10: //CDH update to TPI update
-		UpdateMacro(UTP_PADONLY, PT_AP9LMCDH, rtcc->GETEval2(rtcc->calcParams.CDH + 15.0*60.0), 36, MST_D_DAY5STATE11);
+		UpdateMacro(UTP_PADONLY, PT_AP9LMCDH, mcc_calcs.GETEval(rtcc->calcParams.CDH + 15.0*60.0), 36, MST_D_DAY5STATE11);
 		break;
 	case MST_D_DAY5STATE11: //TPI update to LM realign attitude update
-		UpdateMacro(UTP_PADONLY, PT_AP9LMTPI, rtcc->GETEval2(99.0*3600.0 + 15.0*60.0), 37, MST_D_DAY5STATE12);
+		UpdateMacro(UTP_PADONLY, PT_AP9LMTPI, mcc_calcs.GETEval(99.0*3600.0 + 15.0*60.0), 37, MST_D_DAY5STATE12);
 		break;
 	case MST_D_DAY5STATE12: //LM realign attitude update to LM realign attitude update
 		UpdateMacro(UTP_PADONLY, PT_AP9AOTSTARPAD, SubStateTime > 3.0*60.0, 38, MST_D_DAY5STATE13);
 		break;
 	case MST_D_DAY5STATE13: //LM realign attitude update to LM burn to depletion update
-		UpdateMacro(UTP_PADONLY, PT_AP9AOTSTARPAD, rtcc->GETEval2(99.0*3600.0 + 55.0*60.0), 39, MST_D_DAY5STATE14);
+		UpdateMacro(UTP_PADONLY, PT_AP9AOTSTARPAD, mcc_calcs.GETEval(99.0*3600.0 + 55.0*60.0), 39, MST_D_DAY5STATE14);
 		break;
 	case MST_D_DAY5STATE14: //LM burn to depletion update to LM jettison attitude update
 		UpdateMacro(UTP_PADWITHLGCUPLINK, PT_AP11LMMNV, SubStateTime > 3.0*60.0, 40, MST_D_DAY5STATE15);
 		break;
 	case MST_D_DAY5STATE15: //LM jettison attitude update to Block Data 11
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(100.0*3600.0 + 35.0*60.0), 41, MST_D_DAY5STATE16);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(100.0*3600.0 + 35.0*60.0), 41, MST_D_DAY5STATE16);
 		break;
 	case MST_D_DAY5STATE16: //Block Data 11 to post jettison sep maneuver
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(101.0*3600.0 + 10.0*60.0), 42, MST_D_DAY5STATE17);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(101.0*3600.0 + 10.0*60.0), 42, MST_D_DAY5STATE17);
 		break;
 	case MST_D_DAY5STATE17: //Post jettison sep maneuver to state vector update
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(103.0*3600.0 + 5.0*60.0), 75, MST_D_DAY5STATE18);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(103.0*3600.0 + 5.0*60.0), 75, MST_D_DAY5STATE18);
 		break;
 	case MST_D_DAY5STATE18: //State vector update to Block Data 12
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(104.0*3600.0 + 15.0*60.0), 2, MST_D_DAY5STATE19);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(104.0*3600.0 + 15.0*60.0), 2, MST_D_DAY5STATE19);
 		break;
 	case MST_D_DAY5STATE19: //Block Data 12 to Block Data 13
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(114.0*3600.0 + 55.0*60.0), 43, MST_D_DAY6STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(114.0*3600.0 + 55.0*60.0), 43, MST_D_DAY6STATE1);
 		break;
 	case MST_D_DAY6STATE1: //Block Data 13 to SPS-6 Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(119.0*3600.0 + 40.0*60.0), 44, MST_D_DAY6STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(119.0*3600.0 + 40.0*60.0), 44, MST_D_DAY6STATE2);
 		break;
 	case MST_D_DAY6STATE2: //SPS-6 Update to S065 Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(123.0*3600.0 + 30.0*60.0), 45, MST_D_DAY6STATE3);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(123.0*3600.0 + 30.0*60.0), 45, MST_D_DAY6STATE3);
 		break;
 	case MST_D_DAY6STATE3: //S065 Update to S065 Update
-		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, rtcc->GETEval2(125.0*3600.0 + 5.0*60.0), 46, MST_D_DAY6STATE4);
+		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, mcc_calcs.GETEval(125.0*3600.0 + 5.0*60.0), 46, MST_D_DAY6STATE4);
 		break;
 	case MST_D_DAY6STATE4: //S065 Update to state vector update
-		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, rtcc->GETEval2(126.0*3600.0 + 50.0*60.0), 47, MST_D_DAY6STATE5);
+		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, mcc_calcs.GETEval(126.0*3600.0 + 50.0*60.0), 47, MST_D_DAY6STATE5);
 		break;
 	case MST_D_DAY6STATE5: //State vector update to Block Data 14
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(128.0*3600.0 + 35.0*60.0), 2, MST_D_DAY6STATE6);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(128.0*3600.0 + 35.0*60.0), 2, MST_D_DAY6STATE6);
 		break;
 	case MST_D_DAY6STATE6: //Block Data 14 to Block Data 15
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(140.0*3600.0 + 5.0*60.0), 48, MST_D_DAY7STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(140.0*3600.0 + 5.0*60.0), 48, MST_D_DAY7STATE1);
 		break;
 	case MST_D_DAY7STATE1: //Block Data 15 to Landmark Tracking Align update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(141.0*3600.0 + 35.0*60.0), 49, MST_D_DAY7STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(141.0*3600.0 + 35.0*60.0), 49, MST_D_DAY7STATE2);
 		break;
 	case MST_D_DAY7STATE2: //Landmark Tracking Align update to Landmark Tracking Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_GENERIC, rtcc->GETEval2(142.0*3600.0 + 32.0*60.0), 50, MST_D_DAY7STATE3);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_GENERIC, mcc_calcs.GETEval(142.0*3600.0 + 32.0*60.0), 50, MST_D_DAY7STATE3);
 		break;
 	case MST_D_DAY7STATE3: //Landmark tracking update to landmark tracking update
-		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, rtcc->GETEval2(143.0*3600.0 + 15.0*60.0), 51, MST_D_DAY7STATE4);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, mcc_calcs.GETEval(143.0*3600.0 + 15.0*60.0), 51, MST_D_DAY7STATE4);
 		break;
 	case MST_D_DAY7STATE4: //Landmark tracking update to state vector update
-		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, rtcc->GETEval2(144.0*3600.0 + 5.0*60.0), 52, MST_D_DAY7STATE5);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, mcc_calcs.GETEval(144.0*3600.0 + 5.0*60.0), 52, MST_D_DAY7STATE5);
 		break;
 	case MST_D_DAY7STATE5: //State vector update to landmark tracking update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(144.0*3600.0 + 35.0*60.0), 2, MST_D_DAY7STATE6);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(144.0*3600.0 + 35.0*60.0), 2, MST_D_DAY7STATE6);
 		break;
 	case MST_D_DAY7STATE6: //Landmark tracking update to state vector update
-		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, rtcc->GETEval2(145.0*3600.0 + 35.0*60.0), 53, MST_D_DAY7STATE7);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, mcc_calcs.GETEval(145.0*3600.0 + 35.0*60.0), 53, MST_D_DAY7STATE7);
 		break;
 	case MST_D_DAY7STATE7: //State vector update to landmark tracking update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(146.0*3600.0 + 5.0*60.0), 2, MST_D_DAY7STATE8);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(146.0*3600.0 + 5.0*60.0), 2, MST_D_DAY7STATE8);
 		break;
 	case MST_D_DAY7STATE8: //Landmark tracking update to state vector update
-		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, rtcc->GETEval2(147.0*3600.0 + 5.0*60.0), 54, MST_D_DAY7STATE9);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, mcc_calcs.GETEval(147.0*3600.0 + 5.0*60.0), 54, MST_D_DAY7STATE9);
 		break;
 	case MST_D_DAY7STATE9: //State vector update to state vector update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(148.0*3600.0 + 50.0*60.0), 2, MST_D_DAY7STATE10);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(148.0*3600.0 + 50.0*60.0), 2, MST_D_DAY7STATE10);
 		break;
 	case MST_D_DAY7STATE10: //State vector update to Block Data 16
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(151.0*3600.0 + 30.0*60.0), 2, MST_D_DAY7STATE11);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(151.0*3600.0 + 30.0*60.0), 2, MST_D_DAY7STATE11);
 		break;
 	case MST_D_DAY7STATE11: //Block Data 16 to Block Data 17
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(162.0*3600.0 + 5.0*60.0), 55, MST_D_DAY8STATE1);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(162.0*3600.0 + 5.0*60.0), 55, MST_D_DAY8STATE1);
 		break;
 	case MST_D_DAY8STATE1: //Block Data 17 to SPS-7 Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(168.0*3600.0 + 7.0*60.0), 56, MST_D_DAY8STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(168.0*3600.0 + 7.0*60.0), 56, MST_D_DAY8STATE2);
 		break;
 	case MST_D_DAY8STATE2: //SPS-7 Update to S065 Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(170.0*3600.0 + 35.0*60.0), 57, MST_D_DAY8STATE3);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(170.0*3600.0 + 35.0*60.0), 57, MST_D_DAY8STATE3);
 		break;
 	case MST_D_DAY8STATE3: //S065 Update to S065 Update
-		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, rtcc->GETEval2(172.0*3600.0 + 20.0*60.0), 58, MST_D_DAY8STATE4);
+		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, mcc_calcs.GETEval(172.0*3600.0 + 20.0*60.0), 58, MST_D_DAY8STATE4);
 		break;
 	case MST_D_DAY8STATE4: //S065 Update to Block Data 18
 		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, SubStateTime > 3.0*60.0, 59, MST_D_DAY8STATE5);
 		break;
 	case MST_D_DAY8STATE5: //Block Data 18 to state vector update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(174.0*3600.0), 60, MST_D_DAY8STATE6);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(174.0*3600.0), 60, MST_D_DAY8STATE6);
 		break;
 	case MST_D_DAY8STATE6: //State vector update to Block Data 19
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(185.0*3600.0 + 10.0*60.0), 2, MST_D_DAY9STATE1);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(185.0*3600.0 + 10.0*60.0), 2, MST_D_DAY9STATE1);
 		break;
 	case MST_D_DAY9STATE1: //Block Data 18 to T Align Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(187.0*3600.0 + 30.0*60.0), 61, MST_D_DAY9STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(187.0*3600.0 + 30.0*60.0), 61, MST_D_DAY9STATE2);
 		break;
 	case MST_D_DAY9STATE2: //T Align Update to S065 Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_GENERIC, rtcc->GETEval2(189.0*3600.0 + 50.0*60.0), 62, MST_D_DAY9STATE3);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_GENERIC, mcc_calcs.GETEval(189.0*3600.0 + 50.0*60.0), 62, MST_D_DAY9STATE3);
 		break;
 	case MST_D_DAY9STATE3: //S065 Update to S065 Update
-		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, rtcc->GETEval2(191.0*3600.0 + 30.0*60.0), 63, MST_D_DAY9STATE4);
+		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, mcc_calcs.GETEval(191.0*3600.0 + 30.0*60.0), 63, MST_D_DAY9STATE4);
 		break;
 	case MST_D_DAY9STATE4: //S065 Update to HGA Test REFSMMAT
-		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, rtcc->GETEval2(192.0*3600.0 + 20.0*60.0), 64, MST_D_DAY9STATE5);
+		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, mcc_calcs.GETEval(192.0*3600.0 + 20.0*60.0), 64, MST_D_DAY9STATE5);
 		break;
 	case MST_D_DAY9STATE5: //HGA Test REFSMMAT to Block Data 20
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_GENERIC, rtcc->GETEval2(196.0*3600.0 + 45.0*60), 80, MST_D_DAY9STATE6);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_GENERIC, mcc_calcs.GETEval(196.0*3600.0 + 45.0*60), 80, MST_D_DAY9STATE6);
 		break;
 	case MST_D_DAY9STATE6: //Block Data 20 to state vector update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(198.0*3600.0 + 30.0*60.0), 65, MST_D_DAY9STATE7);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(198.0*3600.0 + 30.0*60.0), 65, MST_D_DAY9STATE7);
 		break;
 	case MST_D_DAY9STATE7: //State vector update to Block Data 21
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(209.0*3600.0 + 50.0*60.0), 2, MST_D_DAY10STATE1);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(209.0*3600.0 + 50.0*60.0), 2, MST_D_DAY10STATE1);
 		break;
 	case MST_D_DAY10STATE1: //Block Data 21 to T Align Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(211.0*3600.0 + 28.0*60.0), 66, MST_D_DAY10STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(211.0*3600.0 + 28.0*60.0), 66, MST_D_DAY10STATE2);
 		break;
 	case MST_D_DAY10STATE2: //T Align Update to S065 Update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_GENERIC, rtcc->GETEval2(213.0*3600.0 + 50.0*60.0), 67, MST_D_DAY10STATE3);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_GENERIC, mcc_calcs.GETEval(213.0*3600.0 + 50.0*60.0), 67, MST_D_DAY10STATE3);
 		break;
 	case MST_D_DAY10STATE3: //S065 Update to S065 Update
-		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, rtcc->GETEval2(215.0*3600.0 + 28.0*60.0), 68, MST_D_DAY10STATE4);
+		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, mcc_calcs.GETEval(215.0*3600.0 + 28.0*60.0), 68, MST_D_DAY10STATE4);
 		break;
 	case MST_D_DAY10STATE4: //S065 Update to state vector update
-		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, rtcc->GETEval2(217.0*3600.0), 69, MST_D_DAY10STATE5);
+		UpdateMacro(UTP_PADONLY, PT_S065UPDATE, mcc_calcs.GETEval(217.0*3600.0), 69, MST_D_DAY10STATE5);
 		break;
 	case MST_D_DAY10STATE5: //State vector update to Block Data 22
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, rtcc->GETEval2(220.0*3600.0 + 48.0*60.0), 2, MST_D_DAY10STATE6);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7NAV, mcc_calcs.GETEval(220.0*3600.0 + 48.0*60.0), 2, MST_D_DAY10STATE6);
 		break;
 	case MST_D_DAY10STATE6: //Block Data 22 to CSM/LM state vector update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(221.0*3600.0 + 5.0*60.0), 70, MST_D_DAY10STATE7);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(221.0*3600.0 + 5.0*60.0), 70, MST_D_DAY10STATE7);
 		break;
 	case MST_D_DAY10STATE7: //CSM/LM state vector update to Block Data 23
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(232.0*3600.0 + 25.0*60.0), 3, MST_D_DAY11STATE1);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(232.0*3600.0 + 25.0*60.0), 3, MST_D_DAY11STATE1);
 		break;
 	case MST_D_DAY11STATE1: //Block Data 23 to Deorbit Maneuver Update
-		UpdateMacro(UTP_PADONLY, PT_AP7BLK, rtcc->GETEval2(235.0*3600.0 + 15.0*60.0), 71, MST_D_DAY11STATE2);
+		UpdateMacro(UTP_PADONLY, PT_AP7BLK, mcc_calcs.GETEval(235.0*3600.0 + 15.0*60.0), 71, MST_D_DAY11STATE2);
 		break;
 	case MST_D_DAY11STATE2: //Deorbit Maneuver Update to Entry PAD Update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, SubStateTime > 5.0*60.0, 72, MST_D_DAY11STATE3);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_F.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_F.cpp
@@ -40,7 +40,7 @@ void MCC::MissionSequence_F()
 {
 	switch (MissionState) {
 	case MST_F_INSERTION: //Ground liftoff time update to TLI Simulation
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(1.0*3600.0 + 40.0*60.0), 1, MST_F_EPO1);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(1.0*3600.0 + 40.0*60.0), 1, MST_F_EPO1);
 		break;
 	case MST_F_EPO1: //TLI Simulation to TLI+90 PAD
 		UpdateMacro(UTP_NONE, PT_NONE, true, 2, MST_F_EPO2);
@@ -52,13 +52,13 @@ void MCC::MissionSequence_F()
 		UpdateMacro(UTP_PADONLY, PT_P37PAD, SubStateTime > 3.0*60.0, 4, MST_F_EPO4);
 		break;
 	case MST_F_EPO4: //TLI PAD to TLI Evaluation
-		UpdateMacro(UTP_PADONLY, PT_TLIPAD, rtcc->GETEval2(rtcc->calcParams.TLI + 18.0), 5, MST_F_TRANSLUNAR1);
+		UpdateMacro(UTP_PADONLY, PT_TLIPAD, mcc_calcs.GETEval(rtcc->calcParams.TLI + 18.0), 5, MST_F_TRANSLUNAR1);
 		break;
 	case MST_F_TRANSLUNAR1: //TLI Evaluation to Block Data 1
-		UpdateMacro(UTP_NONE, PT_NONE, true, 6, MST_F_TRANSLUNAR2, scrubbed, rtcc->GETEval2(3.0*3600.0 + 10.0*60.0), MST_F_EPO1);
+		UpdateMacro(UTP_NONE, PT_NONE, true, 6, MST_F_TRANSLUNAR2, scrubbed, mcc_calcs.GETEval(3.0*3600.0 + 10.0*60.0), MST_F_EPO1);
 		break;
 	case MST_F_TRANSLUNAR2:
-		if (rtcc->GETEval2(rtcc->calcParams.TLI))
+		if (mcc_calcs.GETEval(rtcc->calcParams.TLI))
 		{
 			addMessage("TLI");
 			MissionPhase = MMST_TL_COAST;
@@ -78,14 +78,14 @@ void MCC::MissionSequence_F()
 		}
 		break;
 	case MST_F_TRANSLUNAR4: //
-		if (rtcc->GETEval2(rtcc->calcParams.TLI + 55.0*60.0))
+		if (mcc_calcs.GETEval(rtcc->calcParams.TLI + 55.0*60.0))
 		{
 			SlowIfDesired();
 			setState(MST_F_TRANSLUNAR5);
 		}
 		break;
 	case MST_F_TRANSLUNAR5: //Evasive Maneuver to TB8 enable
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 3600.0 + 30.0*60.0), 7, MST_F_TRANSLUNAR6);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 3600.0 + 30.0*60.0), 7, MST_F_TRANSLUNAR6);
 		break;
 	case MST_F_TRANSLUNAR6:  //TB8 enable to Block Data 1
 		switch (SubState) {
@@ -127,7 +127,7 @@ void MCC::MissionSequence_F()
 		}
 		break;
 		case 3:
-			if (rtcc->GETEval2(rtcc->calcParams.TLI + 2.0*3600.0 + 30.0*60.0))
+			if (mcc_calcs.GETEval(rtcc->calcParams.TLI + 2.0*3600.0 + 30.0*60.0))
 			{
 				SlowIfDesired();
 				setState(MST_F_TRANSLUNAR7);
@@ -136,43 +136,43 @@ void MCC::MissionSequence_F()
 		}
 		break;
 	case MST_F_TRANSLUNAR7: //Block Data 1 to MCC-1 Calculation
-		UpdateMacro(UTP_PADONLY, PT_P37PAD, rtcc->GETEval2(rtcc->calcParams.TLI + 3.0*3600.0 + 20.0*60.0), 8, MST_F_TRANSLUNAR8);
+		UpdateMacro(UTP_PADONLY, PT_P37PAD, mcc_calcs.GETEval(rtcc->calcParams.TLI + 3.0*3600.0 + 20.0*60.0), 8, MST_F_TRANSLUNAR8);
 		break;
 	case MST_F_TRANSLUNAR8: //MCC-1 Calculation to MCC-1 Update (or PTC REFSMMAT)
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TLI + 7.0*3600.0 + 30.0*60.0), 11, MST_F_TRANSLUNAR9, scrubbed, rtcc->GETEval2(rtcc->calcParams.TLI + 4.0*3600.0 + 30.0*60.0), MST_F_TRANSLUNAR_NO_MCC1_1);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TLI + 7.0*3600.0 + 30.0*60.0), 11, MST_F_TRANSLUNAR9, scrubbed, mcc_calcs.GETEval(rtcc->calcParams.TLI + 4.0*3600.0 + 30.0*60.0), MST_F_TRANSLUNAR_NO_MCC1_1);
 		break;
 	case MST_F_TRANSLUNAR9: //MCC-1 Update to PTC REFSMMAT update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 9.0*3600.0 + 20.0*60.0), 12, MST_F_TRANSLUNAR10);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 9.0*3600.0 + 20.0*60.0), 12, MST_F_TRANSLUNAR10);
 		break;
 	case MST_F_TRANSLUNAR_NO_MCC1_1: //PTC REFSMMAT update to SV update (MCC-1 was scrubbed)
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TLI + 7.0*3600.0 + 10.0*60.0), 10, MST_F_TRANSLUNAR_NO_MCC1_2);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TLI + 7.0*3600.0 + 10.0*60.0), 10, MST_F_TRANSLUNAR_NO_MCC1_2);
 		break;
 	case MST_F_TRANSLUNAR_NO_MCC1_2: //SV update to Block Data 2 (MCC-1 was scrubbed)
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TLI + 9.0*3600.0 + 30.0*60.0), 103, MST_F_TRANSLUNAR11);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TLI + 9.0*3600.0 + 30.0*60.0), 103, MST_F_TRANSLUNAR11);
 		break;
 	case MST_F_TRANSLUNAR10: //PTC REFSMMAT to Block Data 2
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TLI + 9.0*3600.0 + 35.0*60.0), 10, MST_F_TRANSLUNAR11);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TLI + 9.0*3600.0 + 35.0*60.0), 10, MST_F_TRANSLUNAR11);
 		break;
 	case MST_F_TRANSLUNAR11: //Block Data 2 to MCC-2
-		UpdateMacro(UTP_PADONLY, PT_P37PAD, rtcc->GETEval2(rtcc->calcParams.TLI + 23.0*3600.0), 9, MST_F_TRANSLUNAR12);
+		UpdateMacro(UTP_PADONLY, PT_P37PAD, mcc_calcs.GETEval(rtcc->calcParams.TLI + 23.0*3600.0), 9, MST_F_TRANSLUNAR12);
 		break;
 	case MST_F_TRANSLUNAR12: //MCC-2 to Lunar Flyby PAD
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 30.0*3600.0 + 30.0*60.0), 13, MST_F_TRANSLUNAR13);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 30.0*3600.0 + 30.0*60.0), 13, MST_F_TRANSLUNAR13);
 		break;
 	case MST_F_TRANSLUNAR13: //Lunar Flyby PAD to State Vector update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 42.0*3600.0), 14, MST_F_TRANSLUNAR14);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 42.0*3600.0), 14, MST_F_TRANSLUNAR14);
 		break;
 	case MST_F_TRANSLUNAR14: //State Vector update to MCC-3 update
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.LOI - 23.0*3600.0 - 30.0*60.0), 103, MST_F_TRANSLUNAR15);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.LOI - 23.0*3600.0 - 30.0*60.0), 103, MST_F_TRANSLUNAR15);
 		break;
 	case MST_F_TRANSLUNAR15: //MCC-3 update to MCC-4 update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 6.0*3600.0 - 30.0*60.0), 15, MST_F_TRANSLUNAR16);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 6.0*3600.0 - 30.0*60.0), 15, MST_F_TRANSLUNAR16);
 		break;
 	case MST_F_TRANSLUNAR16: //MCC-4 update to PC+2 update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 16, MST_F_TRANSLUNAR17);
 		break;
 	case MST_F_TRANSLUNAR17: //PC+2 update to Preliminary LOI-1 update
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 4.0*3600.0 - 30.0*60.0), 17, MST_F_TRANSLUNAR18);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 4.0*3600.0 - 30.0*60.0), 17, MST_F_TRANSLUNAR18);
 		break;
 	case MST_F_TRANSLUNAR18: //Preliminary LOI-1 update to TEI-1 update
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, SubStateTime > 5.0*60.0, 20, MST_F_TRANSLUNAR19);
@@ -181,13 +181,13 @@ void MCC::MissionSequence_F()
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, SubStateTime > 5.0*60.0, 30, MST_F_TRANSLUNAR20);
 		break;
 	case MST_F_TRANSLUNAR20: //TEI-4 update to Rev 1 Map Update
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 2.0*3600.0 - 15.0*60.0), 31, MST_F_TRANSLUNAR21);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 2.0*3600.0 - 15.0*60.0), 31, MST_F_TRANSLUNAR21);
 		break;
 	case MST_F_TRANSLUNAR21: //Rev 1 Map Update to LOI-1 update
-		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, rtcc->GETEval2(rtcc->calcParams.LOI - 1.0*3600.0 - 30.0*60.0), 40, MST_F_TRANSLUNAR22);
+		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, mcc_calcs.GETEval(rtcc->calcParams.LOI - 1.0*3600.0 - 30.0*60.0), 40, MST_F_TRANSLUNAR22);
 		break;
 	case MST_F_TRANSLUNAR22: //LOI-1 update to Rev 2 Map Update
-		if (MissionPhase == MMST_TL_COAST && rtcc->GETEval2(rtcc->calcParams.LOI))
+		if (MissionPhase == MMST_TL_COAST && mcc_calcs.GETEval(rtcc->calcParams.LOI))
 		{
 			MissionPhase = MMST_LUNAR_ORBIT;
 		}
@@ -257,7 +257,7 @@ void MCC::MissionSequence_F()
 		UpdateMacro(UTP_PADONLY, PT_AP11LMMNV, SubStateTime > 2.0*60.0, 72, MST_F_LUNAR_ORBIT_DOI_DAY_14);
 		break;
 	case MST_F_LUNAR_ORBIT_DOI_DAY_14: //PDI Abort update to LGC CSM state vector update
-		UpdateMacro(UTP_PADONLY, PT_AP11LMMNV, (MoonRev >= 12 && MoonRevTime > 50.0*60.0) && rtcc->GETEval2(rtcc->calcParams.SEP + 60.0), 74, MST_F_LUNAR_ORBIT_DOI_DAY_15);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMMNV, (MoonRev >= 12 && MoonRevTime > 50.0*60.0) && mcc_calcs.GETEval(rtcc->calcParams.SEP + 60.0), 74, MST_F_LUNAR_ORBIT_DOI_DAY_15);
 		break;
 	case MST_F_LUNAR_ORBIT_DOI_DAY_15: //LGC CSM state vector update to CMC CSM+LM state vector update
 		UpdateMacro(UTP_LGCUPLINKONLY, PT_NONE, MoonRev >= 12 && MoonRevTime > 1.0*3600.0 + 10.0*60.0, 100, MST_F_LUNAR_ORBIT_DOI_DAY_16);
@@ -407,54 +407,54 @@ void MCC::MissionSequence_F()
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, SubStateTime > 3.0*60.0, 134, MST_F_LUNAR_ORBIT_LMK_TRACK_DAY_35);
 		break;
 	case MST_F_LUNAR_ORBIT_LMK_TRACK_DAY_35: //TEI map update to TV update
-		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, rtcc->GETEval2(rtcc->calcParams.TEI - 55.0*60.0), 144, MST_F_LUNAR_ORBIT_LMK_TRACK_DAY_36);
+		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, mcc_calcs.GETEval(rtcc->calcParams.TEI - 55.0*60.0), 144, MST_F_LUNAR_ORBIT_LMK_TRACK_DAY_36);
 		break;
 	case MST_F_LUNAR_ORBIT_LMK_TRACK_DAY_36: //TV update to TEI
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.TEI), 204, MST_F_TRANSEARTH_1);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.TEI), 204, MST_F_TRANSEARTH_1);
 		break;
 	case MST_F_TRANSEARTH_1: //TEI to PTC REFSMMAT
-		if (rtcc->GETEval2(rtcc->calcParams.TEI) && MissionPhase == MMST_LUNAR_ORBIT)
+		if (mcc_calcs.GETEval(rtcc->calcParams.TEI) && MissionPhase == MMST_LUNAR_ORBIT)
 		{
 			MissionPhase = MMST_TE_COAST;
 		}
-		if (rtcc->GETEval2(rtcc->calcParams.TEI + 35.0*60.0))
+		if (mcc_calcs.GETEval(rtcc->calcParams.TEI + 35.0*60.0))
 		{
 			SlowIfDesired();
 			setState(MST_F_TRANSEARTH_2);
 		}
 		break;
 	case MST_F_TRANSEARTH_2: //PTC REFSMMAT to state vector update
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TEI + 2.0*3600.0 + 40.0*60.0), 10, MST_F_TRANSEARTH_3);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TEI + 2.0*3600.0 + 40.0*60.0), 10, MST_F_TRANSEARTH_3);
 		break;
 	case MST_F_TRANSEARTH_3: //State vector update to state vector update
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TEI + 10.0*3600.0 + 15.0*60.0), 103, MST_F_TRANSEARTH_4);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TEI + 10.0*3600.0 + 15.0*60.0), 103, MST_F_TRANSEARTH_4);
 		break;
 	case MST_F_TRANSEARTH_4: //State vector update to MCC-5 update
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TEI + 14.0*3600.0 + 10.0*60.0), 103, MST_F_TRANSEARTH_5);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TEI + 14.0*3600.0 + 10.0*60.0), 103, MST_F_TRANSEARTH_5);
 		break;
 	case MST_F_TRANSEARTH_5: //MCC-5 update to preliminary MCC-6 update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TEI + 27.0*3600.0 + 20.0*60.0), 90, MST_F_TRANSEARTH_6);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TEI + 27.0*3600.0 + 20.0*60.0), 90, MST_F_TRANSEARTH_6);
 		break;
 	case MST_F_TRANSEARTH_6: //Preliminary MCC-6 update to Entry PAD update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 91, MST_F_TRANSEARTH_7);
 		break;
 	case MST_F_TRANSEARTH_7: //Entry PAD update to MCC-6 update
-		UpdateMacro(UTP_PADONLY, PT_AP11ENT, rtcc->GETEval2(rtcc->calcParams.EI - 16.0*3600.0 - 45.0*60.0), 96, MST_F_TRANSEARTH_8);
+		UpdateMacro(UTP_PADONLY, PT_AP11ENT, mcc_calcs.GETEval(rtcc->calcParams.EI - 16.0*3600.0 - 45.0*60.0), 96, MST_F_TRANSEARTH_8);
 		break;
 	case MST_F_TRANSEARTH_8: //MCC-6 update to Entry PAD update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 3.0*60.0, 92, MST_F_TRANSEARTH_9);
 		break;
 	case MST_F_TRANSEARTH_9: //Entry PAD update to MCC-7 decision update
-		UpdateMacro(UTP_PADONLY, PT_AP11ENT, rtcc->GETEval2(rtcc->calcParams.EI - 5.0*3600.0 - 45.0*60.0), 97, MST_F_TRANSEARTH_10);
+		UpdateMacro(UTP_PADONLY, PT_AP11ENT, mcc_calcs.GETEval(rtcc->calcParams.EI - 5.0*3600.0 - 45.0*60.0), 97, MST_F_TRANSEARTH_10);
 		break;
 	case MST_F_TRANSEARTH_10: //MCC-7 decision update to MCC-7 update
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.EI - 4.5*3600.0), 93, MST_F_TRANSEARTH_11);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.EI - 4.5*3600.0), 93, MST_F_TRANSEARTH_11);
 		break;
 	case MST_F_TRANSEARTH_11: //MCC-7 update to Entry PAD update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 94, MST_F_TRANSEARTH_12);
 		break;
 	case MST_F_TRANSEARTH_12: //Entry PAD update to final entry update
-		UpdateMacro(UTP_PADONLY, PT_AP11ENT, rtcc->GETEval2(rtcc->calcParams.EI - 1.0*3600.0), 98, MST_F_TRANSEARTH_13);
+		UpdateMacro(UTP_PADONLY, PT_AP11ENT, mcc_calcs.GETEval(rtcc->calcParams.EI - 1.0*3600.0), 98, MST_F_TRANSEARTH_13);
 		break;
 	case MST_F_TRANSEARTH_13: //Final entry update to CM/SM separation
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11ENT, cm->GetStage() == CM_STAGE, 99, MST_ENTRY);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_G.cpp
@@ -39,7 +39,7 @@ void MCC::MissionSequence_G()
 	switch (MissionState)
 	{
 	case MST_G_INSERTION: //Ground liftoff time update to TLI Simulation
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(1.0*3600.0 + 30.0*60.0), 10, MST_G_EPO1);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(1.0*3600.0 + 30.0*60.0), 10, MST_G_EPO1);
 		break;
 	case MST_G_EPO1: //TLI Simulation to TLI+90 PAD
 		UpdateMacro(UTP_NONE, PT_NONE, true, 11, MST_G_EPO2);
@@ -51,10 +51,10 @@ void MCC::MissionSequence_G()
 		UpdateMacro(UTP_PADONLY, PT_P37PAD, SubStateTime > 3.0*60.0, 13, MST_G_EPO4);
 		break;
 	case MST_G_EPO4: //TLI PAD to TLI Evaluation
-		UpdateMacro(UTP_PADONLY, PT_TLIPAD, rtcc->GETEval2(rtcc->calcParams.TLI + 18.0), 14, MST_G_TRANSLUNAR1);
+		UpdateMacro(UTP_PADONLY, PT_TLIPAD, mcc_calcs.GETEval(rtcc->calcParams.TLI + 18.0), 14, MST_G_TRANSLUNAR1);
 		break;
 	case MST_G_TRANSLUNAR1: //TLI Evaluation to Evasive Maneuver Update
-		UpdateMacro(UTP_NONE, PT_NONE, true, 15, MST_G_TRANSLUNAR2, scrubbed, rtcc->GETEval2(3.0*3600.0), MST_G_EPO1);
+		UpdateMacro(UTP_NONE, PT_NONE, true, 15, MST_G_TRANSLUNAR2, scrubbed, mcc_calcs.GETEval(3.0*3600.0), MST_G_EPO1);
 		break;
 	case MST_G_TRANSLUNAR2:
 		switch (SubState) {
@@ -67,7 +67,7 @@ void MCC::MissionSequence_G()
 		break;
 		case 1:
 		{
-			if (rtcc->GETEval2(rtcc->calcParams.TLI + 3600.0 + 10.0*60.0))
+			if (mcc_calcs.GETEval(rtcc->calcParams.TLI + 3600.0 + 10.0*60.0))
 			{
 				SlowIfDesired();
 				setState(MST_G_TRANSLUNAR3);
@@ -77,7 +77,7 @@ void MCC::MissionSequence_G()
 		}
 		break;
 	case MST_G_TRANSLUNAR3: //Evasive Maneuver Update to TB8 Enable
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 3600.0 + 30.0*60.0), 16, MST_G_TRANSLUNAR4);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 3600.0 + 30.0*60.0), 16, MST_G_TRANSLUNAR4);
 		break;
 	case MST_G_TRANSLUNAR4:  //TB8 enable to Block Data 1
 		switch (SubState) {
@@ -119,7 +119,7 @@ void MCC::MissionSequence_G()
 		}
 		break;
 		case 3:
-			if (rtcc->GETEval2(rtcc->calcParams.TLI + 3.0*3600.0))
+			if (mcc_calcs.GETEval(rtcc->calcParams.TLI + 3.0*3600.0))
 			{
 				SlowIfDesired();
 				setState(MST_G_TRANSLUNAR5);
@@ -128,52 +128,52 @@ void MCC::MissionSequence_G()
 		}
 		break;
 	case MST_G_TRANSLUNAR5: //Block Data 1 to MCC-1 Calculation
-		UpdateMacro(UTP_PADONLY, PT_P37PAD, rtcc->GETEval2(rtcc->calcParams.TLI + 3.0*3600.0 + 20.0*60.0), 17, MST_G_TRANSLUNAR6);
+		UpdateMacro(UTP_PADONLY, PT_P37PAD, mcc_calcs.GETEval(rtcc->calcParams.TLI + 3.0*3600.0 + 20.0*60.0), 17, MST_G_TRANSLUNAR6);
 		break;
 	case MST_G_TRANSLUNAR6: //MCC-1 Calculation to MCC-1 update (or PTC REFSMMAT)
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TLI + 7.0*3600.0 + 10.0*60.0), 20, MST_G_TRANSLUNAR7, scrubbed, rtcc->GETEval2(rtcc->calcParams.TLI + 4.0*3600.0), MST_G_TRANSLUNAR_NO_MCC1_1);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TLI + 7.0*3600.0 + 10.0*60.0), 20, MST_G_TRANSLUNAR7, scrubbed, mcc_calcs.GETEval(rtcc->calcParams.TLI + 4.0*3600.0), MST_G_TRANSLUNAR_NO_MCC1_1);
 		break;
 	case MST_G_TRANSLUNAR7: //MCC-1 update to PTC REFSMMAT update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 9.0*3600.0 + 5.0*60.0), 21, MST_G_TRANSLUNAR8);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 9.0*3600.0 + 5.0*60.0), 21, MST_G_TRANSLUNAR8);
 		break;
 	case MST_G_TRANSLUNAR_NO_MCC1_1: //PTC REFSMMAT update to SV update (MCC-1 was scrubbed)
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TLI + 7.0*3600.0 + 10.0*60.0), 19, MST_G_TRANSLUNAR_NO_MCC1_2);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TLI + 7.0*3600.0 + 10.0*60.0), 19, MST_G_TRANSLUNAR_NO_MCC1_2);
 		break;
 	case MST_G_TRANSLUNAR_NO_MCC1_2: //SV update to Block Data 2 (MCC-1 was scrubbed)
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TLI + 9.0*3600.0 + 5.0*60.0), 1, MST_G_TRANSLUNAR9);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TLI + 9.0*3600.0 + 5.0*60.0), 1, MST_G_TRANSLUNAR9);
 		break;
 	case MST_G_TRANSLUNAR8: //PTC REFSMMAT update to Block Data 2
 		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, true, 19, MST_G_TRANSLUNAR9);
 		break;
 	case MST_G_TRANSLUNAR9: //Block Data 2 to MCC-2 update
-		UpdateMacro(UTP_PADONLY, PT_P37PAD, rtcc->GETEval2(rtcc->calcParams.TLI + 22.0*3600.0 + 40.0*60.0), 18, MST_G_TRANSLUNAR10);
+		UpdateMacro(UTP_PADONLY, PT_P37PAD, mcc_calcs.GETEval(rtcc->calcParams.TLI + 22.0*3600.0 + 40.0*60.0), 18, MST_G_TRANSLUNAR10);
 		break;
 	case MST_G_TRANSLUNAR10: //MCC-2 update to Lunar Flyby PAD
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 32.0*3600.0 + 10.0*60.0), 22, MST_G_TRANSLUNAR11);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 32.0*3600.0 + 10.0*60.0), 22, MST_G_TRANSLUNAR11);
 		break;
 	case MST_G_TRANSLUNAR11: //Lunar Flyby PAD to MCC-3
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 24.0*3600.0 - 40.0*60.0), 23, MST_G_TRANSLUNAR12);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 24.0*3600.0 - 40.0*60.0), 23, MST_G_TRANSLUNAR12);
 		break;
 	case MST_G_TRANSLUNAR12: //MCC-3 update to MCC-4 update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 6.0*3600.0 - 25.0*60.0), 24, MST_G_TRANSLUNAR13);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 6.0*3600.0 - 25.0*60.0), 24, MST_G_TRANSLUNAR13);
 		break;
 	case MST_G_TRANSLUNAR13: //MCC-4 update to PC+2 update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 25, MST_G_TRANSLUNAR14);
 		break;
 	case MST_G_TRANSLUNAR14: //PC+2 update to LOI-1 update
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 2.0*3600.0 - 50.0*60.0), 26, MST_G_TRANSLUNAR15);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 2.0*3600.0 - 50.0*60.0), 26, MST_G_TRANSLUNAR15);
 		break;
 	case MST_G_TRANSLUNAR15: //LOI-1 update to TEI-1 update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 2.0*3600.0 - 5.0*60.0), 30, MST_G_TRANSLUNAR16);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 2.0*3600.0 - 5.0*60.0), 30, MST_G_TRANSLUNAR16);
 		break;
 	case MST_G_TRANSLUNAR16: //TEI-1 update to TEI-4 update
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, SubStateTime > 5.0*60.0, 40, MST_G_TRANSLUNAR17);
 		break;
 	case MST_G_TRANSLUNAR17: //TEI-4 update to Rev 1 Map Update
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 40.0*60.0), 41, MST_G_TRANSLUNAR18);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 40.0*60.0), 41, MST_G_TRANSLUNAR18);
 		break;
 	case MST_G_TRANSLUNAR18: //Rev 1 Map Update to lunar orbit phase begin
-		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, rtcc->GETEval2(rtcc->calcParams.LOI), 60, MST_G_LUNAR_ORBIT_LOI_DAY_1);
+		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, mcc_calcs.GETEval(rtcc->calcParams.LOI), 60, MST_G_LUNAR_ORBIT_LOI_DAY_1);
 		break;
 	case MST_G_LUNAR_ORBIT_LOI_DAY_1: //Lunar orbit phase begin
 		switch (SubState) {
@@ -236,7 +236,7 @@ void MCC::MissionSequence_G()
 		UpdateMacro(UTP_PADONLY, PT_PDIABORTPAD, SubStateTime > 3.0*60.0, 71, MST_G_LUNAR_ORBIT_PDI_DAY_15);
 		break;
 	case MST_G_LUNAR_ORBIT_PDI_DAY_15: //No PDI+12 PAD to Lunar Surface PAD
-		UpdateMacro(UTP_PADONLY, PT_AP11LMMNV, rtcc->GETEval2(rtcc->calcParams.SEP + 8.0*60.0) && SubStateTime > 3.0*60.0, 72, MST_G_LUNAR_ORBIT_PRE_DOI_1);
+		UpdateMacro(UTP_PADONLY, PT_AP11LMMNV, mcc_calcs.GETEval(rtcc->calcParams.SEP + 8.0*60.0) && SubStateTime > 3.0*60.0, 72, MST_G_LUNAR_ORBIT_PRE_DOI_1);
 		break;
 	case MST_G_LUNAR_ORBIT_PRE_DOI_1: //Lunar Surface PAD to CSM Rescue PAD
 		UpdateMacro(UTP_PADWITHLGCUPLINK, PT_AP11LUNSURFPAD, SubStateTime > 3.0*60.0, 73, MST_G_LUNAR_ORBIT_PRE_DOI_3);
@@ -245,19 +245,19 @@ void MCC::MissionSequence_G()
 		UpdateMacro(UTP_PADONLY, PT_PDIABORTPAD, SubStateTime > 3.0*60.0, 75, MST_G_LUNAR_ORBIT_PRE_DOI_4);
 		break;
 	case MST_G_LUNAR_ORBIT_PRE_DOI_4: //CSM P76 PADs to DOI Evaluation
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11P76PAD, rtcc->GETEval2(rtcc->calcParams.DOI + 45.0*60.0), 76, MST_G_LUNAR_ORBIT_PRE_PDI_1);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11P76PAD, mcc_calcs.GETEval(rtcc->calcParams.DOI + 45.0*60.0), 76, MST_G_LUNAR_ORBIT_PRE_PDI_1);
 		break;
 	case MST_G_LUNAR_ORBIT_PRE_PDI_1: //DOI Evaluation to PDI Evaluation
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.PDI + 2.0*60.0), 77, MST_G_LUNAR_ORBIT_PRE_LANDING_1);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.PDI + 2.0*60.0), 77, MST_G_LUNAR_ORBIT_PRE_LANDING_1);
 		break;
 	case MST_G_LUNAR_ORBIT_PRE_LANDING_1: //PDI Evaluation to landing confirmation
 		UpdateMacro(UTP_NONE, PT_NONE, rtcc->calcParams.tgt->GroundContact(), 78, MST_G_LUNAR_ORBIT_POST_LANDING_1);
 		break;
 	case MST_G_LUNAR_ORBIT_POST_LANDING_1: //Landing confirmation to T1
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.PDI + 15.0*60.0), 79, MST_G_LUNAR_ORBIT_POST_LANDING_2);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.PDI + 15.0*60.0), 79, MST_G_LUNAR_ORBIT_POST_LANDING_2);
 		break;
 	case MST_G_LUNAR_ORBIT_POST_LANDING_2: //T1 to T2
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.PDI + 19.0*60.0 + 30.0), 80, MST_G_LUNAR_ORBIT_POST_LANDING_3);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.PDI + 19.0*60.0 + 30.0), 80, MST_G_LUNAR_ORBIT_POST_LANDING_3);
 		break;
 	case MST_G_LUNAR_ORBIT_POST_LANDING_3: //T2 to LM Tracking PAD
 		UpdateMacro(UTP_NONE, PT_NONE, MoonRev >= 14 && MoonRevTime > 90.0*60.0, 81, MST_G_LUNAR_ORBIT_POST_LANDING_4);
@@ -311,10 +311,10 @@ void MCC::MissionSequence_G()
 		UpdateMacro(UTP_PADONLY, PT_AP11LMASCPAD, SubStateTime > 5.0*60.0, 102, MST_G_LUNAR_ORBIT_ASCENT_DAY_5);
 		break;
 	case MST_G_LUNAR_ORBIT_ASCENT_DAY_5: //CSI Data Card to LM Liftoff Evaluation
-		UpdateMacro(UTP_PADONLY, PT_AP10CSI, rtcc->GETEval2(rtcc->calcParams.LunarLiftoff + 20.0), 103, MST_G_LUNAR_ORBIT_ASCENT_DAY_6);
+		UpdateMacro(UTP_PADONLY, PT_AP10CSI, mcc_calcs.GETEval(rtcc->calcParams.LunarLiftoff + 20.0), 103, MST_G_LUNAR_ORBIT_ASCENT_DAY_6);
 		break;
 	case MST_G_LUNAR_ORBIT_ASCENT_DAY_6: //LM Liftoff Evaluation to CMC LM State Vector update
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.Insertion + 120.0), 104, MST_G_LUNAR_ORBIT_ASCENT_DAY_7, scrubbed, SubStateTime > 15.0*60.0, MST_G_LUNAR_ORBIT_ASCENT_DAY_2);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.Insertion + 120.0), 104, MST_G_LUNAR_ORBIT_ASCENT_DAY_7, scrubbed, SubStateTime > 15.0*60.0, MST_G_LUNAR_ORBIT_ASCENT_DAY_2);
 		break;
 	case MST_G_LUNAR_ORBIT_ASCENT_DAY_7: //CMC LM State Vector update to CSM DAP Update
 		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, (rtcc->calcParams.src->DockingStatus(0) == 1) && (MoonRev >= 27 && MoonRevTime > 38.0*60.0), 2, MST_G_LUNAR_ORBIT_ASCENT_DAY_8);
@@ -332,7 +332,7 @@ void MCC::MissionSequence_G()
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 46, MST_G_LUNAR_ORBIT_ASCENT_DAY_12);
 		break;
 	case MST_G_LUNAR_ORBIT_ASCENT_DAY_12: //TEI-31 PAD to TEI Evaluation
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TEI + 300.0), 47, MST_G_LUNAR_ORBIT_ASCENT_DAY_13);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TEI + 300.0), 47, MST_G_LUNAR_ORBIT_ASCENT_DAY_13);
 		break;
 	case MST_G_LUNAR_ORBIT_ASCENT_DAY_13: //TEI Evaluation to TEI
 		UpdateMacro(UTP_NONE, PT_NONE, true, 105, MST_G_TRANSEARTH_1, scrubbed, MoonRevTime > 40.0*60.0, MST_G_LUNAR_ORBIT_ASCENT_DAY_11);
@@ -345,7 +345,7 @@ void MCC::MissionSequence_G()
 			setSubState(1);
 			break;
 		case 1:
-			if (rtcc->GETEval2(rtcc->calcParams.TEI + 20.0*60.0))
+			if (mcc_calcs.GETEval(rtcc->calcParams.TEI + 20.0*60.0))
 			{
 				SlowIfDesired();
 				setState(MST_G_TRANSEARTH_2);
@@ -354,31 +354,31 @@ void MCC::MissionSequence_G()
 		}
 		break;
 	case MST_G_TRANSEARTH_2: //PTC REFSMMAT to MCC-5 update
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TEI + 13.0*3600.0 + 25.0*60.0), 19, MST_G_TRANSEARTH_3);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TEI + 13.0*3600.0 + 25.0*60.0), 19, MST_G_TRANSEARTH_3);
 		break;
 	case MST_G_TRANSEARTH_3: //MCC-5 update to preliminary MCC-6 update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TEI + 24.0*3600.0 + 25.0*60.0), 110, MST_G_TRANSEARTH_4);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TEI + 24.0*3600.0 + 25.0*60.0), 110, MST_G_TRANSEARTH_4);
 		break;
 	case MST_G_TRANSEARTH_4: //Preliminary MCC-6 update to Entry PAD update
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, SubStateTime > 5.0*60.0, 111, MST_G_TRANSEARTH_5);
 		break;
 	case MST_G_TRANSEARTH_5: //Entry PAD update to MCC-6 update
-		UpdateMacro(UTP_PADONLY, PT_AP11ENT, rtcc->GETEval2(rtcc->calcParams.EI - 24.0*3600.0 - 10.0*60.0), 116, MST_G_TRANSEARTH_6);
+		UpdateMacro(UTP_PADONLY, PT_AP11ENT, mcc_calcs.GETEval(rtcc->calcParams.EI - 24.0*3600.0 - 10.0*60.0), 116, MST_G_TRANSEARTH_6);
 		break;
 	case MST_G_TRANSEARTH_6: //MCC-6 update to Entry PAD update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 112, MST_G_TRANSEARTH_7);
 		break;
 	case MST_G_TRANSEARTH_7: //Entry PAD update to MCC-7 decision update
-		UpdateMacro(UTP_PADONLY, PT_AP11ENT, rtcc->GETEval2(rtcc->calcParams.EI - 6.0*3600.0), 116, MST_G_TRANSEARTH_8);
+		UpdateMacro(UTP_PADONLY, PT_AP11ENT, mcc_calcs.GETEval(rtcc->calcParams.EI - 6.0*3600.0), 116, MST_G_TRANSEARTH_8);
 		break;
 	case MST_G_TRANSEARTH_8: //MCC-7 decision update to MCC-7 update
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.EI - 4.0*3600.0 - 35.0*60.0), 113, MST_G_TRANSEARTH_9);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.EI - 4.0*3600.0 - 35.0*60.0), 113, MST_G_TRANSEARTH_9);
 		break;
 	case MST_G_TRANSEARTH_9: //MCC-7 update to Entry PAD update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 114, MST_G_TRANSEARTH_10);
 		break;
 	case MST_G_TRANSEARTH_10: //Entry PAD update to final entry update
-		UpdateMacro(UTP_PADONLY, PT_AP11ENT, rtcc->GETEval2(rtcc->calcParams.EI - 45.0*60.0), 117, MST_G_TRANSEARTH_11);
+		UpdateMacro(UTP_PADONLY, PT_AP11ENT, mcc_calcs.GETEval(rtcc->calcParams.EI - 45.0*60.0), 117, MST_G_TRANSEARTH_11);
 		break;
 	case MST_G_TRANSEARTH_11: //Final entry update to CM/SM separation
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11ENT, cm->GetStage() == CM_STAGE, 118, MST_ENTRY);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_H1.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_H1.cpp
@@ -39,7 +39,7 @@ void MCC::MissionSequence_H1()
 	switch (MissionState)
 	{
 	case MST_H1_INSERTION: //Ground liftoff time update to TLI Simulation
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(1.0*3600.0 + 30.0*60.0), 10, MST_H1_EPO1);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(1.0*3600.0 + 30.0*60.0), 10, MST_H1_EPO1);
 		break;
 	case MST_H1_EPO1: //TLI Simulation to TLI+90 PAD
 		UpdateMacro(UTP_NONE, PT_NONE, true, 11, MST_H1_EPO2);
@@ -51,10 +51,10 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_PADONLY, PT_P37PAD, SubStateTime > 3.0*60.0, 13, MST_H1_EPO4);
 		break;
 	case MST_H1_EPO4: //TLI PAD to TLI Evaluation
-		UpdateMacro(UTP_PADONLY, PT_TLIPAD, rtcc->GETEval2(rtcc->calcParams.TLI + 18.0), 14, MST_H1_TRANSLUNAR_DAY1_1);
+		UpdateMacro(UTP_PADONLY, PT_TLIPAD, mcc_calcs.GETEval(rtcc->calcParams.TLI + 18.0), 14, MST_H1_TRANSLUNAR_DAY1_1);
 		break;
 	case MST_H1_TRANSLUNAR_DAY1_1: //TLI Evaluation to SIVB Evasive Maneuver
-		UpdateMacro(UTP_NONE, PT_NONE, true, 15, MST_H1_TRANSLUNAR_DAY1_2, scrubbed, rtcc->GETEval2(3.0*3600.0), MST_H1_EPO1);
+		UpdateMacro(UTP_NONE, PT_NONE, true, 15, MST_H1_TRANSLUNAR_DAY1_2, scrubbed, mcc_calcs.GETEval(3.0*3600.0), MST_H1_EPO1);
 		break;
 	case MST_H1_TRANSLUNAR_DAY1_2:
 		switch (SubState) {
@@ -67,7 +67,7 @@ void MCC::MissionSequence_H1()
 		break;
 		case 1:
 		{
-			if (rtcc->GETEval2(rtcc->calcParams.TLI + 3600.0 + 20.0*60.0))  //1:20h from TLI cutoff
+			if (mcc_calcs.GETEval(rtcc->calcParams.TLI + 3600.0 + 20.0*60.0))  //1:20h from TLI cutoff
 			{
 				SlowIfDesired();
 				setState(MST_H1_TRANSLUNAR_DAY1_3);
@@ -119,7 +119,7 @@ void MCC::MissionSequence_H1()
 		}
 		break;
 		case 3:
-			if (SubStateTime >= 8.0*60.0 && rtcc->GETEval2(rtcc->calcParams.TLI + 3600.0 + 31.0*60.0 + 40.0)) //11m40s after LM ejection. Not before 8 minutes after yaw maneuver command was sent
+			if (SubStateTime >= 8.0*60.0 && mcc_calcs.GETEval(rtcc->calcParams.TLI + 3600.0 + 31.0*60.0 + 40.0)) //11m40s after LM ejection. Not before 8 minutes after yaw maneuver command was sent
 			{
 				SlowIfDesired();
 				setState(MST_H1_TRANSLUNAR_DAY1_4);
@@ -159,7 +159,7 @@ void MCC::MissionSequence_H1()
 		}
 		break;
 		case 2:
-			if (rtcc->GETEval2(rtcc->calcParams.TLI + 2.0*3600.0 + 29.0*60.0))
+			if (mcc_calcs.GETEval(rtcc->calcParams.TLI + 2.0*3600.0 + 29.0*60.0))
 			{
 				SlowIfDesired();
 				setState(MST_H1_TRANSLUNAR_DAY1_5);
@@ -171,52 +171,52 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, SubStateTime > 5.0*60.0, 18, MST_H1_TRANSLUNAR_DAY1_6);
 		break;
 	case MST_H1_TRANSLUNAR_DAY1_6: //MCC-1 Evaluation to Block Data 1
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TLI + 2.0*3600.0 + 59.0*60.0), 19, MST_H1_TRANSLUNAR_DAY1_7);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TLI + 2.0*3600.0 + 59.0*60.0), 19, MST_H1_TRANSLUNAR_DAY1_7);
 		break;
 	case MST_H1_TRANSLUNAR_DAY1_7: //Block Data 1 to PTC Quads Decision
-		UpdateMacro(UTP_PADONLY, PT_P37PAD, rtcc->GETEval2(rtcc->calcParams.TLI + 4.0*3600.0 + 10.0*60.0), 16, MST_H1_TRANSLUNAR_DAY1_8);
+		UpdateMacro(UTP_PADONLY, PT_P37PAD, mcc_calcs.GETEval(rtcc->calcParams.TLI + 4.0*3600.0 + 10.0*60.0), 16, MST_H1_TRANSLUNAR_DAY1_8);
 		break;
 	case MST_H1_TRANSLUNAR_DAY1_8: //PTC Quads Decision to MCC-1 update
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.TLI + 7.0*3600.0 + 15.0*60.0), 140, MST_H1_TRANSLUNAR_DAY1_9);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.TLI + 7.0*3600.0 + 15.0*60.0), 140, MST_H1_TRANSLUNAR_DAY1_9);
 		break;
 	case MST_H1_TRANSLUNAR_DAY1_9: //MCC-1 update to MCC-2 Evaluation
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 11.0*3600.0 + 5.0*60.0), 21, MST_H1_TRANSLUNAR_DAY1_10);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 11.0*3600.0 + 5.0*60.0), 21, MST_H1_TRANSLUNAR_DAY1_10);
 		break;
 	case MST_H1_TRANSLUNAR_DAY1_10: //MCC-2 Evaluation to Block Data 2
 		UpdateMacro(UTP_NONE, PT_NONE, true, 20, MST_H1_TRANSLUNAR_DAY1_11);
 		break;
 	case MST_H1_TRANSLUNAR_DAY1_11: //Block Data 2 to PTC Quads Decision
-		UpdateMacro(UTP_PADONLY, PT_P37PAD, rtcc->GETEval2(rtcc->calcParams.TLI + 13.5*3600.0), 17, MST_H1_TRANSLUNAR_DAY1_12);
+		UpdateMacro(UTP_PADONLY, PT_P37PAD, mcc_calcs.GETEval(rtcc->calcParams.TLI + 13.5*3600.0), 17, MST_H1_TRANSLUNAR_DAY1_12);
 		break;
 	case MST_H1_TRANSLUNAR_DAY1_12: //PTC Quads Decision to MCC-2 update
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.TLI + 26.0*3600.0 + 27.0*60.0), 140, MST_H1_TRANSLUNAR_DAY2_1);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.TLI + 26.0*3600.0 + 27.0*60.0), 140, MST_H1_TRANSLUNAR_DAY2_1);
 		break;
 	case MST_H1_TRANSLUNAR_DAY2_1: //MCC-2 update to PTC Quads Decision
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 28.0*3600.0 + 7.0*60.0), 22, MST_H1_TRANSLUNAR_DAY2_2);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 28.0*3600.0 + 7.0*60.0), 22, MST_H1_TRANSLUNAR_DAY2_2);
 		break;
 	case MST_H1_TRANSLUNAR_DAY2_2: //PTC Quads Decision to Lunar Flyby PAD
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.TLI + 31.0*3600.0 + 57.0*60.0), 140, MST_H1_TRANSLUNAR_DAY2_3);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.TLI + 31.0*3600.0 + 57.0*60.0), 140, MST_H1_TRANSLUNAR_DAY2_3);
 		break;
 	case MST_H1_TRANSLUNAR_DAY2_3: //Lunar Flyby PAD to SV Update
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TLI + 39.0*3600.0 + 1.0*60.0), 23, MST_H1_TRANSLUNAR_DAY2_4);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TLI + 39.0*3600.0 + 1.0*60.0), 23, MST_H1_TRANSLUNAR_DAY2_4);
 		break;
 	case MST_H1_TRANSLUNAR_DAY2_4: //SV Update to MCC-3
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.LOI - 23.5*3600.0), 5, MST_H1_TRANSLUNAR_DAY3_1);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.LOI - 23.5*3600.0), 5, MST_H1_TRANSLUNAR_DAY3_1);
 		break;
 	case MST_H1_TRANSLUNAR_DAY3_1: //MCC-3 update to PTC Quads Decision
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 21.8*3600.0), 24, MST_H1_TRANSLUNAR_DAY3_2, scrubbed, rtcc->GETEval2(rtcc->calcParams.LOI - 6.5*3600.0), MST_H1_TRANSLUNAR_DAY4_1);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 21.8*3600.0), 24, MST_H1_TRANSLUNAR_DAY3_2, scrubbed, mcc_calcs.GETEval(rtcc->calcParams.LOI - 6.5*3600.0), MST_H1_TRANSLUNAR_DAY4_1);
 		break;
 	case MST_H1_TRANSLUNAR_DAY3_2: //PTC Quads Decision to MCC-4 Evaluation
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.LOI - 6.5*3600.0), 140, MST_H1_TRANSLUNAR_DAY4_1);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.LOI - 6.5*3600.0), 140, MST_H1_TRANSLUNAR_DAY4_1);
 		break;
 	case MST_H1_TRANSLUNAR_DAY4_1: //MCC-4 Evaluation to MCC-4 update or SV update
-		UpdateMacro(UTP_NONE, PT_NONE, SubStateTime > 5.0*60.0, 25, MST_H1_TRANSLUNAR_DAY4_2, scrubbed, rtcc->GETEval2(rtcc->calcParams.LOI - 4.5*3600.0), MST_H1_TRANSLUNAR_NO_MCC4_1);
+		UpdateMacro(UTP_NONE, PT_NONE, SubStateTime > 5.0*60.0, 25, MST_H1_TRANSLUNAR_DAY4_2, scrubbed, mcc_calcs.GETEval(rtcc->calcParams.LOI - 4.5*3600.0), MST_H1_TRANSLUNAR_NO_MCC4_1);
 		break;
 	case MST_H1_TRANSLUNAR_NO_MCC4_1: //SV update to PC+2 update *No MCC-4 Timeline*
 		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, SubStateTime > 20.0*60.0, 5, MST_H1_TRANSLUNAR_NO_MCC4_2);
 		break;
 	case MST_H1_TRANSLUNAR_NO_MCC4_2: //PC+2 update to LOI-1 update (preliminary) *No MCC-4 Timeline*
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 2.0*3600.0 - 20.0*60.0), 28, MST_H1_TRANSLUNAR_NO_MCC4_3);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 2.0*3600.0 - 20.0*60.0), 28, MST_H1_TRANSLUNAR_NO_MCC4_3);
 		break;
 	case MST_H1_TRANSLUNAR_NO_MCC4_3: //LOI-1 update (preliminary) to TEI-1 update *No MCC-4 Timeline*
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 29, MST_H1_TRANSLUNAR_DAY4_5);
@@ -225,7 +225,7 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 26, MST_H1_TRANSLUNAR_DAY4_3);
 		break;
 	case MST_H1_TRANSLUNAR_DAY4_3: //PC+2 update to LOI-1 update (preliminary)
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 2.0*3600.0 - 20.0*60.0), 27, MST_H1_TRANSLUNAR_DAY4_4);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 2.0*3600.0 - 20.0*60.0), 27, MST_H1_TRANSLUNAR_DAY4_4);
 		break;
 	case MST_H1_TRANSLUNAR_DAY4_4: //LOI-1 update (preliminary) to TEI-1 update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 30, MST_H1_TRANSLUNAR_DAY4_5);
@@ -234,13 +234,13 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, SubStateTime > 5.0*60.0, 40, MST_H1_TRANSLUNAR_DAY4_6);
 		break;
 	case MST_H1_TRANSLUNAR_DAY4_6: //TEI-4 update to Rev 1 Map Update
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.LOI - 1.0*3600.0), 41, MST_H1_TRANSLUNAR_DAY4_7);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.LOI - 1.0*3600.0), 41, MST_H1_TRANSLUNAR_DAY4_7);
 		break;
 	case MST_H1_TRANSLUNAR_DAY4_7: //Rev 1 Map Update to LOI-1 update (final)
 		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, SubStateTime > 5.0*60.0, 60, MST_H1_TRANSLUNAR_DAY4_8);
 		break;
 	case MST_H1_TRANSLUNAR_DAY4_8: //LOI-1 update (final) to LOI-1 Evaluation
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->TimeofIgnition + 7.0*60.0), 30, MST_H1_TRANSLUNAR_DAY4_9);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->TimeofIgnition + 7.0*60.0), 30, MST_H1_TRANSLUNAR_DAY4_9);
 		break;
 	case MST_H1_TRANSLUNAR_DAY4_9: //LOI-1 Evaluation to Lunar orbit phase begin or PC+2
 		UpdateMacro(UTP_NONE, PT_NONE, true, 33, MST_H1_LUNAR_ORBIT_LOI_DAY_1, scrubbed, true, MST_H1_ABORT);
@@ -324,7 +324,7 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_PADONLY, PT_AP12SEPPAD, SubStateTime > 5.0*60.0, 37, MST_H1_LUNAR_ORBIT_PDI_DAY_13);
 		break;
 	case MST_H1_LUNAR_ORBIT_PDI_DAY_13: //Rev 13 map update to DOI update
-		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, rtcc->GETEval2(rtcc->calcParams.SEP - 25.0*60.0), 600, MST_H1_LUNAR_ORBIT_PDI_DAY_14);
+		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, mcc_calcs.GETEval(rtcc->calcParams.SEP - 25.0*60.0), 600, MST_H1_LUNAR_ORBIT_PDI_DAY_14);
 		break;
 	case MST_H1_LUNAR_ORBIT_PDI_DAY_14: //DOI update to No PDI+12 PAD
 		UpdateMacro(UTP_PADWITHLGCUPLINK, PT_AP11LMMNV, SubStateTime > 3.0*60.0, 38, MST_H1_LUNAR_ORBIT_PDI_DAY_15);
@@ -343,22 +343,22 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_PADONLY, PT_AP12LUNSURFPAD, SubStateTime > 3.0*60.0, 73, MST_H1_LUNAR_ORBIT_PRE_DOI_2);
 		break;
 	case MST_H1_LUNAR_ORBIT_PRE_DOI_2: //P22 Acquistion time to LM SV update
-		UpdateMacro(UTP_PADONLY, PT_LMP22ACQPAD, rtcc->GETEval2(rtcc->calcParams.SEP + 5.0*60.0), 58, MST_H1_LUNAR_ORBIT_PRE_DOI_3);
+		UpdateMacro(UTP_PADONLY, PT_LMP22ACQPAD, mcc_calcs.GETEval(rtcc->calcParams.SEP + 5.0*60.0), 58, MST_H1_LUNAR_ORBIT_PRE_DOI_3);
 		break;
 	case MST_H1_LUNAR_ORBIT_PRE_DOI_3: //LM SV update to rev 14 map update
 		UpdateMacro(UTP_LGCUPLINKONLY, PT_NONE, SubStateTime > 2.0*60.0, 400, MST_H1_LUNAR_ORBIT_PRE_DOI_4);
 		break;
 	case MST_H1_LUNAR_ORBIT_PRE_DOI_4: //Rev 14 map update to rev 15 map update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP10MAPUPDATE, rtcc->GETEval2(rtcc->calcParams.PDI - 33.0*60.0), 76, MST_H1_LUNAR_ORBIT_PRE_PDI_1);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP10MAPUPDATE, mcc_calcs.GETEval(rtcc->calcParams.PDI - 33.0*60.0), 76, MST_H1_LUNAR_ORBIT_PRE_PDI_1);
 		break;
 	case MST_H1_LUNAR_ORBIT_PRE_PDI_1: //Rev 15 map update to DOI Evaluation
-		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, rtcc->GETEval2(rtcc->calcParams.PDI - 21.0*60.0), 600, MST_H1_LUNAR_ORBIT_PRE_PDI_2);
+		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, mcc_calcs.GETEval(rtcc->calcParams.PDI - 21.0*60.0), 600, MST_H1_LUNAR_ORBIT_PRE_PDI_2);
 		break;
 	case MST_H1_LUNAR_ORBIT_PRE_PDI_2: //DOI Evaluation to SV and RLS uplink
 		UpdateMacro(UTP_NONE, PT_NONE, SubStateTime > 3.0*60.0, 77, MST_H1_LUNAR_ORBIT_PRE_PDI_3);
 		break;
 	case MST_H1_LUNAR_ORBIT_PRE_PDI_3: //SV and RLS uplink to PDI Evaluation
-		UpdateMacro(UTP_LGCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.PDI + 2.0*60.0), 75, MST_H1_LUNAR_ORBIT_PRE_LANDING_1);
+		UpdateMacro(UTP_LGCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.PDI + 2.0*60.0), 75, MST_H1_LUNAR_ORBIT_PRE_LANDING_1);
 		break;
 	case MST_H1_LUNAR_ORBIT_PRE_LANDING_1: //PDI Evaluation to landing confirmation or PDI Recycle
 		UpdateMacro(UTP_NONE, PT_NONE, rtcc->calcParams.tgt->GroundContact(), 78, MST_H1_LUNAR_ORBIT_POST_LANDING_1, scrubbed, SubStateTime > 3.0*60.0, MST_H1_LUNAR_ORBIT_NO_PDI);
@@ -367,13 +367,13 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_PADWITHLGCUPLINK, PT_AP11AGSACT, SubStateTime > 3.0*60.0, 170, MST_H1_LUNAR_ORBIT_PDI_DAY_15);
 		break;
 	case MST_H1_LUNAR_ORBIT_POST_LANDING_1: //Landing confirmation to T1
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.PDI + 15.0*60.0), 79, MST_H1_LUNAR_ORBIT_POST_LANDING_2);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.PDI + 15.0*60.0), 79, MST_H1_LUNAR_ORBIT_POST_LANDING_2);
 		break;
 	case MST_H1_LUNAR_ORBIT_POST_LANDING_2: //T1 to T2
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.PDI + 19.0*60.0 + 30.0), 80, MST_H1_LUNAR_ORBIT_POST_LANDING_3);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.PDI + 19.0*60.0 + 30.0), 80, MST_H1_LUNAR_ORBIT_POST_LANDING_3);
 		break;
 	case MST_H1_LUNAR_ORBIT_POST_LANDING_3: //T2 to Landing Site Update
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.PDI + 75.0*60.0), 81, MST_H1_LUNAR_ORBIT_POST_LANDING_4);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.PDI + 75.0*60.0), 81, MST_H1_LUNAR_ORBIT_POST_LANDING_4);
 		break;
 	case MST_H1_LUNAR_ORBIT_POST_LANDING_4: //Landing Site Update to Lmk 193 Landmark Tracking PAD
 		UpdateMacro(UTP_PADWITHLGCUPLINK, PT_LMP22ACQPAD, SubStateTime > 8.0*60.0, 74, MST_H1_LUNAR_ORBIT_POST_LANDING_5);
@@ -385,13 +385,13 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, SubStateTime > 3.0*60.0, 1, MST_H1_LUNAR_ORBIT_POST_LANDING_7);
 		break;
 	case MST_H1_LUNAR_ORBIT_POST_LANDING_7: //Rev 16 map update to DAP Load
-		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, rtcc->GETEval2(rtcc->calcParams.PDI + 2.0*3600.0 + 10.0*60.0), 600, MST_H1_LUNAR_ORBIT_POST_LANDING_8);
+		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, mcc_calcs.GETEval(rtcc->calcParams.PDI + 2.0*3600.0 + 10.0*60.0), 600, MST_H1_LUNAR_ORBIT_POST_LANDING_8);
 		break;
 	case MST_H1_LUNAR_ORBIT_POST_LANDING_8: //DAP Load to Liftoff Times Update 1
 		UpdateMacro(UTP_PADONLY, PT_AP10DAPDATA, SubStateTime > 3.0*60.0, 8, MST_H1_LUNAR_ORBIT_POST_LANDING_9);
 		break;
 	case MST_H1_LUNAR_ORBIT_POST_LANDING_9: //Liftoff Times Update 1 to LM Tracking PAD
-		UpdateMacro(UTP_PADONLY, PT_LIFTOFFTIMES, rtcc->GETEval2(rtcc->calcParams.PDI + 3.0*3600.0 + 23.0*60.0), 85, MST_H1_LUNAR_ORBIT_POST_LANDING_10);
+		UpdateMacro(UTP_PADONLY, PT_LIFTOFFTIMES, mcc_calcs.GETEval(rtcc->calcParams.PDI + 3.0*3600.0 + 23.0*60.0), 85, MST_H1_LUNAR_ORBIT_POST_LANDING_10);
 		break;
 	case MST_H1_LUNAR_ORBIT_POST_LANDING_10: //LM Tracking PAD to rev 17 map update
 		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, SubStateTime > 3.0*60.0, 66, MST_H1_LUNAR_ORBIT_POST_LANDING_11);
@@ -409,7 +409,7 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_NONE, PT_NONE, true, 93, MST_H1_LUNAR_ORBIT_PLANE_CHANGE_2, scrubbed, MoonRev >= 19 && MoonRevTime > 50.0*60.0, MST_H1_LUNAR_ORBIT_NO_PLANE_CHANGE_1);
 		break;
 	case MST_H1_LUNAR_ORBIT_PLANE_CHANGE_2: //PC-1 Update to Liftoff Times Update 2
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->TimeofIgnition + 5*60.0), 94, MST_H1_LUNAR_ORBIT_EVA_DAY_1);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->TimeofIgnition + 5*60.0), 94, MST_H1_LUNAR_ORBIT_EVA_DAY_1);
 		break;
 	case MST_H1_LUNAR_ORBIT_NO_PLANE_CHANGE_1: //CMC CSM state vector update to Liftoff Times Update 2
 		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, SubStateTime > 5.0*60.0, 1, MST_H1_LUNAR_ORBIT_EVA_DAY_1);
@@ -469,13 +469,13 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, MoonRev >= 29 && MoonRevTime > 75.0*60.0, 600, MST_H1_LUNAR_ORBIT_ASCENT_DAY_1);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_1: //Nominal Insertion targeting + CMC SV update to LM Ascent PAD
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.LunarLiftoff - 90.0*60.0), 100, MST_H1_LUNAR_ORBIT_ASCENT_DAY_2);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.LunarLiftoff - 90.0*60.0), 100, MST_H1_LUNAR_ORBIT_ASCENT_DAY_2);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_2: //LM Ascent PAD to CSI Data Card
 		UpdateMacro(UTP_PADONLY, PT_AP12LMASCPAD, SubStateTime > 5.0*60.0, 105, MST_H1_LUNAR_ORBIT_ASCENT_DAY_3);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_3: //CSI Data Card to LM Tracking PAD
-		UpdateMacro(UTP_PADONLY, PT_AP10CSI, rtcc->GETEval2(rtcc->calcParams.LunarLiftoff - 45.0*60.0), 106, MST_H1_LUNAR_ORBIT_ASCENT_DAY_4);
+		UpdateMacro(UTP_PADONLY, PT_AP10CSI, mcc_calcs.GETEval(rtcc->calcParams.LunarLiftoff - 45.0*60.0), 106, MST_H1_LUNAR_ORBIT_ASCENT_DAY_4);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_4: //LM Tracking PAD to CMC SV uplinks
 		UpdateMacro(UTP_PADONLY, PT_AP11LMARKTRKPAD, true, 66, MST_H1_LUNAR_ORBIT_ASCENT_DAY_5);
@@ -484,16 +484,16 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, SubStateTime > 5.0*60.0, 101, MST_H1_LUNAR_ORBIT_ASCENT_DAY_6);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_6: //LGC SV + RLS uplinks to LM Liftoff Evaluation
-		UpdateMacro(UTP_LGCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.LunarLiftoff + 20.0), 102, MST_H1_LUNAR_ORBIT_ASCENT_DAY_7);
+		UpdateMacro(UTP_LGCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.LunarLiftoff + 20.0), 102, MST_H1_LUNAR_ORBIT_ASCENT_DAY_7);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_7: //LM Liftoff Evaluation to CMC LM State Vector update
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.Insertion + 120.0), 107, MST_H1_LUNAR_ORBIT_ASCENT_DAY_8, scrubbed, SubStateTime > 15.0*60.0, MST_H1_LUNAR_ORBIT_ASCENT_DAY_1);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.Insertion + 120.0), 107, MST_H1_LUNAR_ORBIT_ASCENT_DAY_8, scrubbed, SubStateTime > 15.0*60.0, MST_H1_LUNAR_ORBIT_ASCENT_DAY_1);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_8: //CMC LM State Vector update to DAP PAD
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, (rtcc->calcParams.src->DockingStatus(0) == 1) && rtcc->GETEval2(rtcc->calcParams.LunarLiftoff + 3.65*3600.0), 2, MST_H1_LUNAR_ORBIT_ASCENT_DAY_9);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, (rtcc->calcParams.src->DockingStatus(0) == 1) && mcc_calcs.GETEval(rtcc->calcParams.LunarLiftoff + 3.65*3600.0), 2, MST_H1_LUNAR_ORBIT_ASCENT_DAY_9);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_9: //DAP PAD to rev 33 map update
-		UpdateMacro(UTP_PADONLY, PT_AP10DAPDATA, rtcc->GETEval2(rtcc->calcParams.LunarLiftoff + 4.0*3600.0), 700, MST_H1_LUNAR_ORBIT_ASCENT_DAY_10);
+		UpdateMacro(UTP_PADONLY, PT_AP10DAPDATA, mcc_calcs.GETEval(rtcc->calcParams.LunarLiftoff + 4.0*3600.0), 700, MST_H1_LUNAR_ORBIT_ASCENT_DAY_10);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_10: //Rev 33 map update to SEP burn PAD
 		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, SubStateTime > 3.0*60.0, 600, MST_H1_LUNAR_ORBIT_ASCENT_DAY_11);
@@ -502,7 +502,7 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 3.0*60.0, 110, MST_H1_LUNAR_ORBIT_ASCENT_DAY_12);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_12: //Impact burn PAD to CSM P76 PAD
-		UpdateMacro(UTP_PADWITHLGCUPLINK, PT_AP11LMMNV, rtcc->GETEval2(rtcc->calcParams.SEP - 50.0*60.0), 111, MST_H1_LUNAR_ORBIT_ASCENT_DAY_13);
+		UpdateMacro(UTP_PADWITHLGCUPLINK, PT_AP11LMMNV, mcc_calcs.GETEval(rtcc->calcParams.SEP - 50.0*60.0), 111, MST_H1_LUNAR_ORBIT_ASCENT_DAY_13);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_13: //CSM P76 PAD to rev 34 map update
 		UpdateMacro(UTP_PADONLY, PT_AP11P76PAD, SubStateTime > 3.0*60.0, 112, MST_H1_LUNAR_ORBIT_ASCENT_DAY_14);
@@ -511,7 +511,7 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, SubStateTime > 3.0*60.0, 600, MST_H1_LUNAR_ORBIT_ASCENT_DAY_15);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_15: //DAP data to P42 uplink
-		UpdateMacro(UTP_PADONLY, PT_AP10DAPDATA, rtcc->GETEval2(rtcc->calcParams.SEP + 5.0*60.0), 7, MST_H1_LUNAR_ORBIT_ASCENT_DAY_16);
+		UpdateMacro(UTP_PADONLY, PT_AP10DAPDATA, mcc_calcs.GETEval(rtcc->calcParams.SEP + 5.0*60.0), 7, MST_H1_LUNAR_ORBIT_ASCENT_DAY_16);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_16: //P42 uplink to LM DSKY Pro
 		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, SubStateTime > 20.0, 120, MST_H1_LUNAR_ORBIT_ASCENT_DAY_17);
@@ -520,13 +520,13 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, SubStateTime > 20.0, 121, MST_H1_LUNAR_ORBIT_ASCENT_DAY_18);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_18: //LM DSKY Enter to TEI-39 PAD
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(rtcc->TimeofIgnition - 10.0*60.0), 122, MST_H1_LUNAR_ORBIT_ASCENT_DAY_19);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(rtcc->TimeofIgnition - 10.0*60.0), 122, MST_H1_LUNAR_ORBIT_ASCENT_DAY_19);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_19: //TEI-39 PAD to LM command ullage off
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TIGSTORE1), 45, MST_H1_LUNAR_ORBIT_ASCENT_DAY_20);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TIGSTORE1), 45, MST_H1_LUNAR_ORBIT_ASCENT_DAY_20);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_20: //LM command ullage off to LM impact prediction
-		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TIGSTORE1 + 5.0*60.0), 123, MST_H1_LUNAR_ORBIT_ASCENT_DAY_21);
+		UpdateMacro(UTP_LGCUPLINKDIRECT, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TIGSTORE1 + 5.0*60.0), 123, MST_H1_LUNAR_ORBIT_ASCENT_DAY_21);
 		break;
 	case MST_H1_LUNAR_ORBIT_ASCENT_DAY_21: //LM impact prediction to PC-2 Update
 		UpdateMacro(UTP_PADONLY, PT_GENERIC, MoonRev >= 38 && MoonRevTime > 50.0*60.0, 124, MST_H1_LUNAR_ORBIT_PC2_DAY_1);
@@ -541,7 +541,7 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, SubStateTime > 3.0*60.0, 600, MST_H1_LUNAR_ORBIT_PC2_DAY_4);
 		break;
 	case MST_H1_LUNAR_ORBIT_PC2_DAY_4: //TEI-41 PAD to Lalande Photography
-		UpdateMacro(UTP_PADONLY, PT_AP11MNV, rtcc->GETEval2(rtcc->TimeofIgnition + 5.0*60.0), 46, MST_H1_LUNAR_ORBIT_PC2_DAY_5);
+		UpdateMacro(UTP_PADONLY, PT_AP11MNV, mcc_calcs.GETEval(rtcc->TimeofIgnition + 5.0*60.0), 46, MST_H1_LUNAR_ORBIT_PC2_DAY_5);
 		break;
 	case MST_H1_LUNAR_ORBIT_PC2_DAY_5: //Lalande Photography to Photography REFSMMAT Uplink
 		UpdateMacro(UTP_PADONLY, PT_GENERIC, true, 605, MST_H1_LUNAR_ORBIT_PC2_DAY_6);
@@ -610,10 +610,10 @@ void MCC::MissionSequence_H1()
 		UpdateMacro(UTP_PADONLY, PT_AP11MNV, SubStateTime > 5.0*60.0, 51, MST_H1_LUNAR_ORBIT_PC2_DAY_27);
 		break;
 	case MST_H1_LUNAR_ORBIT_PC2_DAY_27: //Rev 46 map update to TEI Evaluation
-		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, rtcc->GETEval2(rtcc->calcParams.TEI + 300.0), 601, MST_H1_LUNAR_ORBIT_PC2_DAY_28);
+		UpdateMacro(UTP_PADONLY, PT_AP10MAPUPDATE, mcc_calcs.GETEval(rtcc->calcParams.TEI + 300.0), 601, MST_H1_LUNAR_ORBIT_PC2_DAY_28);
 		break;
 	case MST_H1_LUNAR_ORBIT_PC2_DAY_28: //TEI Evaluation to TEI
-		UpdateMacro(UTP_NONE, PT_NONE, true, 200, MST_H1_TRANSEARTH_DAY1_1, scrubbed, rtcc->GETEval2(rtcc->calcParams.TEI + 30.0*60.0), MST_H1_LUNAR_ORBIT_PC2_DAY_26);
+		UpdateMacro(UTP_NONE, PT_NONE, true, 200, MST_H1_TRANSEARTH_DAY1_1, scrubbed, mcc_calcs.GETEval(rtcc->calcParams.TEI + 30.0*60.0), MST_H1_LUNAR_ORBIT_PC2_DAY_26);
 		break;
 	case MST_H1_TRANSEARTH_DAY1_1: //TEI to PTC REFSMMAT
 		switch (SubState)
@@ -623,7 +623,7 @@ void MCC::MissionSequence_H1()
 			setSubState(1);
 			break;
 		case 1:
-			if (rtcc->GETEval2(rtcc->calcParams.TEI + 20.0*60.0))
+			if (mcc_calcs.GETEval(rtcc->calcParams.TEI + 20.0*60.0))
 			{
 				SlowIfDesired();
 				setState(MST_H1_TRANSEARTH_DAY1_2);
@@ -632,49 +632,49 @@ void MCC::MissionSequence_H1()
 		}
 		break;
 	case MST_H1_TRANSEARTH_DAY1_2: //PTC REFSMMAT to PTC Quads Decision
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.TEI + 1.0*3600.0 + 10.0*60.0), 18, MST_H1_TRANSEARTH_DAY1_3);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.TEI + 1.0*3600.0 + 10.0*60.0), 18, MST_H1_TRANSEARTH_DAY1_3);
 		break;
 	case MST_H1_TRANSEARTH_DAY1_3: //PTC Quads Decision to MCC-5 update
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.TEI + 12.0*3600.0), 140, MST_H1_TRANSEARTH_DAY2_1);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.TEI + 12.0*3600.0), 140, MST_H1_TRANSEARTH_DAY2_1);
 		break;
 	case MST_H1_TRANSEARTH_DAY2_1: //MCC-5 update to PTC Quads Decision
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, rtcc->GETEval2(rtcc->calcParams.TEI + 17.0*3600.0 + 40.0*60.0), 210, MST_H1_TRANSEARTH_DAY2_2);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, mcc_calcs.GETEval(rtcc->calcParams.TEI + 17.0*3600.0 + 40.0*60.0), 210, MST_H1_TRANSEARTH_DAY2_2);
 		break;
 	case MST_H1_TRANSEARTH_DAY2_2: //PTC Quads Decision to PTC Quads Decision
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.TEI + 23.0*3600.0 + 40.0*60.0), 140, MST_H1_TRANSEARTH_DAY2_3);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.TEI + 23.0*3600.0 + 40.0*60.0), 140, MST_H1_TRANSEARTH_DAY2_3);
 		break;
 	case MST_H1_TRANSEARTH_DAY2_3: //PTC Quads Decision to CSM SV update
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.EI - 36.0 * 3600.0), 140, MST_H1_TRANSEARTH_DAY3_1);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.EI - 36.0 * 3600.0), 140, MST_H1_TRANSEARTH_DAY3_1);
 		break;
 	case MST_H1_TRANSEARTH_DAY3_1: //CSM SV update to PTC Quads Decision
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(rtcc->calcParams.EI - (30.0 * 3600.0 + 20.0*60.0)), 5, MST_H1_TRANSEARTH_DAY3_2);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.EI - (30.0 * 3600.0 + 20.0*60.0)), 5, MST_H1_TRANSEARTH_DAY3_2);
 		break;
 	case MST_H1_TRANSEARTH_DAY3_2: //PTC Quads Decision to MCC-6 update
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.EI - (23.0 * 3600.0 + 20.0 * 60.0)), 140, MST_H1_TRANSEARTH_DAY3_3);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.EI - (23.0 * 3600.0 + 20.0 * 60.0)), 140, MST_H1_TRANSEARTH_DAY3_3);
 		break;
 	case MST_H1_TRANSEARTH_DAY3_3: //MCC-6 update to Entry PAD update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 212, MST_H1_TRANSEARTH_DAY3_4);
 		break;
 	case MST_H1_TRANSEARTH_DAY3_4: //Entry PAD update to PTC Quads Decision
-		UpdateMacro(UTP_PADONLY, PT_AP11ENT, rtcc->GETEval2(rtcc->calcParams.EI - (21.0*3600.0 + 50.0*60.0)), 216, MST_H1_TRANSEARTH_DAY3_5);
+		UpdateMacro(UTP_PADONLY, PT_AP11ENT, mcc_calcs.GETEval(rtcc->calcParams.EI - (21.0*3600.0 + 50.0*60.0)), 216, MST_H1_TRANSEARTH_DAY3_5);
 		break;
 	case MST_H1_TRANSEARTH_DAY3_5: //PTC Quads Decision to PTC Quads Decision
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.EI - (20.0*3600.0 + 20.0*60.0)), 140, MST_H1_TRANSEARTH_DAY3_6);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.EI - (20.0*3600.0 + 20.0*60.0)), 140, MST_H1_TRANSEARTH_DAY3_6);
 		break;
 	case MST_H1_TRANSEARTH_DAY3_6: //PTC Quads Decision to PTC Quads Decision
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.EI - (7.0*3600.0 + 20.0*60.0)), 140, MST_H1_TRANSEARTH_DAY4_1);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.EI - (7.0*3600.0 + 20.0*60.0)), 140, MST_H1_TRANSEARTH_DAY4_1);
 		break;
 	case MST_H1_TRANSEARTH_DAY4_1: //PTC Quads Decision to MCC-7 decision update
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.EI - 6.0*3600.0), 140, MST_H1_TRANSEARTH_DAY4_2);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.EI - 6.0*3600.0), 140, MST_H1_TRANSEARTH_DAY4_2);
 		break;
 	case MST_H1_TRANSEARTH_DAY4_2: //MCC-7 decision update to MCC-7 update
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(rtcc->calcParams.EI - 5.0*3600.0), 213, MST_H1_TRANSEARTH_DAY4_3);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.EI - 5.0*3600.0), 213, MST_H1_TRANSEARTH_DAY4_3);
 		break;
 	case MST_H1_TRANSEARTH_DAY4_3: //MCC-7 update to Entry PAD update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 5.0*60.0, 214, MST_H1_TRANSEARTH_DAY4_4);
 		break;
 	case MST_H1_TRANSEARTH_DAY4_4: //Entry PAD update to final entry update
-		UpdateMacro(UTP_PADONLY, PT_AP11ENT, rtcc->GETEval2(rtcc->calcParams.EI - 45.0*60.0), 217, MST_H1_TRANSEARTH_DAY4_5);
+		UpdateMacro(UTP_PADONLY, PT_AP11ENT, mcc_calcs.GETEval(rtcc->calcParams.EI - 45.0*60.0), 217, MST_H1_TRANSEARTH_DAY4_5);
 		break;
 	case MST_H1_TRANSEARTH_DAY4_5: //Final entry update to CM/SM separation
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11ENT, cm->GetStage() == CM_STAGE, 218, MST_ENTRY);
@@ -715,33 +715,33 @@ void MCC::MissionSequence_H1()
 			switch (SubState) {
 			case 0:
 			{
-				if (rtcc->GETEval2(OrbMech::HHMMSSToSS(60, 0, 0)))
+				if (mcc_calcs.GETEval(OrbMech::HHMMSSToSS(60, 0, 0)))
 				{
 					setSubState(13);//Flyby
 				}
 				else
 				{
-					if (rtcc->GETEval2(OrbMech::HHMMSSToSS(45, 0, 0))) //LO+60
+					if (mcc_calcs.GETEval(OrbMech::HHMMSSToSS(45, 0, 0))) //LO+60
 					{
 						rtcc->calcParams.TEI = OrbMech::HHMMSSToSS(60, 0, 0);
 					}
-					else if (rtcc->GETEval2(OrbMech::HHMMSSToSS(35, 0, 0))) //LO+45
+					else if (mcc_calcs.GETEval(OrbMech::HHMMSSToSS(35, 0, 0))) //LO+45
 					{
 						rtcc->calcParams.TEI = OrbMech::HHMMSSToSS(45, 0, 0);
 					}
-					else if (rtcc->GETEval2(OrbMech::HHMMSSToSS(25, 0, 0))) //LO+35
+					else if (mcc_calcs.GETEval(OrbMech::HHMMSSToSS(25, 0, 0))) //LO+35
 					{
 						rtcc->calcParams.TEI = OrbMech::HHMMSSToSS(35, 0, 0);
 					}
-					else if (rtcc->GETEval2(OrbMech::HHMMSSToSS(15, 0, 0))) //LO+25
+					else if (mcc_calcs.GETEval(OrbMech::HHMMSSToSS(15, 0, 0))) //LO+25
 					{
 						rtcc->calcParams.TEI = OrbMech::HHMMSSToSS(25, 0, 0);
 					}
-					else if (rtcc->GETEval2(OrbMech::HHMMSSToSS(8, 0, 0))) //LO+15
+					else if (mcc_calcs.GETEval(OrbMech::HHMMSSToSS(8, 0, 0))) //LO+15
 					{
 						rtcc->calcParams.TEI = OrbMech::HHMMSSToSS(15, 0, 0);
 					}
-					else if (rtcc->GETEval2(rtcc->calcParams.TLI + 90.0*60.0)) //LO+8
+					else if (mcc_calcs.GETEval(rtcc->calcParams.TLI + 90.0*60.0)) //LO+8
 					{
 						rtcc->calcParams.TEI = OrbMech::HHMMSSToSS(8, 0, 0);
 					}
@@ -756,7 +756,7 @@ void MCC::MissionSequence_H1()
 			break;
 			case 1:
 			{
-				if (rtcc->GETEval2(rtcc->calcParams.TEI + 10.0*60.0))
+				if (mcc_calcs.GETEval(rtcc->calcParams.TEI + 10.0*60.0))
 				{
 					startSubthread(205, UTP_NONE); //Evaluate EI conditions
 					setSubState(2);
@@ -775,7 +775,7 @@ void MCC::MissionSequence_H1()
 				break;
 			case 3:
 			{
-				if (rtcc->GETEval2(rtcc->calcParams.EI - 4.0*3600.0 - 35.0*60.0))
+				if (mcc_calcs.GETEval(rtcc->calcParams.EI - 4.0*3600.0 - 35.0*60.0))
 				{
 					SlowIfDesired();
 					setState(MST_H1_TRANSEARTH_DAY4_3);
@@ -784,7 +784,7 @@ void MCC::MissionSequence_H1()
 			break;
 			case 4:
 			{
-				if (rtcc->GETEval2(rtcc->calcParams.TEI + 4.0 * 60 * 60))
+				if (mcc_calcs.GETEval(rtcc->calcParams.TEI + 4.0 * 60 * 60))
 				{
 					SlowIfDesired();
 					setSubState(5);
@@ -853,7 +853,7 @@ void MCC::MissionSequence_H1()
 				}
 				break;
 			case 11: // Await burn
-				if (rtcc->GETEval2(rtcc->calcParams.EI - 4.0*3600.0 - 35.0*60.0))
+				if (mcc_calcs.GETEval(rtcc->calcParams.EI - 4.0*3600.0 - 35.0*60.0))
 				{
 					SlowIfDesired();
 					setState(MST_H1_TRANSEARTH_DAY4_3);
@@ -868,7 +868,7 @@ void MCC::MissionSequence_H1()
 			case 13:
 			{
 				//Wait until LOI + 2.5 hours, then calculate Pericynthion time and EI conditions for return trajectory
-				if (rtcc->GETEval2(rtcc->calcParams.LOI + 2.5*3600.0))
+				if (mcc_calcs.GETEval(rtcc->calcParams.LOI + 2.5*3600.0))
 				{
 					EphemerisData sv = rtcc->StateVectorCalcEphem(rtcc->calcParams.src);
 					double dt = OrbMech::timetoperi(sv.R, sv.V, OrbMech::mu_Moon);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_SL.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_SL.cpp
@@ -30,25 +30,25 @@ void MCC::MissionSequence_SL()
 	switch (MissionState)
 	{
 	case MST_SL_PRELAUNCH: //Scenario start to targeting update
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(-95.0*60.0), 1, MST_SL_PRELAUNCH_TARGETING);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(-95.0*60.0), 1, MST_SL_PRELAUNCH_TARGETING);
 		break;
 	case MST_SL_PRELAUNCH_TARGETING: //Targeting update to prelaunch
-		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, rtcc->GETEval2(-16.0*60.0), 2, MST_1B_PRELAUNCH);
+		UpdateMacro(UTP_CMCUPLINKONLY, PT_NONE, mcc_calcs.GETEval(-16.0*60.0), 2, MST_1B_PRELAUNCH);
 		break;
 	case MST_SL_INSERTION: //Insertion to Rendezvous planning
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(30.0*60.0), 10, MST_SL_RENDEZVOUS_PLAN);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(30.0*60.0), 10, MST_SL_RENDEZVOUS_PLAN);
 		break;
 	case MST_SL_RENDEZVOUS_PLAN: //Rendezvous planning to NC1 preliminary update
-		UpdateMacro(UTP_NONE, PT_NONE, rtcc->GETEval2(1.0*3600.0 + 35.0*60.0), 11, MST_SL_PRELIM_NC1);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(1.0*3600.0 + 35.0*60.0), 11, MST_SL_PRELIM_NC1);
 		break;
 	case MST_SL_PRELIM_NC1: //NC1 preliminary update to NC1 final update
-		UpdateMacro(UTP_PADONLY, PT_AP7MNV, rtcc->GETEval2(1.0 * 3600.0 + 55.0*60.0), 12, MST_SL_FINAL_NC1);
+		UpdateMacro(UTP_PADONLY, PT_AP7MNV, mcc_calcs.GETEval(1.0 * 3600.0 + 55.0*60.0), 12, MST_SL_FINAL_NC1);
 		break;
 	case MST_SL_FINAL_NC1: //NC1 final update to NC2 preliminary update
-		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, rtcc->GETEval2(3.0 * 3600.0 + 5.0*60.0), 13, MST_SL_PRELIM_NC2);
+		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP7MNV, mcc_calcs.GETEval(3.0 * 3600.0 + 5.0*60.0), 13, MST_SL_PRELIM_NC2);
 		break;
 	case MST_SL_PRELIM_NC2: //NC2 preliminary update to NC2 final update
-		UpdateMacro(UTP_PADONLY, PT_AP7MNV, rtcc->GETEval2(4.0 * 3600.0 + 12.0*60.0), 14, MST_SL_FINAL_NC2);
+		UpdateMacro(UTP_PADONLY, PT_AP7MNV, mcc_calcs.GETEval(4.0 * 3600.0 + 12.0*60.0), 14, MST_SL_FINAL_NC2);
 		break;
 	case MST_SL_FINAL_NC2: //NC2 final update to NCC preliminary update
 		UpdateMacro(UTP_PADONLY, PT_AP7MNV, SubStateTime > 2.0*60.0, 15, MST_SL_PRELIM_NCC);
@@ -57,22 +57,22 @@ void MCC::MissionSequence_SL()
 		UpdateMacro(UTP_PADONLY, PT_AP7MNV, SubStateTime > 2.0*60.0, 16, MST_SL_PRELIM_NSR);
 		break;
 	case MST_SL_PRELIM_NSR: //NSR preliminary update to NCC final update
-		UpdateMacro(UTP_PADONLY, PT_AP7MNV, rtcc->GETEval2(rtcc->calcParams.CSI - 24.0*60.0), 18, MST_SL_FINAL_NCC);
+		UpdateMacro(UTP_PADONLY, PT_AP7MNV, mcc_calcs.GETEval(rtcc->calcParams.CSI - 24.0*60.0), 18, MST_SL_FINAL_NCC);
 		break;
 	case MST_SL_FINAL_NCC: //NCC final update to NSR final update
 		UpdateMacro(UTP_PADONLY, PT_AP7MNV, SubStateTime > 2.0*60.0, 17, MST_SL_FINAL_NSR);
 		break;
 	case MST_SL_FINAL_NSR: //NSR final update to TPI preliminary update
-		UpdateMacro(UTP_PADONLY, PT_AP7MNV, rtcc->GETEval2(rtcc->calcParams.TPI - 32.0*60.0), 19, MST_SL_PRELIM_TPI);
+		UpdateMacro(UTP_PADONLY, PT_AP7MNV, mcc_calcs.GETEval(rtcc->calcParams.TPI - 32.0*60.0), 19, MST_SL_PRELIM_TPI);
 		break;
 	case MST_SL_PRELIM_TPI: //TPI preliminary update to docking attitude PAD
 		UpdateMacro(UTP_PADONLY, PT_AP7MNV, SubStateTime > 2.0*60.0, 20, MST_DOCKING_ATTITUDE_PAD);
 		break;
 	case MST_DOCKING_ATTITUDE_PAD: //Docking attitude PAD to TPI final update
-		UpdateMacro(UTP_PADONLY, PT_GENERIC, rtcc->GETEval2(rtcc->calcParams.TPI - 24.0*60.0), 22, MST_SL_FINAL_TPI);
+		UpdateMacro(UTP_PADONLY, PT_GENERIC, mcc_calcs.GETEval(rtcc->calcParams.TPI - 24.0*60.0), 22, MST_SL_FINAL_TPI);
 		break;
 	case MST_SL_FINAL_TPI: //TPI final update to Skylab Solar Inertial Command
-		UpdateMacro(UTP_PADONLY, PT_AP7MNV, rtcc->GETEval2(rtcc->calcParams.TPI + 3.0*60.0), 21, MST_SL_SOLAR_INERTIAL);
+		UpdateMacro(UTP_PADONLY, PT_AP7MNV, mcc_calcs.GETEval(rtcc->calcParams.TPI + 3.0*60.0), 21, MST_SL_SOLAR_INERTIAL);
 		break;
 	case MST_SL_SOLAR_INERTIAL: //Skylab Solar Inertial Command to
 		UpdateMacro(UTP_NONE, PT_NONE, false, 23, MST_ENTRY);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C.cpp
@@ -46,17 +46,15 @@ bool RTCC::CalculationMTP_C(int fcn, LPVOID &pad, char * upString, char * upDesc
 		char Buff[128];
 
 		//P80 MED: mission initialization
-		sprintf_s(Buff, "P80,1,CSM,%d,%d,%d;", GZGENCSN.MonthofLiftoff, GZGENCSN.DayofLiftoff, GZGENCSN.Year);
-		GMGMED(Buff);
+		mcc->mcc_calcs.PrelaunchMissionInitialization();
 
 		//P10 MED: Enter actual liftoff time
-		double TEPHEM0, tephem_scal;
+		double tephem_cs;
 		Saturn *cm = (Saturn *)calcParams.src;
 
-		//Get TEPHEM
-		TEPHEM0 = 40038.;
-		tephem_scal = GetTEPHEMFromAGC(&cm->agc.vagc, true);
-		double LaunchMJD = (tephem_scal / 8640000.) + TEPHEM0;
+		//Get TEPHEM from CMC
+		tephem_cs = GetTEPHEMFromAGC(&cm->agc.vagc, true);
+		double LaunchMJD = (tephem_cs / 8640000.) + SystemParameters.TEPHEM0;
 		LaunchMJD = (LaunchMJD - SystemParameters.GMTBASE)*24.0;
 
 		int hh, mm;
@@ -455,7 +453,7 @@ bool RTCC::CalculationMTP_C(int fcn, LPVOID &pad, char * upString, char * upDesc
 
 			opt.TIG = GET_TIG;
 			opt.dV_LVLH = dV_LVLH;
-			opt.enginetype = SPSRCSDecision(SystemParameters.MCTST1 / calcParams.src->GetMass(), dV_LVLH);
+			opt.enginetype = mcc->mcc_calcs.SPSRCSDecision(SystemParameters.MCTST1 / calcParams.src->GetMass(), dV_LVLH);
 			opt.HeadsUp = true;
 			opt.sxtstardtime = 0;
 			opt.REFSMMAT = GetREFSMMATfromAGC(&mcc->cm->agc.vagc, true);
@@ -650,7 +648,7 @@ bool RTCC::CalculationMTP_C(int fcn, LPVOID &pad, char * upString, char * upDesc
 			char buffer1[1000];
 			VECTOR3 dV_LVLH;
 			int enginetype;
-			enginetype = SPSRCSDecision(SystemParameters.MCTST1 / WeightsTable.ConfigWeight, res.dV);
+			enginetype = mcc->mcc_calcs.SPSRCSDecision(SystemParameters.MCTST1 / WeightsTable.ConfigWeight, res.dV);
 
 			in.CONFIG = 1; //CSM
 			in.CSMWeight = WeightsTable.CSMWeight;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_D.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_D.cpp
@@ -140,17 +140,15 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 		char Buff[128];
 
 		//P80 MED: mission initialization
-		sprintf_s(Buff, "P80,1,CSM,%d,%d,%d;", GZGENCSN.MonthofLiftoff, GZGENCSN.DayofLiftoff, GZGENCSN.Year);
-		GMGMED(Buff);
+		mcc->mcc_calcs.PrelaunchMissionInitialization();
 
 		//P10 MED: Enter actual liftoff time
-		double TEPHEM0, tephem_scal;
+		double tephem_scal;
 		Saturn *cm = (Saturn *)calcParams.src;
 
 		//Get TEPHEM
-		TEPHEM0 = 40038.;
 		tephem_scal = GetTEPHEMFromAGC(&cm->agc.vagc, true);
-		double LaunchMJD = (tephem_scal / 8640000.) + TEPHEM0;
+		double LaunchMJD = (tephem_scal / 8640000.) + SystemParameters.TEPHEM0;
 		LaunchMJD = (LaunchMJD - SystemParameters.GMTBASE)*24.0;
 
 		int hh, mm;
@@ -836,7 +834,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 		//Coast to uplink state vector time with total weight and LM area
 		sv1 = coast(sv0, GMTfromGET(90.0*3600.0) - sv0.GMT, med_m50.CSMWT + med_m50.LMWT, PZMPTLEM.ConfigurationArea, 1.0, false);
 
-		DMissionRendezvousPlan(ConvertEphemDatatoSV(sv1), t_TPI0);
+		mcc->mcc_calcs.DMissionRendezvousPlan(ConvertEphemDatatoSV(sv1), t_TPI0);
 
 		//Calculate LM REFSMMAT
 		opt.REFSMMATopt = 2;
@@ -942,7 +940,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 		sv = StateVectorCalcEphem(calcParams.src);
 		med_m50.LMWT = calcParams.tgt->GetMass();
 
-		DMissionRendezvousPlan(ConvertEphemDatatoSV(sv), t_TPI0);
+		mcc->mcc_calcs.DMissionRendezvousPlan(ConvertEphemDatatoSV(sv), t_TPI0);
 		//Store the TPI0 time here, the nominal TPI time is already stored in calcParams.TPI
 		TimeofIgnition = t_TPI0;
 
@@ -1535,7 +1533,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			dt = OrbMech::HHMMSSToSS(124, 0, 0) - OrbMech::GETfromMJD(sv0.MJD, GETbase);
 			sv1 = coast(sv0, dt);
 
-			FindRadarAOSLOS(sv1, 31.0*RAD, -115.5*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, 31.0*RAD, -115.5*RAD, GET_AOS, GET_LOS);
 			form->GETStart[0] = GET_AOS - 5.0*60.0;
 			form->OrbRate[0] = true;
 			form->OrbRate[2] = true;
@@ -1545,7 +1543,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			form->ExposureInterval[1] = 6.0;
 			form->ExposureNum[1] = 25;
 
-			FindRadarAOSLOS(sv1, 29.6667*RAD, -95.1667*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, 29.6667*RAD, -95.1667*RAD, GET_AOS, GET_LOS);
 			sprintf(form->Area[2], "Houston");
 			form->GETStart[2] = GET_AOS;
 			form->ExposureInterval[2] = 6.0;
@@ -1556,7 +1554,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			dt = OrbMech::HHMMSSToSS(125, 40, 0) - OrbMech::GETfromMJD(sv0.MJD, GETbase);
 			sv1 = coast(sv0, dt);
 
-			FindRadarAOSLOS(sv1, 19.3*RAD, -99.6667*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, 19.3*RAD, -99.6667*RAD, GET_AOS, GET_LOS);
 			form->GETStart[0] = GET_AOS - 5.0*60.0;
 			form->OrbRate[0] = true;
 			form->OrbRate[2] = true;
@@ -1571,7 +1569,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			dt = OrbMech::HHMMSSToSS(171, 10, 0) - OrbMech::GETfromMJD(sv0.MJD, GETbase);
 			sv1 = coast(sv0, dt);
 
-			FindRadarAOSLOS(sv1, 31.0*RAD, -115.5*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, 31.0*RAD, -115.5*RAD, GET_AOS, GET_LOS);
 			form->GETStart[0] = GET_AOS - 5.0*60.0;
 			form->OrbRate[0] = true;
 			form->OrbRate[2] = true;
@@ -1586,7 +1584,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			dt = OrbMech::HHMMSSToSS(172, 45, 0) - OrbMech::GETfromMJD(sv0.MJD, GETbase);
 			sv1 = coast(sv0, dt);
 
-			FindRadarAOSLOS(sv1, 19.3*RAD, -99.666*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, 19.3*RAD, -99.666*RAD, GET_AOS, GET_LOS);
 			form->GETStart[0] = GET_AOS - 5.0*60.0;
 			form->OrbRate[0] = true;
 			form->OrbRate[2] = true;
@@ -1596,7 +1594,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			form->ExposureInterval[1] = 6.0;
 			form->ExposureNum[1] = 25;
 
-			FindRadarAOSLOS(sv1, -19.81666*RAD, -43.3666*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, -19.81666*RAD, -43.3666*RAD, GET_AOS, GET_LOS);
 			sprintf(form->Area[2], "Brazil");
 			form->GETStart[2] = GET_AOS;
 			form->ExposureInterval[2] = 6.0;
@@ -1607,7 +1605,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			dt = OrbMech::HHMMSSToSS(190, 25, 0) - OrbMech::GETfromMJD(sv0.MJD, GETbase);
 			sv1 = coast(sv0, dt);
 
-			FindRadarAOSLOS(sv1, 31.91666*RAD, -105.0*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, 31.91666*RAD, -105.0*RAD, GET_AOS, GET_LOS);
 			form->GETStart[0] = GET_AOS - 5.0*60.0;
 			form->OrbRate[0] = true;
 			form->OrbRate[2] = true;
@@ -1617,13 +1615,13 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			form->ExposureInterval[1] = 6.0;
 			form->ExposureNum[1] = 6;
 
-			FindRadarAOSLOS(sv1, 29.1667*RAD, -89.333*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, 29.1667*RAD, -89.333*RAD, GET_AOS, GET_LOS);
 			sprintf(form->Area[2], "Southeast US");
 			form->GETStart[2] = GET_AOS;
 			form->ExposureInterval[2] = 6.0;
 			form->ExposureNum[2] = 6;
 
-			FindRadarAOSLOS(sv1, 17.0*RAD, -15.61667*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, 17.0*RAD, -15.61667*RAD, GET_AOS, GET_LOS);
 			sprintf(form->Area[3], "Africa");
 			form->GETStart[3] = GET_AOS;
 			form->ExposureInterval[3] = 12.0;
@@ -1634,7 +1632,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			dt = OrbMech::HHMMSSToSS(192, 0, 0) - OrbMech::GETfromMJD(sv0.MJD, GETbase);
 			sv1 = coast(sv0, dt);
 
-			FindRadarAOSLOS(sv1, 31.0*RAD, -115.5*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, 31.0*RAD, -115.5*RAD, GET_AOS, GET_LOS);
 			form->GETStart[0] = GET_AOS - 5.0*60.0;
 			form->OrbRate[0] = true;
 			form->OrbRate[2] = true;
@@ -1650,7 +1648,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			sv1 = coast(sv0, dt);
 
 			//Wilmington, North Carolina
-			FindRadarAOSLOS(sv1, 34.22333*RAD, -77.91222*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, 34.22333*RAD, -77.91222*RAD, GET_AOS, GET_LOS);
 			form->GETStart[0] = GET_AOS - 5.0*60.0;
 			form->OrbRate[0] = true;
 			form->OrbRate[2] = true;
@@ -1660,7 +1658,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			form->ExposureInterval[1] = 20;
 			form->ExposureNum[1] = 3;
 
-			FindRadarAOSLOS(sv1, -17.3667*RAD, 37.95*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, -17.3667*RAD, 37.95*RAD, GET_AOS, GET_LOS);
 			sprintf(form->Area[2], "Mozambique");
 			form->GETStart[2] = GET_AOS;
 			form->ExposureInterval[2] = 12.0;
@@ -1671,7 +1669,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 			dt = OrbMech::HHMMSSToSS(215, 55, 0) - OrbMech::GETfromMJD(sv0.MJD, GETbase);
 			sv1 = coast(sv0, dt);
 
-			FindRadarAOSLOS(sv1, 32.333*RAD, -107.667*RAD, GET_AOS, GET_LOS);
+			mcc->mcc_calcs.FindRadarAOSLOS(sv1, 32.333*RAD, -107.667*RAD, GET_AOS, GET_LOS);
 			form->GETStart[0] = GET_AOS - 5.0*60.0;
 			form->OrbRate[0] = true;
 			form->OrbRate[2] = true;
@@ -1976,7 +1974,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 		sv1 = coast(sv0, dt);
 
 		//Northern Mexico
-		FindRadarAOSLOS(sv1, 31.91666*RAD, -105.0*RAD, GET_AOS, GET_LOS);
+		mcc->mcc_calcs.FindRadarAOSLOS(sv1, 31.91666*RAD, -105.0*RAD, GET_AOS, GET_LOS);
 		t_align = GET_AOS - 5.0*60.0;
 
 		OrbMech::format_time_HHMMSS(buff, t_align);
@@ -2041,7 +2039,7 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 		sv0 = StateVectorCalc(calcParams.src);
 		t_guess = OrbMech::HHMMSSToSS(214, 21, 0);
 
-		t_align = FindOrbitalSunrise(sv0, t_guess);
+		t_align = mcc->mcc_calcs.FindOrbitalSunrise(sv0, t_guess);
 
 		OrbMech::format_time_HHMMSS(buff, t_align);
 		sprintf(form->paddata, "T Align is %s GET", buff);
@@ -2265,9 +2263,9 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 		sv1 = coast(sv0, dt);
 
 		//Carnarvon
-		FindRadarAOSLOS(sv1, -24.90619*RAD, 113.72595*RAD, GET_AOS, GET_LOS);
+		mcc->mcc_calcs.FindRadarAOSLOS(sv1, -24.90619*RAD, 113.72595*RAD, GET_AOS, GET_LOS);
 		//Hawaii
-		FindRadarAOSLOS(sv1, 21.44719*RAD, -157.76307*RAD, GET_AOS_HAW, GET_LOS_HAW);
+		mcc->mcc_calcs.FindRadarAOSLOS(sv1, 21.44719*RAD, -157.76307*RAD, GET_AOS_HAW, GET_LOS_HAW);
 
 		refsopt.csmlmdocked = false;
 		refsopt.dV_LVLH = _V(0, -1.0, 0.0); //Pointing north
@@ -2298,42 +2296,4 @@ bool RTCC::CalculationMTP_D(int fcn, LPVOID &pad, char * upString, char * upDesc
 	}
 
 	return scrubbed;
-}
-
-void RTCC::DMissionRendezvousPlan(SV sv_A0, double &t_TPI0)
-{
-	SV sv2;
-
-	//Step 1: Find TPI0 time (25 minutes before sunrise)
-	double TPI0_guess, TPI0_sunrise_guess, TPI0_sunrise, dt_sunrise;
-	dt_sunrise = 25.0*60.0;
-	TPI0_guess = OrbMech::HHMMSSToSS(95, 0, 0);
-	TPI0_sunrise_guess = TPI0_guess + dt_sunrise;
-	TPI0_sunrise = FindOrbitalSunrise(sv_A0, TPI0_sunrise_guess);
-	t_TPI0 = TPI0_sunrise - dt_sunrise;
-
-	//Step 2: Phasing is 70 minutes before TPI0
-	calcParams.Phasing = t_TPI0 - 70.0*60.0;
-
-	//Step 3: Insertion is 111:42 minutes after Phasing
-	calcParams.Insertion = calcParams.Phasing + 111.0*60.0 + 42.0;
-
-	//Step 4: CSI is two minutes (rounded) after 5° AOS of the TAN pass
-	double CSI_guess, lat_TAN, lng_TAN, AOS_TAN, LOS_TAN;
-	lat_TAN = groundstations[13][0];
-	lng_TAN = groundstations[13][1];
-	CSI_guess = calcParams.Insertion + 40.0*60.0;
-	sv2 = coast(sv_A0, CSI_guess - OrbMech::GETfromMJD(sv_A0.MJD, CalcGETBase()));
-	FindRadarAOSLOS(sv2, lat_TAN, lng_TAN, AOS_TAN, LOS_TAN);
-	calcParams.CSI = (floor(AOS_TAN / 60.0) + 2.0)*60.0;
-
-	//Step 5: CDH is placed 44.4 minutes after CSI
-	calcParams.CDH = calcParams.CSI + 44.4*60.0;
-
-	//Step 6: Find TPI0 time (25 minutes before sunrise)
-	double TPI_guess, TPI_sunrise_guess, TPI_sunrise;
-	TPI_guess = OrbMech::HHMMSSToSS(98, 0, 0);
-	TPI_sunrise_guess = TPI_guess + dt_sunrise;
-	TPI_sunrise = FindOrbitalSunrise(sv_A0, TPI_sunrise_guess);
-	calcParams.TPI = TPI_sunrise - dt_sunrise;
 }

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
@@ -100,17 +100,15 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		char Buff[128];
 
 		//P80 MED: mission initialization
-		sprintf_s(Buff, "P80,1,CSM,%d,%d,%d;", GZGENCSN.MonthofLiftoff, GZGENCSN.DayofLiftoff, GZGENCSN.Year);
-		GMGMED(Buff);
+		mcc->mcc_calcs.PrelaunchMissionInitialization();
 
 		//P10 MED: Enter actual liftoff time
-		double TEPHEM0, tephem_scal;
+		double tephem_scal;
 		Saturn *cm = (Saturn *)calcParams.src;
 
 		//Get TEPHEM
-		TEPHEM0 = 40403.;
 		tephem_scal = GetTEPHEMFromAGC(&cm->agc.vagc, true);
-		double LaunchMJD = (tephem_scal / 8640000.) + TEPHEM0;
+		double LaunchMJD = (tephem_scal / 8640000.) + SystemParameters.TEPHEM0;
 		LaunchMJD = (LaunchMJD - SystemParameters.GMTBASE)*24.0;
 
 		int hh, mm;
@@ -179,7 +177,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		PMSVCT(4, RTCC_MPT_CSM, sv0);
 
 		//Add TLI to MPT
-		if (GETEval2(3.0*3600.0))
+		if (mcc->mcc_calcs.GETEval(3.0*3600.0))
 		{
 			//Second opportunity
 			GMGMED("M68,CSM,2;");
@@ -478,7 +476,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 			else
 			{
 				calcParams.LOI = PZMCCDIS.data[0].GET_LOI;
-				engine = SPSRCSDecision(SPS_THRUST / (CSMmass + LMmass), PZMCCDIS.data[0].DV_MCC);
+				engine = mcc->mcc_calcs.SPSRCSDecision(SPS_THRUST / (CSMmass + LMmass), PZMCCDIS.data[0].DV_MCC);
 				PoweredFlightProcessor(sv, CSMmass, PZMCCPLN.MidcourseGET, engine, LMmass, PZMCCXFR.V_man_after[0] - PZMCCXFR.sv_man_bef[0].V, false, P30TIG, dV_LVLH);
 			}
 		}
@@ -524,7 +522,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 				manopt.WeightsTable = GetWeightsTable(calcParams.src, true, true);
 				manopt.TIG = P30TIG;
 				manopt.dV_LVLH = dV_LVLH;
-				manopt.enginetype = SPSRCSDecision(SPS_THRUST / manopt.WeightsTable.ConfigWeight, dV_LVLH);
+				manopt.enginetype = mcc->mcc_calcs.SPSRCSDecision(SPS_THRUST / manopt.WeightsTable.ConfigWeight, dV_LVLH);
 				manopt.HeadsUp = true;
 				manopt.REFSMMAT = GetREFSMMATfromAGC(&mcc->cm->agc.vagc, true);
 				manopt.RV_MCC = sv;
@@ -598,7 +596,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 			GMGMED("F30,1;");
 
 			calcParams.LOI = PZMCCDIS.data[0].GET_LOI;
-			engine = SPSRCSDecision(SPS_THRUST / WeightsTable.ConfigWeight, PZMCCDIS.data[0].DV_MCC);
+			engine = mcc->mcc_calcs.SPSRCSDecision(SPS_THRUST / WeightsTable.ConfigWeight, PZMCCDIS.data[0].DV_MCC);
 			PoweredFlightProcessor(sv, WeightsTable.CSMWeight, PZMCCPLN.MidcourseGET, engine, WeightsTable.LMAscWeight + WeightsTable.LMDscWeight, PZMCCXFR.V_man_after[0] - PZMCCXFR.sv_man_bef[0].V, false, P30TIG, dV_LVLH);
 
 			manopt.TIG = P30TIG;
@@ -654,7 +652,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 
 		opt.TIG = res.P30TIG;
 		opt.dV_LVLH = res.dV_LVLH;
-		opt.enginetype = SPSRCSDecision(SPS_THRUST / (calcParams.src->GetMass() + calcParams.tgt->GetMass()), res.dV_LVLH);
+		opt.enginetype = mcc->mcc_calcs.SPSRCSDecision(SPS_THRUST / (calcParams.src->GetMass() + calcParams.tgt->GetMass()), res.dV_LVLH);
 		opt.HeadsUp = false;
 		opt.REFSMMAT = GetREFSMMATfromAGC(&mcc->cm->agc.vagc, true);
 		opt.RV_MCC = ConvertSVtoEphemData(sv);
@@ -776,7 +774,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 
 			calcParams.LOI = PZMCCDIS.data[0].GET_LOI;
 
-			engine = SPSRCSDecision(SPS_THRUST / WeightsTable.ConfigWeight, dv);
+			engine = mcc->mcc_calcs.SPSRCSDecision(SPS_THRUST / WeightsTable.ConfigWeight, dv);
 			PoweredFlightProcessor(sv, WeightsTable.CSMWeight, tig, engine, WeightsTable.LMAscWeight + WeightsTable.LMDscWeight, dv, false, P30TIG, dV_LVLH);
 
 			manopt.TIG = P30TIG;
@@ -908,7 +906,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 			tig = GETfromGMT(PZMCCXFR.sv_man_bef[0].GMT);
 			dv = PZMCCXFR.V_man_after[0] - PZMCCXFR.sv_man_bef[0].V;
 
-			engine = SPSRCSDecision(SPS_THRUST / WeightsTable.ConfigWeight, dv);
+			engine = mcc->mcc_calcs.SPSRCSDecision(SPS_THRUST / WeightsTable.ConfigWeight, dv);
 			PoweredFlightProcessor(sv, WeightsTable.CSMWeight, tig, engine, WeightsTable.LMAscWeight + WeightsTable.LMDscWeight, dv, false, P30TIG, dV_LVLH);
 
 			manopt.TIG = P30TIG;
@@ -971,7 +969,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		AP11ManeuverPAD(opt, *form);
 		sprintf(form->remarks, "Assumes LS REFSMMAT and docked");
 
-		if (!REFSMMATDecision(form->Att*RAD))
+		if (!mcc->mcc_calcs.REFSMMATDecision(form->Att*RAD))
 		{
 			REFSMMATOpt refsopt;
 			MATRIX3 REFSMMAT;
@@ -1626,9 +1624,9 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		t_sunrise2 = calcParams.PDI + 5.0*3600.0;
 
 		//Find two TPI opportunities
-		t_TPI = FindOrbitalSunrise(sv, t_sunrise1) - 23.0*60.0;
+		t_TPI = mcc->mcc_calcs.FindOrbitalSunrise(sv, t_sunrise1) - 23.0*60.0;
 		form->T_TPI_Pre10Min = round(t_TPI);
-		t_TPI = FindOrbitalSunrise(sv, t_sunrise2) - 23.0*60.0;
+		t_TPI = mcc->mcc_calcs.FindOrbitalSunrise(sv, t_sunrise2) - 23.0*60.0;
 		form->T_TPI_Post10Min = round(t_TPI);
 
 		//Phasing 67 minutes after PDI
@@ -1664,7 +1662,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		sv_LM2 = ConvertEphemDatatoSV(sv_DOI, WeightsTable_LM2.ConfigWeight);
 
 		t_sunrise = calcParams.PDI + 3.0*3600.0;
-		t_TPI = FindOrbitalSunrise(sv_CSM2, t_sunrise) - 23.0*60.0;
+		t_TPI = mcc->mcc_calcs.FindOrbitalSunrise(sv_CSM2, t_sunrise) - 23.0*60.0;
 
 		GZGENCSN.TIElevationAngle = 26.6*RAD;
 
@@ -1750,7 +1748,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		t_CSI1 = t_C1 + dt2;
 
 		t_sunrise = calcParams.PDI + 7.0*3600.0;
-		t_TPI = FindOrbitalSunrise(sv_CSM, t_sunrise) - 23.0*60.0;
+		t_TPI = mcc->mcc_calcs.FindOrbitalSunrise(sv_CSM, t_sunrise) - 23.0*60.0;
 		//Round to next 30 seconds
 		t_TPI = round(t_TPI / 30.0)*30.0;
 
@@ -1766,7 +1764,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 
 		//Calculate TPI time for T3
 		t_sunrise = calcParams.PDI + 5.0*3600.0;
-		t_TPI = FindOrbitalSunrise(sv_CSM, t_sunrise) - 23.0*60.0;
+		t_TPI = mcc->mcc_calcs.FindOrbitalSunrise(sv_CSM, t_sunrise) - 23.0*60.0;
 		//Round to next 30 seconds
 		t_TPI = round(t_TPI / 30.0)*30.0;
 
@@ -1925,7 +1923,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 
 		//Calculate TPI time for T3
 		t_sunrise = calcParams.PDI + 5.0*3600.0;
-		t_TPI = FindOrbitalSunrise(sv_CSM, t_sunrise) - 23.0*60.0;
+		t_TPI = mcc->mcc_calcs.FindOrbitalSunrise(sv_CSM, t_sunrise) - 23.0*60.0;
 		//Round to next 30 seconds
 		t_TPI = round(t_TPI / 30.0)*30.0;
 
@@ -2098,7 +2096,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		}
 
 		double t_TPI;
-		t_TPI = FindOrbitalSunrise(sv_CSM, t_TPI_guess) - 23.0*60.0;
+		t_TPI = mcc->mcc_calcs.FindOrbitalSunrise(sv_CSM, t_TPI_guess) - 23.0*60.0;
 		//Round to next 30 seconds
 		t_TPI = round(t_TPI / 30.0)*30.0;
 		opt.t_hole = GMTfromGET(t_TPI);
@@ -2125,7 +2123,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 			form->TIG[i] = PZLRPT.data[1].GETLO;
 
 			t_TPI_guess += 2.0*3600.0;
-			t_TPI = FindOrbitalSunrise(sv_CSM, t_TPI_guess) - 23.0*60.0;
+			t_TPI = mcc->mcc_calcs.FindOrbitalSunrise(sv_CSM, t_TPI_guess) - 23.0*60.0;
 			//Round to next 30 seconds
 			t_TPI = round(t_TPI / 30.0)*30.0;
 			opt.t_hole = GMTfromGET(t_TPI);
@@ -2273,7 +2271,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 
 		//Rev 24 is the nominal for this update. Nominal TPI time is about 24.5 hours after PDI
 		t_TPI_guess = calcParams.PDI + 24.5*3600.0 + 23.0*60.0 + 2.0*3600.0*(double)(mcc->MoonRev - 24);
-		t_TPI = FindOrbitalSunrise(sv_CSM, t_TPI_guess) - 23.0*60.0;
+		t_TPI = mcc->mcc_calcs.FindOrbitalSunrise(sv_CSM, t_TPI_guess) - 23.0*60.0;
 		//Round to next 30 seconds
 		t_TPI = round(t_TPI / 30.0)*30.0;
 
@@ -2563,7 +2561,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 				opt.WeightsTable = GetWeightsTable(calcParams.src, true, false);
 				opt.TIG = res.P30TIG;
 				opt.dV_LVLH = res.dV_LVLH;
-				opt.enginetype = SPSRCSDecision(SPS_THRUST / opt.WeightsTable.ConfigWeight, res.dV_LVLH);
+				opt.enginetype = mcc->mcc_calcs.SPSRCSDecision(SPS_THRUST / opt.WeightsTable.ConfigWeight, res.dV_LVLH);
 				opt.HeadsUp = false;
 				opt.REFSMMAT = REFSMMAT;
 				opt.RV_MCC = ConvertSVtoEphemData(sv);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_SL.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_SL.cpp
@@ -44,8 +44,7 @@ bool RTCC::CalculationMTP_SL(int fcn, LPVOID &pad, char * upString, char * upDes
 	case 1: //MISSION INITIALIZATION
 	{
 		//P80 MED: mission initialization
-		sprintf_s(Buff, "P80,1,CSM,%d,%d,%d;", GZGENCSN.MonthofLiftoff, GZGENCSN.DayofLiftoff, GZGENCSN.Year);
-		GMGMED(Buff);
+		mcc->mcc_calcs.PrelaunchMissionInitialization();
 
 		//P10 MED: Predicted liftoff time
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -2604,7 +2604,6 @@ public:
 	AEGBlock SVToAEG(EphemerisData sv, double Area, double Weight, double KFactor);
 	//Apsides Determination Subroutine
 	int PMMAPD(AEGHeader Header, AEGDataBlock Z, int KAOP, int KE, double *INFO, AEGDataBlock *sv_A, AEGDataBlock *sv_P);
-	bool GETEval2(double get);
 	bool PDIIgnitionAlgorithm(SV sv, VECTOR3 R_LS, double TLAND, SV &sv_IG, double &t_go, double &CR, VECTOR3 &U_IG, MATRIX3 &REFSMMAT);
 	bool PoweredDescentAbortProgram(PDAPOpt opt, PDAPResults &res);
 	MATRIX3 GetREFSMMATfromAGC(agc_t *agc, bool cmc);
@@ -5031,16 +5030,8 @@ private:
 	void SunburstLMPCommand(char *list, int code);
 	void SunburstMassUpdate(char *list, double masskg);
 	void P27PADCalc(const P27Opt &opt, P27PAD &pad);
-	int SPSRCSDecision(double a, VECTOR3 dV_LVLH);	//0 = SPS, 1 = RCS
-	bool REFSMMATDecision(VECTOR3 Att); //true = everything ok, false = Preferred REFSMMAT necessary
-	double FindOrbitalMidnight(SV sv, double t_TPI_guess);
-	double FindOrbitalSunrise(SV sv, double t_sunrise_guess);
-	void FindRadarAOSLOS(SV sv, double lat, double lng, double &GET_AOS, double &GET_LOS);
-	void FindRadarMidPass(SV sv, double lat, double lng, double &GET_Mid);
 	void papiWriteScenario_REFS(FILEHANDLE scn, char *item, int tab, int i, REFSMMATData in);
 	bool papiReadScenario_REFS(char *line, char *item, int &tab, int &i, REFSMMATData &out);
-	void DMissionRendezvousPlan(SV sv_A0, double &t_TPI0);
-	void FMissionRendezvousPlan(VESSEL *chaser, VESSEL *target, SV sv_A0, double t_TIG, double t_TPI, double &t_Ins, double &CSI);
 
 	bool CalculationMTP_B(int fcn, LPVOID &pad, char * upString = NULL, char * upDesc = NULL, char * upMessage = NULL);
 	bool CalculationMTP_C(int fcn, LPVOID &pad, char * upString = NULL, char * upDesc = NULL, char * upMessage = NULL);


### PR DESCRIPTION
This PR only moves several functions, that are used by the MCC but are not real RTCC functions, from the RTCC class to the new MCC Calculations class. As a start of a more substantial restructuring it also does a small part of the mission initialization in a utility function now. This part I have tested.

This PR will cause some merge conflicts with work-in-progress MCC updates like #1321 but they should be easy to fix.