### PR TITLE
Apollo 11 MCC Followup Corrections

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/MCC_Mission_G.cpp
@@ -372,7 +372,7 @@ void MCC::MissionSequence_G()
 		UpdateMacro(UTP_PADONLY, PT_AP11ENT, mcc_calcs.GETEval(rtcc->calcParams.EI - 6.0*3600.0), 116, MST_G_TRANSEARTH_8);
 		break;
 	case MST_G_TRANSEARTH_8: //MCC-7 decision update to MCC-7 update
-		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.EI - 4.0*3600.0 - 35.0*60.0), 113, MST_G_TRANSEARTH_9);
+		UpdateMacro(UTP_NONE, PT_NONE, mcc_calcs.GETEval(rtcc->calcParams.EI - 4.0*3600.0 - 30.0*60.0), 113, MST_G_TRANSEARTH_9);
 		break;
 	case MST_G_TRANSEARTH_9: //MCC-7 update to Entry PAD update
 		UpdateMacro(UTP_PADWITHCMCUPLINK, PT_AP11MNV, SubStateTime > 3.0*60.0, 114, MST_G_TRANSEARTH_10);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
@@ -876,7 +876,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 			sprintf(upMessage, "MCC-4 has been scrubbed");
 			sprintf(upDesc, "CSM state vector, Landing Site REFSMMAT");
 
-			AGCStateVectorUpdate(buffer1, RTCC_MPT_CSM, RTCC_MPT_CSM, sv, true);
+			AGCStateVectorUpdate(buffer1, RTCC_MPT_CSM, RTCC_MPT_CSM, sv);
 			AGCDesiredREFSMMATUpdate(buffer2, REFSMMAT);
 
 			sprintf(uplinkdata, "%s%s", buffer1, buffer2);

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
@@ -358,7 +358,6 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		opt.WeightsTable = GetWeightsTable(calcParams.src, true, true);
 
 		AP11ManeuverPAD(opt, *form);
-		form->type = 2;
 
 		sprintf(form->purpose, "Evasive");
 		sprintf(form->remarks, "No ullage, LM weight is %.0f.", form->LMWeight);


### PR DESCRIPTION
- Remove V66 uplink at MCC4 calculation
- Change Apollo 11 evasive maneuver pad back to form 1 to include dvc
- Change MCC7 update time