### PR TITLE
Both MCC and RTCC MFD can use the entry target line setting from the RTE constraints page

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -4191,7 +4191,7 @@ public:
 		double RTEUADVMax;
 		double RTEPTPMissDistance;
 		double RTEInclination;
-		int EntryProfile;
+		int EntryProfile;  //0 = guided reentry to the shallow target line, 1 = manual reentry to the shallow target line, 2 = manual reentry to the steep target line
 		int RTETradeoffRemotePage;
 		int RTESiteNum;
 		bool RTEIsPTPSite;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -4992,6 +4992,21 @@ int ARCore::subThread()
 			}
 			EphemerisData sv = GC->rtcc->StateVectorCalcEphem(v);
 			GC->rtcc->PZREAP.RTEVectorTime = sv.GMT / 3600.0;
+			if (GC->rtcc->PZREAP.TGTLN == 1)
+			{
+				GC->rtcc->PZREAP.EntryProfile = 2;
+			}
+			else
+			{
+				if (GC->rtcc->med_f75_f77.EntryProfile == "HB1")
+				{
+					GC->rtcc->PZREAP.EntryProfile = 1;
+				}
+				else
+				{
+					GC->rtcc->PZREAP.EntryProfile = 0;
+				}
+			}
 			GC->rtcc->PMMREAST(RTEASTType, &sv);
 		}
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -4961,17 +4961,17 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 
 		skp->SetTextAlign(oapi::Sketchpad::LEFT);
 
+		if (GC->rtcc->med_m65.Table == 1)
+		{
+			skp->Text(1 * W / 16, 2 * H / 14, "CSM", 3);
+		}
+		else
+		{
+			skp->Text(1 * W / 16, 2 * H / 14, "LEM", 3);
+		}
+
 		if (GC->MissionPlanningActive)
 		{
-			if (GC->rtcc->med_m65.Table == 1)
-			{
-				skp->Text(1 * W / 16, 2 * H / 14, "CSM", 3);
-			}
-			else
-			{
-				skp->Text(1 * W / 16, 2 * H / 14, "LEM", 3);
-			}
-
 			if (GC->rtcc->med_m65.ReplaceCode == 0)
 			{
 				skp->Text(1 * W / 16, 4 * H / 14, "Don't replace", 13);


### PR DESCRIPTION
… to decide between steep and shallow target line, for both Earth and Moon centered RTE maneuvers.

Also adds saving/loaded of the TGTLN parameter from the RTE constraints.

EDIT:

-A small fix to the RTCC MFD display for transferring GPM maneuvers was added to this PR.
-Sunrise/sunset display finds more environment changes than before