### PR TITLE
Improve stability of S-IVB Auxiliary Propulsion System attitude control with time acceleration

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_saturn/sivbsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/sivbsystems.cpp
@@ -1550,14 +1550,21 @@ void SIVBSystems::SetAPSAttitudeEngine(int n, bool on)
 {
 	if (apsThrusters[0])
 	{
+		double Level;
+
 		if (on)
 		{
-			vessel->SetThrusterLevel(apsThrusters[n], 1.0);
+			Level = vessel->GetThrusterLevel(apsThrusters[n]);
+
+			//On the first timestep when an APS thruster is fired, cause a minimum impulse firing (7.5 lbf-sec impulse with 150 lbf thrust equals 50 milliseconds)
+			Level += 0.05 / oapiGetSimStep();
+			Level = min(1.0, Level);
 		}
 		else
 		{
-			vessel->SetThrusterLevel(apsThrusters[n], 0.0);
+			Level = 0.0;
 		}
+		vessel->SetThrusterLevel(apsThrusters[n], Level);
 	}
 }
 


### PR DESCRIPTION
This is the same scheme we use in the CSM. Instead of only simulating full or zero thrust for APS thrusters, this change makes it so that on the first timestep when an APS thruster is commanded on it will only give the amount of impulse of a minimum impulse firing (which gives 7.5 lbf-sec of impulse according to various documentation). During time acceleration full thrust for one timestep might have already been enough to cancel out and overshoot the existing attitude rate, leading to a control stability problems or at least increased propellant consumption. With every timestep that the FCC actually wants the APS thruster on the thrust gets increased, so eventually it will (like before) reach full thrust.

Examples:
-60 fps and 144 fps at 1.0x time acceleration go to full thrust, like before
-With 60 fps and 10x time acceleration it would go from 0% to 30% thrust on the first timestep when the thruster is commanded on. As long as the FCC wants the thruster on, every timestep increases the thrust by 30% until it reaches 100%.
-With 144 fps and 10x time acceleration the thrust goes from 0% to 72% and then on the next timestep to 100%. So barely a change in behavior.

And yes I know, we need this sort of thing in the LM, too. :D