### PR TITLE
Don't Delete ASTP DM Docking Port 1 for Soyuz Docking

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_saturn/Astp.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/Astp.cpp
@@ -137,11 +137,6 @@ void ASTP::Setup()
 
 void ASTP::clbkPreStep(double simt, double simdt, double mjd)
 {
-	// Delete DM/SLA docking port at DM extraction from SIVB
-	if (docksla && !DockingStatus(1)) {
-		DelDock(docksla);
-		docksla = NULL;
-	}
 }
 
 void ASTP::clbkDockEvent(int dock, OBJHANDLE connected)
@@ -160,12 +155,6 @@ void ASTP::clbkDockEvent(int dock, OBJHANDLE connected)
 	}
 }
 void ASTP::clbkPostCreation() {
-
-	// Delete DM/SLA docking port if DM extracted from SIVB
-	if (docksla && !DockingStatus(1)) {
-		DelDock(docksla);
-		docksla = NULL;
-	}
 }
 
 void ASTP::StartSeparationPyros()


### PR DESCRIPTION
The DM docking port set up for SLA connections is convieniently in the correct position to allow for docking with Soyuz, so the deletion of it at extraction can be removed.