### PR TITLE
Correct Telescope 25 degree switch behavior

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/CSMcomputer.cpp
@@ -831,8 +831,8 @@ void CMOptics::TimeStep(double simdt) {
 		case THREEPOSSWITCH_CENTER:		// 0 DEG
 			TeleTrunionTarget = 0;
 			break;
-		case THREEPOSSWITCH_DOWN:		// OFFSET 25 DEG
-			TeleTrunionTarget = SextTrunion + 25.0*RAD;
+		case THREEPOSSWITCH_DOWN:		// Fixed 25 degrees
+			TeleTrunionTarget = 25.0*RAD;
 			break;
 	}
 


### PR DESCRIPTION
Fix the 25 degree switch to properly go to a *fixed* 25 degree trunnion instead of a 25 degree offset from sextant.

Per the AOH: 

With the switch in the 25° position, an external voltage is applied to
the same lX receiving resolver which will cause the SCT trunnion position
loop to null out so that the centerline of the 60-degree field-of-view is
offset 25 degrees (At of SCT at 12.5 degrees) from the LLOS of the SXT.
This position of the SCT trunnion will allow the landmark to remain in the
60-degree field-of-view while still providing a total possible field-of-view
of 110 degrees if the SCT shaft is swept through 360 degrees . 

Additional documentation was checked in discord and agrees with this.  This switch simplifies the P23 process when working correctly.