### PR TITLE
RTCC MFD: Simplify REFSMMAT uplink options (no distinction between MPT and non-MPT mode) and make all RTCC REFSMMATs available for uplink

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -5917,16 +5917,8 @@ void ApolloRTCCMFD::menuLMLSUpload()
 
 void ApolloRTCCMFD::menuREFSMMATUplinkCalc()
 {
-	if (GC->MissionPlanningActive)
-	{
-		bool REFSMMATUplinkCalcMPTInput(void *id, char *str, void *data);
-		oapiOpenInputBox("Format: C12,VEH. COMPUTER,REFSMMAT,ADDRESS; VEH. COMPUTER = CMC, LGC. REFSMMAT = CUR, PCR, TLM, MED, LCV, OST, DMT, DOD, DOK, LLA, LLD. ADDRESS = 1 for actual, 2 for desired REFSMMAT", REFSMMATUplinkCalcMPTInput, 0, 20, (void*)this);
-	}
-	else
-	{
-		bool REFSMMATUplinkCalcInput(void *id, char *str, void *data);
-		oapiOpenInputBox("Format: 1 for actual REFSMMAT, 2 for desired REFSMMAT", REFSMMATUplinkCalcInput, 0, 20, (void*)this);
-	}
+	bool REFSMMATUplinkCalcInput(void *id, char *str, void *data);
+	oapiOpenInputBox("Format: REFSMMAT ADDRESS. REFSMMAT = CUR, PCR, TLM, MED, LCV, OST, DMT, DOD, DOK, LLA, LLD. ADDRESS = 1 for actual, 2 for desired REFSMMAT", REFSMMATUplinkCalcInput, "CUR 2", 20, (void*)this);
 }
 
 bool REFSMMATUplinkCalcInput(void *id, char *str, void *data)
@@ -5936,8 +5928,9 @@ bool REFSMMATUplinkCalcInput(void *id, char *str, void *data)
 
 bool ApolloRTCCMFD::REFSMMATUplinkCalc(char *str)
 {
+	char Buff1[4];
 	int type;
-	if (sscanf(str, "%d", &type) == 1)
+	if (sscanf_s(str, "%s %d", Buff1, 4, &type) == 2)
 	{
 		if (type >= 1 && type <= 2)
 		{
@@ -5951,18 +5944,12 @@ bool ApolloRTCCMFD::REFSMMATUplinkCalc(char *str)
 			{
 				sprintf_s(veh, "LGC");
 			}
-			sprintf_s(str2, 32, "C12,%s,CUR,%d;", veh, type);
+			sprintf_s(str2, 32, "C12,%s,%s,%d;", veh, Buff1, type);
 			GeneralMEDRequest(str2);
 			return true;
 		}
 	}
 	return false;
-}
-
-bool REFSMMATUplinkCalcMPTInput(void *id, char *str, void *data)
-{
-	((ApolloRTCCMFD*)data)->GeneralMEDRequest(str);
-	return true;
 }
 
 void ApolloRTCCMFD::menuCycleTwoImpulseOption()


### PR DESCRIPTION
Previous behavior:
-In MPT mode the C12 MED has to be entered in correct format. All REFSMMATs available and actual vs. desired can be selected
-In non-MPT mode only actual vs. desired can be selected by entering 1 or 2. Only the CUR REFSMMAT is selected.

New behavior:
-In both modes all REFSMMATs are available for uplink. The MFD input box is prefilled with "CUR 2" to uplink the current REFSMMAT as the desired one, but these inputs can be changed.