### PR TITLE
Fix two RTCC bugs

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -14262,7 +14262,14 @@ void RTCC::EMMDYNEL(EphemerisData sv, TimeConstraintsTable &tab)
 		tab.RA = PI2 - tab.RA;
 	}
 	tab.sv_present = sv;
-	tab.T0 = OrbMech::period(sv.R, sv.V, mu);
+	if (tab.e < 1.0)
+	{
+		tab.T0 = OrbMech::period(sv.R, sv.V, mu);
+	}
+	else
+	{
+		tab.T0 = 0.0;
+	}
 	tab.TA = acos2(dotp(unit(E), unit(sv.R)));
 	if (dotp(sv.R, sv.V) < 0)
 	{

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -6439,6 +6439,8 @@ void ApolloRTCCMFD::GetEntryTargetfromAGC()
 
 	if (utils::IsVessel(v, utils::Saturn) == false) return;
 
+	Saturn *saturn = (Saturn *)v;
+
 	unsigned short Entryoct[6];
 	Entryoct[2] = saturn->agc.vagc.Erasable[0][03400];
 	Entryoct[3] = saturn->agc.vagc.Erasable[0][03401];

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -882,8 +882,6 @@ protected:
 	oapi::Font *font5;
 	oapi::Pen *pen;
 	oapi::Pen *pen2;
-	Saturn *saturn;
-	LEM *lem;
 	int screen;
 	int subscreen;
 	int marker;


### PR DESCRIPTION
-Splashdown coordinates downlink from the CMC to the RTCC on the Entry PAD page was broken
-Present position data calculation for FDO Orbit Digitals calculates orbital period even for a hyperbolic orbit, which could lead to a graphics CTD when trying to show this number