### PR TITLE
MCC: Don't reset the scrubbed variable in MCC code; this enables the …

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
@@ -4002,7 +4002,6 @@ void MCC::UpdateMacro(int type, int padtype, bool condition, int updatenumber, i
 						addMessage(upMessage);
 					}
 					freePad();
-					scrubbed = false;
 					setSubState(2);
 				}
 				else
@@ -4053,7 +4052,6 @@ void MCC::UpdateMacro(int type, int padtype, bool condition, int updatenumber, i
 						addMessage(upMessage);
 					}
 					freePad();
-					scrubbed = false;
 				}
 				else
 				{
@@ -4223,7 +4221,6 @@ void MCC::UpdateMacro(int type, int padtype, bool condition, int updatenumber, i
 						addMessage(upMessage);
 					}
 					freePad();
-					scrubbed = false;
 				}
 				else
 				{


### PR DESCRIPTION
…variable to be used by all MCC update types; fixes Apollo 12 MCC bug where a PTC decision update is given despite MCC-3 being scrubbed