### PR TITLE
Saturn V: Don't calculate the ApolloNo if it has not been set in the launch scenario

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_saturn/Saturn5.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/Saturn5.cpp
@@ -597,14 +597,6 @@ void SaturnV::SetVehicleStats(){
 	}
 
 	CalculateStageMass ();
-
-	//
-	// Calculate Apollo mission number.
-	//
-
-	if (!ApolloNo && (VehicleNo >= 503 && VehicleNo <= 512)) {
-		ApolloNo = VehicleNo - 495;
-	}
 }
 
 void SaturnV::SaveVehicleStats(FILEHANDLE scn)


### PR DESCRIPTION
Background:

In the long term I want to get rid of the (integer) Apollo mission number that is used to e.g. load mission files, launch audio etc. Instead a mission name (string) has already been introduced which works for the Skylab missions so far (no LM). If only a mission name has been set the ApolloNo remains 0, the default value. This works with the Saturn IB (CSM only launches) and I thought it also worked with the Saturn V, but there is this piece of code which "calculates" an ApolloNo if it is 0. Removing this piece of code will make the mission name system work for Saturn V. All our current launch scenarios load the APOLLONO already, so this piece of code is not really required.