### PR TITLE
MCC: Reduce text size of annotations from 0.65 to 0.60 scale

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
@@ -575,11 +575,11 @@ void MCC::Init(){
 	// CAPCOM INTERFACE INITIALIZATION
 	// Get handles to annotations.
 	// The menu lives in the top left, the message box to the right of that
-	NHmenu = oapiCreateAnnotation(false,0.65,_V(1,1,0));
+	NHmenu = oapiCreateAnnotation(false,0.60,_V(1,1,0));
 	oapiAnnotationSetPos(NHmenu,0,0,0.15,0.2);
-	NHmessages = oapiCreateAnnotation(false,0.65,_V(1,1,0));
+	NHmessages = oapiCreateAnnotation(false,0.60,_V(1,1,0));
 	oapiAnnotationSetPos(NHmessages,0.18,0,0.87,0.2);
-	NHpad = oapiCreateAnnotation(false,0.65,_V(1,1,0));
+	NHpad = oapiCreateAnnotation(false,0.60,_V(1,1,0));
 	oapiAnnotationSetPos(NHpad,0,0.2,0.33,1);
 	// Clobber message output buffer
 	msgOutputBuf[0] = 0;


### PR DESCRIPTION
This allows additional lines of remarks to be shown for Maneuver PADs and prevents some cases of overlap between the CAPCOM menu and the PADs.

Before:
![image](https://github.com/user-attachments/assets/cba83215-471a-4bc2-b751-2c25a6dca373)

After:
![image](https://github.com/user-attachments/assets/34e6d58b-02c7-4c7d-9fc9-2a5f1f7825d1)
