### PR TITLE
Apollo 7 MCC: Fix NCC-2 calculation; initialize two impulse processor results to zero

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C.cpp
@@ -623,8 +623,8 @@ bool RTCC::CalculationMTP_C(int fcn, LPVOID &pad, char * upString, char * upDesc
 		GET_TIG_imp = OrbMech::HHMMSSToSS(27, 30, 0);
 
 		lambert.mode = 5;
-		lambert.T1 = GET_TIG_imp;
-		lambert.T2 = OrbMech::HHMMSSToSS(28, 1, 0);
+		lambert.T1 = GMTfromGET(GET_TIG_imp);
+		lambert.T2 = GMTfromGET(OrbMech::HHMMSSToSS(28, 1, 0));
 		lambert.ChaserVehicle = RTCC_MPT_CSM;
 		lambert.sv_A = sv_A;
 		lambert.sv_P = sv_P;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -344,6 +344,13 @@ AP9LMCDHPADOpt::AP9LMCDHPADOpt()
 	REFSMMAT = _M(1, 0, 0, 0, 1, 0, 0, 0, 1);
 }
 
+TwoImpulseResuls::TwoImpulseResuls()
+{
+	dV = dV2 = dV_LVLH = dV_LVLH2 = _V(0, 0, 0);
+	T1 = T2 = 0.0;
+	SolutionFound = false;
+}
+
 FIDOOrbitDigitals::FIDOOrbitDigitals()
 {
 	A = 0.0;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -399,6 +399,8 @@ struct EntryResults
 
 struct TwoImpulseResuls
 {
+	TwoImpulseResuls();
+
 	EphemerisData sv_tig;		//State vector before NCC/TPI
 	EphemerisData sv_tig_apo;	//State vector after NCC/TPI
 	EphemerisData sv_tig2;		//State vector before NSR/TPF


### PR DESCRIPTION
Forgot to convert input times from GET to GMT. Attached is the scenario that has a broken Maneuver PAD and gives bad/random results when trying to repeat the NCC-2 calculation.

[Apollo 7 NCC-2 Broken PAD.scn.txt](https://github.com/user-attachments/files/19553865/Apollo.7.NCC-2.Broken.PAD.scn.txt)
