### PR TITLE
Add NASSP-specific quicksave feature with more useful save names

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -2003,6 +2003,36 @@ void Saturn::clbkSaveState(FILEHANDLE scn)
 	eventControl.save(scn);
 }
 
+void Saturn::QuicksaveScenario()
+{
+	double time = MissionTime;
+	VECTOR3 hhhmmss = _V(0, 0, 0);
+
+	for (time; time > 3600;) {
+		time -= 3600;
+		hhhmmss.x += 1;
+	}
+	for (time; time > 60;) {
+		time -= 60;
+		hhhmmss.y += 1;
+	}
+	hhhmmss.z = time;
+
+	char scnPath[64] = "";
+	char scnMission[128] = "";
+	char scnTime[64] = "";
+	strcpy(scnPath,"/Quicksave/");
+	strcpy(scnMission, pMission->GetMissionName().c_str());
+	sprintf(scnTime, " - %dh %dm %0.2fs", (int)hhhmmss.x, (int)hhhmmss.y, hhhmmss.z);
+
+	char scnName[256] = "";
+	strcat(scnName, scnPath);
+	strcat(scnName, scnMission);
+	strcat(scnName, scnTime);
+
+	oapiSaveScenario(scnName, "");
+}
+
 //
 // Scenario state functions.
 //
@@ -3785,6 +3815,17 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 			}
 		}
 		return 0;
+	}
+
+	if (!KEYMOD_SHIFT(kstate) && KEYMOD_CONTROL(kstate) && KEYMOD_ALT(kstate))
+	{
+		if (down) {
+			switch (key) {
+			case OAPI_KEY_S:
+				QuicksaveScenario();
+				break;
+			}
+		}
 	}
 
 	if (KEYMOD_CONTROL(kstate)) {

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -2007,6 +2007,12 @@ void Saturn::QuicksaveScenario()
 {
 	double time = MissionTime;
 	VECTOR3 hhhmmss = _V(0, 0, 0);
+	char timeSign = '+';
+
+	if (time < 0) {
+		time = abs(time);
+		timeSign = '-';
+	}
 
 	for (time; time > 3600;) {
 		time -= 3600;
@@ -2023,7 +2029,7 @@ void Saturn::QuicksaveScenario()
 	char scnTime[64] = "";
 	strcpy(scnPath,"/Quicksave/");
 	strcpy(scnMission, pMission->GetMissionName().c_str());
-	sprintf(scnTime, " - %dh %dm %0.2fs", (int)hhhmmss.x, (int)hhhmmss.y, hhhmmss.z);
+	sprintf(scnTime, " %c%03dh %02dm %05.2fs", timeSign, (int)hhhmmss.x, (int)hhhmmss.y, hhhmmss.z);
 
 	char scnName[256] = "";
 	strcat(scnName, scnPath);

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -2014,20 +2014,16 @@ void Saturn::QuicksaveScenario()
 		timeSign = '-';
 	}
 
-	for (time; time > 3600;) {
-		time -= 3600;
-		hhhmmss.x += 1;
-	}
-	for (time; time > 60;) {
-		time -= 60;
-		hhhmmss.y += 1;
-	}
-	hhhmmss.z = time;
+	time = round(time / 0.01) * 0.01;
+
+	hhhmmss.x = (int)trunc(time / 3600.0);
+	hhhmmss.y = (int)trunc((time - 3600.0 * hhhmmss.x) / 60.0);
+	hhhmmss.z = time - (double)(3600 * hhhmmss.x + 60 * hhhmmss.y);
 
 	char scnPath[64] = "";
 	char scnMission[128] = "";
 	char scnTime[64] = "";
-	strcpy(scnPath,"/Quicksave/");
+	strcpy(scnPath, "/Quicksave/");
 	strcpy(scnMission, pMission->GetMissionName().c_str());
 	sprintf(scnTime, " %c%03dh %02dm %05.2fs", timeSign, (int)hhhmmss.x, (int)hhhmmss.y, hhhmmss.z);
 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -1325,6 +1325,11 @@ public:
 	PointLight* floodLight_P8;
 	PointLight* floodLight_P100;
 
+	//
+	// Custom quicksave behaviour
+	//
+	void QuicksaveScenario();
+
 protected:
 
 	///

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -2469,6 +2469,12 @@ void LEM::QuicksaveScenario()
 {
 	double time = MissionTime;
 	VECTOR3 hhhmmss = _V(0, 0, 0);
+	char timeSign = '+';
+
+	if (time < 0) {
+		time = abs(time);
+		timeSign = '-';
+	}
 
 	for (time; time > 3600;) {
 		time -= 3600;
@@ -2485,7 +2491,7 @@ void LEM::QuicksaveScenario()
 	char scnTime[64] = "";
 	strcpy(scnPath, "/Quicksave/");
 	strcpy(scnMission, pMission->GetMissionName().c_str());
-	sprintf(scnTime, " - %dh %dm %0.2fs", (int)hhhmmss.x, (int)hhhmmss.y, hhhmmss.z);
+	sprintf(scnTime, " %c%03dh %02dm %05.2fs", timeSign, (int)hhhmmss.x, (int)hhhmmss.y, hhhmmss.z);
 
 	char scnName[256] = "";
 	strcat(scnName, scnPath);

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -1049,6 +1049,17 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 		return 0;
 	}
 
+	if (!KEYMOD_SHIFT(keystate) && KEYMOD_CONTROL(keystate) && KEYMOD_ALT(keystate))
+	{
+		if (down) {
+			switch (key) {
+			case OAPI_KEY_S:
+				QuicksaveScenario();
+				break;
+			}
+		}
+	}
+
 	if (down){
 		switch(key){
 			// Valid shaft positions should be:
@@ -2452,6 +2463,36 @@ void LEM::clbkSaveState (FILEHANDLE scn)
 	MissionTimerDisplay.SaveState(scn, "MISSIONTIMER_START", MISSIONTIMER_END_STRING, false);
 	EventTimerDisplay.SaveState(scn, "EVENTTIMER_START", EVENTTIMER_END_STRING, true);
 	checkControl.save(scn);
+}
+
+void LEM::QuicksaveScenario()
+{
+	double time = MissionTime;
+	VECTOR3 hhhmmss = _V(0, 0, 0);
+
+	for (time; time > 3600;) {
+		time -= 3600;
+		hhhmmss.x += 1;
+	}
+	for (time; time > 60;) {
+		time -= 60;
+		hhhmmss.y += 1;
+	}
+	hhhmmss.z = time;
+
+	char scnPath[64] = "";
+	char scnMission[128] = "";
+	char scnTime[64] = "";
+	strcpy(scnPath, "/Quicksave/");
+	strcpy(scnMission, pMission->GetMissionName().c_str());
+	sprintf(scnTime, " - %dh %dm %0.2fs", (int)hhhmmss.x, (int)hhhmmss.y, hhhmmss.z);
+
+	char scnName[256] = "";
+	strcat(scnName, scnPath);
+	strcat(scnName, scnMission);
+	strcat(scnName, scnTime);
+
+	oapiSaveScenario(scnName, "");
 }
 
 bool LEM::clbkLoadGenericCockpit ()

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -2476,15 +2476,11 @@ void LEM::QuicksaveScenario()
 		timeSign = '-';
 	}
 
-	for (time; time > 3600;) {
-		time -= 3600;
-		hhhmmss.x += 1;
-	}
-	for (time; time > 60;) {
-		time -= 60;
-		hhhmmss.y += 1;
-	}
-	hhhmmss.z = time;
+	time = round(time / 0.01) * 0.01;
+
+	hhhmmss.x = (int)trunc(time / 3600.0);
+	hhhmmss.y = (int)trunc((time - 3600.0 * hhhmmss.x) / 60.0);
+	hhhmmss.z = time - (double)(3600 * hhhmmss.x + 60 * hhhmmss.y);
 
 	char scnPath[64] = "";
 	char scnMission[128] = "";

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -690,6 +690,9 @@ public:
 	// Floodlight LM Commander
 	PointLight* floodLight_Right;
 
+	// Custom quicksave behaviour
+	void QuicksaveScenario();
+
 protected:
 
 	//


### PR DESCRIPTION
Name format:  Apollo 11 - 69h 0m 5.49s
New keybind:  Ctrl+Alt+S

This does _not_ affect Orbiter's default Ctrl+S quicksave functionality in any way.