### PR TITLE
Cleanup of time formatting in MCC, RTCC and RTCC MFD

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
@@ -1773,8 +1773,8 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 			MJD_100E = OrbMech::P29TimeOfLongitude(SystemParameters.MAT_J2000_BRCS, sv_DOI.R, sv_DOI.V, sv_DOI2.MJD, sv_DOI2.gravref, 100.0*RAD);
 			t_100E = (MJD_100E - GETbase)*24.0*3600.0;
 
-			OrbMech::format_time_MMSS(GETbuffer, P30TIG - t_100E);
-			OrbMech::format_time_MMSS(GETbuffer2, P30TIG - t_LS);
+			OrbMech::format_time_XMSS(GETbuffer, P30TIG - t_100E);
+			OrbMech::format_time_XMSS(GETbuffer2, P30TIG - t_LS);
 			sprintf(form->remarks, "100-degree east time is %s. Site 2 time is %s", GETbuffer, GETbuffer2);
 		}
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/mcc.cpp
@@ -2702,8 +2702,8 @@ void MCC::drawPad(bool writetofile){
 
 			for (int i = 0;i < 4;i++)
 			{
-				OrbMech::format_time(tmpbuf, form->GETI[i]);
-				OrbMech::format_time(tmpbuf2, form->GETI[i + 4]);
+				OrbMech::format_time_HHHMMSS(tmpbuf, form->GETI[i]);
+				OrbMech::format_time_HHHMMSS(tmpbuf2, form->GETI[i + 4]);
 				length += sprintf(buffer + length, "\nXX%s XX%s AREA\nXXX%+05.1f XXX%+05.1f LAT\nXX%+06.1f XX%+06.1f LONG\n%s %s GETI\nXXX%4.1f XXX%4.1f DVC\n%s %s WX", form->Area[i], form->Area[i + 4], form->Lat[i], form->Lat[i + 4], form->Lng[i], form->Lng[i + 4], tmpbuf, tmpbuf2, form->dVC[i], form->dVC[i + 4], form->Wx[i], form->Wx[i + 4]);
 			}
 			oapiAnnotationSetText(NHpad, buffer);
@@ -2712,7 +2712,7 @@ void MCC::drawPad(bool writetofile){
 	case PT_P27PAD:
 		{
 			P27PAD * form = (P27PAD *)padForm;
-			OrbMech::format_time(tmpbuf, form->GET[0]);
+			OrbMech::format_time_HHHMMSS(tmpbuf, form->GET[0]);
 			sprintf(buffer, "P27 UPDATE\nPURP V%d\nGET %s\n304 01 INDEX %d\n", form->Verb[0], tmpbuf, form->Index[0]);
 			for (int i = 0;i < 16;i++)
 			{
@@ -2893,8 +2893,8 @@ void MCC::drawPad(bool writetofile){
 
 			for (int i = 0;i < 4;i++)
 			{
-				OrbMech::format_time(tmpbuf, form->GETI[i]);
-				OrbMech::format_time(tmpbuf2, form->GET400K[i]);
+				OrbMech::format_time_HHHMMSS(tmpbuf, form->GETI[i]);
+				OrbMech::format_time_HHHMMSS(tmpbuf2, form->GET400K[i]);
 				sprintf(buffer, "%s-------------------------\n%s GETI\nX%+04.0f DVT\nX%+5.1f LONG\n%s GET 400K\n", buffer, tmpbuf, form->dVT[i], form->lng[i], tmpbuf2);
 			}
 			oapiAnnotationSetText(NHpad, buffer);
@@ -2911,7 +2911,7 @@ void MCC::drawPad(bool writetofile){
 		OrbMech::SStoHHMMSS(form->GETI, hh, mm, ss, 0.01);
 		OrbMech::SStoHHMMSS(form->burntime, hh2, mm2, ss2);
 
-		OrbMech::format_time(tmpbuf, form->GET05G);
+		OrbMech::format_time_HHHMMSS(tmpbuf, form->GET05G);
 
 		sprintf(buffer, "%s\n%s PURPOSE\n%s PROP/GUID\n%+05.0f WT N47\n%+07.2f PTRIM N48\n%+07.2f YTRIM\n%+06d HRS GETI\n%+06d MIN N33\n%+07.2f SEC\n%+07.1f DVX N81\n%+07.1f DVY\n%+07.1f DVZ\nXXX%03.0f R\nXXX%03.0f P\nXXX%03.0f Y\n",
 			buffer, form->purpose, form->PropGuid, form->Weight, form->pTrim, form->yTrim, hh, mm, ss, form->dV.x, form->dV.y, form->dV.z, form->Att.x, form->Att.y, form->Att.z);
@@ -2940,14 +2940,14 @@ void MCC::drawPad(bool writetofile){
 
 			buffer3 = "LUNAR ENTRY\n";
 
-			OrbMech::format_time(tmpbuf, form->GETHorCheck[0]);
+			OrbMech::format_time_HHHMMSS(tmpbuf, form->GETHorCheck[0]);
 			sprintf_s(buffer2, "%s AREA\nXXX%03.0f R 0.05G\nXXX%03.0f P 0.05G\nXXX%03.0f Y 0.05G\n%s GET HOR CHK\n", form->Area[0], form->Att05[0].x, form->Att05[0].y, form->Att05[0].z, tmpbuf);
 			buffer3.append(buffer2);
 
 			sprintf_s(buffer2, "XXX%03.0f P\n%+07.2f LAT N61\n%+07.2f LONG\nXXX%04.1f MAX G\n", form->PitchHorCheck[0], form->Lat[0], form->Lng[0], form->MaxG[0]);
 			buffer3.append(buffer2);
 
-			OrbMech::format_time(tmpbuf, form->RRT[0]);
+			OrbMech::format_time_HHHMMSS(tmpbuf, form->RRT[0]);
 			sprintf_s(buffer2, "%+06.0f V400K N60\n%+07.2f y400K\n%+07.1f RTGO EMS\n%+06.0f VI0\n%s RRT\n", form->V400K[0], form->Gamma400K[0], form->RTGO[0], form->VIO[0], tmpbuf);
 			buffer3.append(buffer2);
 
@@ -2991,7 +2991,7 @@ void MCC::drawPad(bool writetofile){
 			double ss;
 
 			buffer3 = "TLI\n";
-			OrbMech::format_time(tmpbuf, form->TB6P);
+			OrbMech::format_time_HHHMMSS(tmpbuf, form->TB6P);
 			OrbMech::SStoHHMMSS(form->BurnTime, hh, mm, ss);
 
 			sprintf_s(buffer2, "%s TB6p\nXXX%03.0f R\nXXX%03.0f P TLI\nXXX%03.0f Y\nXXX%d:%02.0f BT\n%07.1f DVC\n%+05.0f VI\nXXX%03.0f R\nXXX%03.0f P SEP\nXXX%03.0f Y\n", tmpbuf, form->IgnATT.x, form->IgnATT.y, form->IgnATT.z, mm, ss, form->dVC, form->VI, form->SepATT.x, form->SepATT.y, form->SepATT.z);
@@ -3478,7 +3478,7 @@ void MCC::drawPad(bool writetofile){
 
 		for (int i = 0;i < form->entries;i++)
 		{
-			OrbMech::format_time(tmpbuf, form->TIG[i]);
+			OrbMech::format_time_HHHMMSS(tmpbuf, form->TIG[i]);
 			sprintf(buffer, "%sT%d %s\n", buffer, form->startdigit + i, tmpbuf);
 		}
 

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -65,28 +65,6 @@ using namespace nassp;
 #define LOAD_M3(KEY,VALUE) if(strnicmp(line,KEY,strlen(KEY))==0){ sscanf(line+strlen(KEY),"%lf %lf %lf %lf %lf %lf %lf %lf %lf",&VALUE.m11,&VALUE.m12,&VALUE.m13,&VALUE.m21,&VALUE.m22,&VALUE.m23,&VALUE.m31,&VALUE.m32,&VALUE.m33); }
 #define LOAD_STRING(KEY,VALUE,LEN) if(strnicmp(line,KEY,strlen(KEY))==0){ strncpy(VALUE, line + (strlen(KEY)+1), LEN); }
 
-void format_time_rtcc(char *buf, double time) {
-	buf[0] = 0; // Clobber
-	int hours, minutes, seconds;
-	bool negative = false;
-	if (time < 0)
-	{
-		time = abs(time);
-		negative = true;
-	}
-	hours = (int)(time / 3600);
-	minutes = (int)((time / 60) - (hours * 60));
-	seconds = (int)((time - (hours * 3600)) - (minutes * 60));
-	if (negative)
-	{
-		sprintf_s(buf, 64, "-%03d:%02d:%02d", hours, minutes, seconds);
-	}
-	else
-	{
-		sprintf_s(buf, 64, "%03d:%02d:%02d", hours, minutes, seconds);
-	}
-}
-
 //Ephemeris format 2 to format 1
 EphemerisData Eph2ToEph1(EphemerisData2 in, int RBI)
 {
@@ -17059,7 +17037,7 @@ void RTCC::EMSEPH(int QUEID, StateVectorTableEntry &sv, int &L, double PresentGM
 
 				double get = GETfromGMT(InTable.NIAuxOutputTable.sv_cutoff.GMT);
 				char Buff[64];
-				format_time_rtcc(Buff, get);
+				OrbMech::format_time_HHHMMSS(Buff, get);
 				RTCCONLINEMON.TextBuffer[2].assign(Buff);
 
 				double lat, lng, alt;
@@ -17149,9 +17127,9 @@ void RTCC::EMSEPH(int QUEID, StateVectorTableEntry &sv, int &L, double PresentGM
 		}
 		EMGPRINT("EMSEPH", 12);
 		char Buff[64];
-		format_time_rtcc(Buff, table->EPHEM.Header.TL);
+		OrbMech::format_time_HHHMMSS(Buff, table->EPHEM.Header.TL);
 		RTCCONLINEMON.TextBuffer[1].assign(Buff);
-		format_time_rtcc(Buff, table->EPHEM.Header.TR);
+		OrbMech::format_time_HHHMMSS(Buff, table->EPHEM.Header.TR);
 		RTCCONLINEMON.TextBuffer[2].assign(Buff);
 		EMGPRINT("EMSEPH", 15);
 
@@ -35577,7 +35555,7 @@ void RTCC::BMDVPS()
 	int i, j;
 	MissionPlanTable *mpt;
 	
-	format_time_rtcc(Buff, RTCCPresentTimeGMT());
+	OrbMech::format_time_HHHMMSS(Buff, RTCCPresentTimeGMT());
 	VectorPanelSummaryBuffer.CurrentGMT.assign(Buff);
 	for (i = 0;i < 2;i++)
 	{
@@ -35592,7 +35570,7 @@ void RTCC::BMDVPS()
 		if (mpt->GMTAV != 0.0)
 		{
 			VectorPanelSummaryBuffer.AnchorVectorID[i] = mpt->StationID;
-			format_time_rtcc(Buff, mpt->GMTAV);
+			OrbMech::format_time_HHHMMSS(Buff, mpt->GMTAV);
 			VectorPanelSummaryBuffer.AnchorVectorGMT[i].assign(Buff);
 		}
 		else
@@ -35605,7 +35583,7 @@ void RTCC::BMDVPS()
 			if (BZUSEVEC.data[6 * i + j].ID > 0)
 			{
 				VectorPanelSummaryBuffer.CompUsableID[i][j] = BZUSEVEC.data[6 * i + j].VectorCode;
-				format_time_rtcc(Buff, BZUSEVEC.data[6 * i + j].Vector.GMT);
+				OrbMech::format_time_HHHMMSS(Buff, BZUSEVEC.data[6 * i + j].Vector.GMT);
 				VectorPanelSummaryBuffer.CompUsableGMT[i][j].assign(Buff);
 			}
 			else
@@ -35616,7 +35594,7 @@ void RTCC::BMDVPS()
 			if (BZEVLVEC.data[4 * i + j].ID > 0)
 			{
 				VectorPanelSummaryBuffer.CompEvalID[i][j] = BZEVLVEC.data[4 * i + j].VectorCode;
-				format_time_rtcc(Buff, BZEVLVEC.data[4 * i + j].Vector.GMT);
+				OrbMech::format_time_HHHMMSS(Buff, BZEVLVEC.data[4 * i + j].Vector.GMT);
 				VectorPanelSummaryBuffer.CompEvalGMT[i][j].assign(Buff);
 			}
 			else
@@ -35629,7 +35607,7 @@ void RTCC::BMDVPS()
 		if (BZUSEVEC.data[6 * i + 4].Vector.RBI != -1)
 		{
 			VectorPanelSummaryBuffer.HSRID[i] = BZUSEVEC.data[6 * i + 4].VectorCode;
-			format_time_rtcc(Buff, BZUSEVEC.data[6 * i + 4].Vector.GMT);
+			OrbMech::format_time_HHHMMSS(Buff, BZUSEVEC.data[6 * i + 4].Vector.GMT);
 			VectorPanelSummaryBuffer.HSRGMT[i].assign(Buff);
 		}
 		else
@@ -35640,7 +35618,7 @@ void RTCC::BMDVPS()
 		if (BZUSEVEC.data[6 * i + 5].Vector.RBI != -1)
 		{
 			VectorPanelSummaryBuffer.DCID[i] = BZUSEVEC.data[6 * i + 5].VectorCode;
-			format_time_rtcc(Buff, BZUSEVEC.data[6 * i + 5].Vector.GMT);
+			OrbMech::format_time_HHHMMSS(Buff, BZUSEVEC.data[6 * i + 5].Vector.GMT);
 			VectorPanelSummaryBuffer.DCGMT[i].assign(Buff);
 		}
 		else
@@ -35651,9 +35629,9 @@ void RTCC::BMDVPS()
 		if (mpt->LastExecutedManeuver > 0)
 		{
 			gmttemp = mpt->mantable[mpt->LastExecutedManeuver - 1].GMT_BI - mpt->mantable[mpt->LastExecutedManeuver - 1].dt_ullage + 1.0;
-			format_time_rtcc(Buff, gmttemp);
+			OrbMech::format_time_HHHMMSS(Buff, gmttemp);
 			VectorPanelSummaryBuffer.LastManGMTUL[i].assign(Buff);
-			format_time_rtcc(Buff, mpt->mantable[mpt->LastExecutedManeuver - 1].GMT_BO);
+			OrbMech::format_time_HHHMMSS(Buff, mpt->mantable[mpt->LastExecutedManeuver - 1].GMT_BO);
 			VectorPanelSummaryBuffer.LastManGMTBO[i].assign(Buff);
 		}
 		else
@@ -35665,7 +35643,7 @@ void RTCC::BMDVPS()
 	}
 	if (BZSTLM.HighSpeedCMCCSMVector.RBI != -1)
 	{
-		format_time_rtcc(Buff, BZSTLM.HighSpeedCMCCSMVector.GMT);
+		OrbMech::format_time_HHHMMSS(Buff, BZSTLM.HighSpeedCMCCSMVector.GMT);
 		VectorPanelSummaryBuffer.CompTelemetryHighGMT[0][0].assign(Buff);
 	}
 	else
@@ -35674,7 +35652,7 @@ void RTCC::BMDVPS()
 	}
 	if (BZSTLM.HighSpeedLGCCSMVector.RBI != -1)
 	{
-		format_time_rtcc(Buff, BZSTLM.HighSpeedLGCCSMVector.GMT);
+		OrbMech::format_time_HHHMMSS(Buff, BZSTLM.HighSpeedLGCCSMVector.GMT);
 		VectorPanelSummaryBuffer.CompTelemetryHighGMT[0][1].assign(Buff);
 	}
 	else
@@ -35683,7 +35661,7 @@ void RTCC::BMDVPS()
 	}
 	if (BZSTLM.HighSpeedAGSCSMVector.RBI != -1)
 	{
-		format_time_rtcc(Buff, BZSTLM.HighSpeedAGSCSMVector.GMT);
+		OrbMech::format_time_HHHMMSS(Buff, BZSTLM.HighSpeedAGSCSMVector.GMT);
 		VectorPanelSummaryBuffer.CompTelemetryHighGMT[0][2].assign(Buff);
 	}
 	else
@@ -35692,7 +35670,7 @@ void RTCC::BMDVPS()
 	}
 	if (BZSTLM.HighSpeedIUVector.RBI != -1)
 	{
-		format_time_rtcc(Buff, BZSTLM.HighSpeedIUVector.GMT);
+		OrbMech::format_time_HHHMMSS(Buff, BZSTLM.HighSpeedIUVector.GMT);
 		VectorPanelSummaryBuffer.CompTelemetryHighGMT[0][3].assign(Buff);
 	}
 	else
@@ -35701,7 +35679,7 @@ void RTCC::BMDVPS()
 	}
 	if (BZSTLM.HighSpeedCMCLEMVector.RBI != -1)
 	{
-		format_time_rtcc(Buff, BZSTLM.HighSpeedCMCLEMVector.GMT);
+		OrbMech::format_time_HHHMMSS(Buff, BZSTLM.HighSpeedCMCLEMVector.GMT);
 		VectorPanelSummaryBuffer.CompTelemetryHighGMT[1][0].assign(Buff);
 	}
 	else
@@ -35710,7 +35688,7 @@ void RTCC::BMDVPS()
 	}
 	if (BZSTLM.HighSpeedLGCLEMVector.RBI != -1)
 	{
-		format_time_rtcc(Buff, BZSTLM.HighSpeedLGCLEMVector.GMT);
+		OrbMech::format_time_HHHMMSS(Buff, BZSTLM.HighSpeedLGCLEMVector.GMT);
 		VectorPanelSummaryBuffer.CompTelemetryHighGMT[1][1].assign(Buff);
 	}
 	else
@@ -35719,7 +35697,7 @@ void RTCC::BMDVPS()
 	}
 	if (BZSTLM.HighSpeedAGSLEMVector.RBI != -1)
 	{
-		format_time_rtcc(Buff, BZSTLM.HighSpeedAGSLEMVector.GMT);
+		OrbMech::format_time_HHHMMSS(Buff, BZSTLM.HighSpeedAGSLEMVector.GMT);
 		VectorPanelSummaryBuffer.CompTelemetryHighGMT[1][2].assign(Buff);
 	}
 	else
@@ -35728,7 +35706,7 @@ void RTCC::BMDVPS()
 	}
 	if (BZSTLM.HighSpeedIUVector.RBI != -1)
 	{
-		format_time_rtcc(Buff, BZSTLM.HighSpeedIUVector.GMT);
+		OrbMech::format_time_HHHMMSS(Buff, BZSTLM.HighSpeedIUVector.GMT);
 		VectorPanelSummaryBuffer.CompTelemetryHighGMT[1][3].assign(Buff);
 	}
 	else

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -392,47 +392,25 @@ void ApolloRTCCMFD::Text(oapi::Sketchpad *skp, int x, int y, char *format, int v
 
 void ApolloRTCCMFD::Text_GET_MMSS(oapi::Sketchpad *skp, int x, int y, double val)
 {
-	int mm;
-	double ss;
-	OrbMech::SStoMMSS(abs(val), mm, ss);
-
-	if (val >= 0.0)
-	{
-		sprintf_s(Buffer, "%d:%02.0f", mm, ss);
-	}
-	else
-	{
-		sprintf_s(Buffer, "-%d:%02.0f", mm, ss);
-	}
+	OrbMech::format_time_XMSS(Buffer, val);
 	Text(skp, x, y, Buffer);
 }
 
 void ApolloRTCCMFD::Text_GET_MMSSC(oapi::Sketchpad *skp, int x, int y, double val)
 {
-	int mm;
-	double ss;
-	OrbMech::SStoMMSS(abs(val), mm, ss, 0.1);
-
-	if (val >= 0.0)
-	{
-		sprintf_s(Buffer, "%d:%04.1f", mm, ss);
-	}
-	else
-	{
-		sprintf_s(Buffer, "-%d:%04.1f", mm, ss);
-	}
+	OrbMech::format_time_MMSSC(Buffer, val);
 	Text(skp, x, y, Buffer);
 }
 
-void ApolloRTCCMFD::Text_GET_HHMM(oapi::Sketchpad *skp, int x, int y, double val)
+void ApolloRTCCMFD::Text_GET_HHHMM(oapi::Sketchpad *skp, int x, int y, double val)
 {
-	GET_Display_HHMM(Buffer, val);
+	GET_Display_HHHMM(Buffer, val);
 	Text(skp, x, y, Buffer);
 }
 
 void ApolloRTCCMFD::Text_GET_HHMMSS(oapi::Sketchpad *skp, int x, int y, double val)
 {
-	GET_Display4(Buffer, val);
+	OrbMech::format_time_HHMMSS(Buffer, val);
 	Text(skp, x, y, Buffer);
 }
 
@@ -451,6 +429,12 @@ void ApolloRTCCMFD::Text_GET_HHHMMSSC(oapi::Sketchpad *skp, int x, int y, double
 void ApolloRTCCMFD::Text_GET_HHHMMSSCS(oapi::Sketchpad *skp, int x, int y, double val)
 {
 	GET_Display2(Buffer, val);
+	Text(skp, x, y, Buffer);
+}
+
+void ApolloRTCCMFD::Text_GMT_HHHMMSSCS(oapi::Sketchpad *skp, int x, int y, double val)
+{
+	GMT_Display2(Buffer, val);
 	Text(skp, x, y, Buffer);
 }
 
@@ -586,18 +570,10 @@ void ApolloRTCCMFD::FormatDeclination(char *Buff, double angle)
 
 void ApolloRTCCMFD::GET_Display(char* Buff, double time, bool DispGET) //Display a time in the format hhh:mm:ss
 {
-	int hours, minutes;
-	double seconds;
-
-	OrbMech::SStoHHMMSS(time, hours, minutes, seconds);
-
+	OrbMech::format_time_HHHMMSS(Buff, time);
 	if (DispGET)
 	{
-		sprintf_s(Buff, 32, "%03d:%02d:%02.0f GET", hours, minutes, seconds);
-	}
-	else
-	{
-		sprintf_s(Buff, 32, "%03d:%02d:%02.0f", hours, minutes, seconds);
+		strcat(Buff, " GET");
 	}
 }
 
@@ -622,58 +598,17 @@ void ApolloRTCCMFD::GMT_Display2(char* Buff, double time) const
 
 void ApolloRTCCMFD::GET_Display2(char* Buff, double time) const //Display a time in the format hhh:mm:ss.ss
 {
-	bool pos = true;
-	if (time < 0)
-	{
-		pos = false;
-		time = abs(time);
-	}
-
-	int hours, minutes;
-	double seconds;
-
-	OrbMech::SStoHHMMSS(time, hours, minutes, seconds, 0.01);
-
-	if (pos)
-	{
-		sprintf(Buff, "%03d:%02d:%05.2lf", hours, minutes, seconds);
-	}
-	else
-	{
-		sprintf(Buff, "-%03d:%02d:%05.2lf", hours, minutes, seconds);
-	}
+	OrbMech::format_time_HHHMMSSCS(Buff, time);
 }
 
 void ApolloRTCCMFD::GET_Display3(char* Buff, double time) //Display a time in the format hhh:mm:ss.s
 {
-	int hours, minutes;
-	double seconds;
-
-	OrbMech::SStoHHMMSS(time, hours, minutes, seconds, 0.1);
-
-	sprintf(Buff, "%03d:%02d:%04.1f", hours, minutes, seconds);
+	OrbMech::format_time_HHHMMSSC(Buff, time);
 }
 
-//Format: HH:MM:SS
-void ApolloRTCCMFD::GET_Display4(char* Buff, double time) //Display a time in the format hh:mm:ss
+void ApolloRTCCMFD::GET_Display_HHHMM(char *Buff, double time) //Displays a time in the format HHH:MM
 {
-	int hours, minutes;
-	double seconds;
-
-	OrbMech::SStoHHMMSS(time, hours, minutes, seconds);
-
-	sprintf(Buff, "%02d:%02d:%02.0f", hours, minutes, seconds);
-}
-
-//Format: HH:MM
-void ApolloRTCCMFD::GET_Display_HHMM(char *Buff, double time)
-{
-	int hours, minutes;
-	double seconds;
-
-	OrbMech::SStoHHMMSS(time, hours, minutes, seconds, 60.0);
-
-	sprintf(Buff, "%03d:%02d", hours, minutes);
+	OrbMech::format_time_HHHMM(Buff, time);
 }
 
 void ApolloRTCCMFD::AGC_Display(char* Buff, double vel)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -91,11 +91,12 @@ public:
 	void Text(oapi::Sketchpad *skp, int x, int y, char *format, int val);
 	void Text_GET_MMSS(oapi::Sketchpad *skp, int x, int y, double val);
 	void Text_GET_MMSSC(oapi::Sketchpad *skp, int x, int y, double val);
-	void Text_GET_HHMM(oapi::Sketchpad *skp, int x, int y, double val);
+	void Text_GET_HHHMM(oapi::Sketchpad *skp, int x, int y, double val);
 	void Text_GET_HHMMSS(oapi::Sketchpad *skp, int x, int y, double val);
 	void Text_GET_HHHMMSS(oapi::Sketchpad *skp, int x, int y, double val);
 	void Text_GET_HHHMMSSC(oapi::Sketchpad *skp, int x, int y, double val);
 	void Text_GET_HHHMMSSCS(oapi::Sketchpad *skp, int x, int y, double val);
+	void Text_GMT_HHHMMSSCS(oapi::Sketchpad *skp, int x, int y, double val);
 	void Text_Latitude(oapi::Sketchpad *skp, int x, int y, double val);
 	void Text_Longitude(oapi::Sketchpad *skp, int x, int y, double val);
 	void Text_Latitude(oapi::Sketchpad *skp, int x, int y, double val, int decimals);
@@ -178,8 +179,7 @@ public:
 	void GMT_Display2(char * Buff, double time) const;
 	void GET_Display2(char * Buff, double time) const;
 	void GET_Display3(char* Buff, double time);
-	void GET_Display4(char* Buff, double time);
-	void GET_Display_HHMM(char *Buff, double time);
+	void GET_Display_HHHMM(char *Buff, double time);
 	void AGC_Display(char * Buff, double time);
 	void FormatLatitude(char * Buff, double lat);
 	void FormatLongitude(char * Buff, double lng, int precision = 2);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -774,6 +774,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		skp->Text(CW * 22, CH * 14, Buffer, strlen(Buffer));
 		skp->Text(CW * 33, CH * 14, "246", 3);
 
+
 		sprintf(Buffer, "%+06.0f", G->agssvpad.DEDA264);
 		skp->Text(CW * 22, CH * 15, Buffer, strlen(Buffer));
 		skp->Text(CW * 33, CH * 15, "264", 3);
@@ -956,7 +957,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+07.1f VT", GC->manpad.Vt);
 				skp->Text(CW * 17, CH * 16, Buffer, strlen(Buffer));
 
-				OrbMech::SStoHHMMSS(GC->manpad.burntime, hh, mm, secs);
+				OrbMech::SStoMMSS(GC->manpad.burntime, mm, secs);
 
 				sprintf(Buffer, "XXX%d:%02.0f BT (MIN:SEC)", mm, secs);
 				skp->Text(CW * 17, CH * 17, Buffer, strlen(Buffer));
@@ -1050,7 +1051,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+07.1f DVR", GC->lmmanpad.dVR);
 				skp->Text(CW * 17, CH * 13, Buffer, strlen(Buffer));
 
-				OrbMech::SStoHHMMSS(GC->lmmanpad.burntime, hh, mm, secs);
+				OrbMech::SStoMMSS(GC->lmmanpad.burntime, mm, secs);
 				sprintf(Buffer, "XXX%d:%02.0f BT", mm, secs);
 				skp->Text(CW * 17, CH * 14, Buffer, strlen(Buffer));
 
@@ -1182,7 +1183,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			sprintf(Buffer, "XXX%03.0f Y", GC->tlipad.IgnATT.z);
 			skp->Text(CW * 17, CH * 8, Buffer, strlen(Buffer));
 
-			OrbMech::SStoHHMMSS(GC->tlipad.BurnTime, hh, mm, secs);
+			OrbMech::SStoMMSS(GC->tlipad.BurnTime, mm, secs);
 			sprintf(Buffer, "XXX%d:%02.0f BT", mm, secs);
 			skp->Text(CW * 17, CH * 9, Buffer, strlen(Buffer));
 
@@ -1251,7 +1252,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			skp->Text(CW * 15, CH * 7, "SEC", 3);
 			sprintf(Buffer, "%+07.2f", secs);
 			skp->Text(CW * 32, CH * 7, Buffer, strlen(Buffer));
-			OrbMech::SStoHHMMSS(GC->pdipad.t_go, hh, mm, secs);
+			OrbMech::SStoMMSS(GC->pdipad.t_go, mm, secs);
 			skp->Text(CW * 15, CH * 8, "TGO      N61", 12);
 			sprintf(Buffer, "XX%02d:%02.0f", mm, secs);
 			skp->Text(CW * 32, CH * 8, Buffer, strlen(Buffer));
@@ -1294,30 +1295,30 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf(Buffer, "%+06.0f VIO  .05G", GC->earthentrypad.VIO[0]);
 				skp->Text(CW * 23, CH * 9, Buffer, strlen(Buffer));
 				
-				OrbMech::SStoHHMMSS(GC->earthentrypad.Ret05[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.Ret05[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RET  .05G", mm, secs);
 				skp->Text(CW * 23, CH * 10, Buffer, strlen(Buffer));
 				sprintf(Buffer, "%+07.2f LAT", GC->earthentrypad.Lat[0]);
 				skp->Text(CW * 23, CH * 11, Buffer, strlen(Buffer));
 				sprintf(Buffer, "%+07.2f LONG", GC->earthentrypad.Lng[0]);
 				skp->Text(CW * 23, CH * 12, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->earthentrypad.Ret2[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.Ret2[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RET  .2G", mm, secs);
 				skp->Text(CW * 23, CH * 13, Buffer, strlen(Buffer));
 				sprintf(Buffer, "%+07.1lf DRE (55°)  N66", GC->earthentrypad.DRE[0]);
 				skp->Text(CW * 23, CH * 14, Buffer, strlen(Buffer));
 				sprintf(Buffer, "RR55/55 BANK AN");
 				skp->Text(CW * 23, CH * 15, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->earthentrypad.RetRB[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.RetRB[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RET RB", mm, secs);
 				skp->Text(CW * 23, CH * 16, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->earthentrypad.RetBBO[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.RetBBO[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RETBBO", mm, secs);
 				skp->Text(CW * 23, CH * 17, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->earthentrypad.RetEBO[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.RetEBO[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RETEBO", mm, secs);
 				skp->Text(CW * 23, CH * 18, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->earthentrypad.RetDrog[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.RetDrog[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RETDROG", mm, secs);
 				skp->Text(CW * 23, CH * 19, Buffer, strlen(Buffer));
 				skp->Text(CW * 27, CH * 20, "POSTBURN", 8);
@@ -1327,26 +1328,26 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text(CW * 23, CH * 22, Buffer, strlen(Buffer));
 				sprintf(Buffer, "%+06.0f VIO  .05G", GC->earthentrypad.PB_VIO[0]);
 				skp->Text(CW * 23, CH * 23, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->earthentrypad.PB_Ret05[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.PB_Ret05[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RET  .05G", mm, secs);
 				skp->Text(CW * 23, CH * 24, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->earthentrypad.PB_Ret2[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.PB_Ret2[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RET  .2G", mm, secs);
 				skp->Text(CW * 23, CH * 25, Buffer, strlen(Buffer));
 				sprintf(Buffer, "%+07.1lf DRE +/- 100nm  N66", GC->earthentrypad.PB_DRE[0]);
 				skp->Text(CW * 23, CH * 26, Buffer, strlen(Buffer));
 				sprintf(Buffer, "RR55/55 BANK AN");
 				skp->Text(CW * 23, CH * 27, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->earthentrypad.PB_RetRB[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.PB_RetRB[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RET RB", mm, secs);
 				skp->Text(CW * 23, CH * 28, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->earthentrypad.PB_RetBBO[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.PB_RetBBO[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RETBBO", mm, secs);
 				skp->Text(CW * 23, CH * 29, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->earthentrypad.PB_RetEBO[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.PB_RetEBO[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RETEBO", mm, secs);
 				skp->Text(CW * 23, CH * 30, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->earthentrypad.PB_RetDrog[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->earthentrypad.PB_RetDrog[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RETDROG", mm, secs);
 				skp->Text(CW * 23, CH * 31, Buffer, strlen(Buffer));
 
@@ -1423,7 +1424,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				GET_Display(Buffer, GC->lunarentrypad.RRT[0]);
 				sprintf(Buffer, "%s RRT", Buffer);
 				skp->Text(CW * 23, CH * 17, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->lunarentrypad.RET05[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->lunarentrypad.RET05[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RET  .05G", mm, secs);
 				skp->Text(CW * 23, CH * 18, Buffer, strlen(Buffer));
 				sprintf(Buffer, "%+07.2lf DL MAX", GC->lunarentrypad.DLMax[0]);
@@ -1436,16 +1437,16 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text(CW * 23, CH * 22, Buffer, strlen(Buffer));
 				sprintf(Buffer, "XXX%04.2f DO", GC->lunarentrypad.DO[0]);
 				skp->Text(CW * 23, CH * 23, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->lunarentrypad.RETVCirc[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->lunarentrypad.RETVCirc[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RET V CIRC", mm, secs);
 				skp->Text(CW * 23, CH * 24, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->lunarentrypad.RETBBO[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->lunarentrypad.RETBBO[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RETBBO", mm, secs);
 				skp->Text(CW * 23, CH * 25, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->lunarentrypad.RETEBO[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->lunarentrypad.RETEBO[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RETEBO", mm, secs);
 				skp->Text(CW * 23, CH * 26, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(GC->lunarentrypad.RETDRO[0], hh, mm, secs);
+				OrbMech::SStoMMSS(GC->lunarentrypad.RETDRO[0], mm, secs);
 				sprintf(Buffer, "XX%02d:%02.0f RETDRO", mm, secs);
 				skp->Text(CW * 23, CH * 27, Buffer, strlen(Buffer));
 				if (GC->lunarentrypad.SXTS[0] == 0)
@@ -2355,12 +2356,12 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				skp->Text(CW * (31 + 22 * i), CH * 10, Buffer, strlen(Buffer));
 				sprintf_s(Buffer, "%.1lf", tab->DVC / 0.3048);
 				skp->Text(CW * (22 + 22 * i), CH * 11, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(tab->dt, hh, mm, secs, 0.1);
+				OrbMech::SStoMMSS(tab->dt, mm, secs, 0.1);
 				sprintf_s(Buffer, "%02d:%02.1lf", mm, secs);
 				skp->Text(CW * (31 + 22 * i), CH * 11, Buffer, strlen(Buffer));
 				sprintf_s(Buffer, "%.1lf", tab->dv / 0.3048);
 				skp->Text(CW * (22 + 22 * i), CH * 12, Buffer, strlen(Buffer));
-				OrbMech::SStoHHMMSS(tab->dt_ullage, hh, mm, secs);
+				OrbMech::SStoMMSS(tab->dt_ullage, mm, secs);
 				sprintf_s(Buffer, "%+d %02d:%02.0lf", tab->NumQuads, mm, secs);
 				skp->Text(CW * (31 + 22 * i), CH * 12, Buffer, strlen(Buffer));
 				GET_Display(Buffer, tab->PETI, false);
@@ -2834,7 +2835,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			Text(skp, 1, 22, "GET");
 			Text(skp, 1, 23, "DEL H");
 			Text(skp, 1, 24, "PHASE");
-			Text_GET_HHHMMSSC(skp, 7, 22, GC->rtcc->GETfromGMT(GC->rtcc->GZGENCSN.TINSRNominalTime));
+			Text_GMT_HHHMMSSCS(skp, 7, 22, GC->rtcc->GZGENCSN.TINSRNominalTime);
 			Text(skp, 7, 23, " %.2lf NM", GC->rtcc->GZGENCSN.TINSRNominalDeltaH / 1852.0);
 			Text(skp, 7, 24, " %.2lf deg", GC->rtcc->GZGENCSN.TINSRNominalPhaseAngle*DEG);
 		}
@@ -3521,7 +3522,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		}
 		for (unsigned i = 1; i < GC->rtcc->MPTDISPLAY.man.size(); i++)
 		{
-			GET_Display_HHMM(Buffer, GC->rtcc->MPTDISPLAY.man[i].DT);
+			GET_Display_HHHMM(Buffer, GC->rtcc->MPTDISPLAY.man[i].DT);
 			skp->Text(CW * 19, (CH * (15 + i * 2)) / 2, Buffer, strlen(Buffer));
 		}
 		break;
@@ -6056,21 +6057,21 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			Text(skp, x + dx * i, y, "%.3lf", GC->rtcc->PZMCCDIS.data[i].AZ_min*DEG); y++;
 			Text(skp, x + dx * i, y, "%.3lf", GC->rtcc->PZMCCDIS.data[i].AZ_max*DEG); y++;
 			Text(skp, x + dx * i, y, "%.0lf", (GC->rtcc->PZMCCDIS.data[i].CSMWT + GC->rtcc->PZMCCDIS.data[i].LMWT) / 0.45359237); y++;
-			Text_GET_HHMM(skp, x + dx * i, y, GC->rtcc->PZMCCDIS.data[i].GET_MCC); y++;
+			Text_GET_HHHMM(skp, x + dx * i, y, GC->rtcc->PZMCCDIS.data[i].GET_MCC); y++;
 			Text(skp, x + dx * i, y, "%.1lf", length(GC->rtcc->PZMCCDIS.data[i].DV_MCC) / 0.3048); y++;
 			Text(skp, x + dx * i, y, "%.3lf", GC->rtcc->PZMCCDIS.data[i].YAW_MCC*DEG); y++;
 			Text(skp, x + dx * i, y, "%.3lf", GC->rtcc->PZMCCDIS.data[i].h_PC / 1852.0); y++;
-			Text_GET_HHMM(skp, x + dx * i, y, GC->rtcc->PZMCCDIS.data[i].GET_LOI); y++;
+			Text_GET_HHHMM(skp, x + dx * i, y, GC->rtcc->PZMCCDIS.data[i].GET_LOI); y++;
 			Text(skp, x + dx * i, y, "%.1lf", length(GC->rtcc->PZMCCDIS.data[i].DV_LOI) / 0.3048); y++;
 			Text(skp, x + dx * i, y, "%.3lf", GC->rtcc->PZMCCDIS.data[i].AZ_act*DEG); y++;
 			Text(skp, x + dx * i, y, "%.3lf", GC->rtcc->PZMCCDIS.data[i].incl_fr*DEG); y++;
 			Text(skp, x + dx * i, y, "%.3lf", GC->rtcc->PZMCCDIS.data[i].incl_pr*DEG); y++;
 			Text(skp, x + dx * i, y, "%.1lf", GC->rtcc->PZMCCDIS.data[i].v_EI / 0.3048); y++;
 			Text(skp, x + dx * i, y, "%.3lf", GC->rtcc->PZMCCDIS.data[i].gamma_EI*DEG); y++;
-			Text_GET_HHMM(skp, x + dx * i, y, GC->rtcc->PZMCCDIS.data[i].GET_TEI); y++;
+			Text_GET_HHHMM(skp, x + dx * i, y, GC->rtcc->PZMCCDIS.data[i].GET_TEI); y++;
 			Text(skp, x + dx * i, y, "%.1lf", length(GC->rtcc->PZMCCDIS.data[i].DV_TEI) / 0.3048); y++;
 			Text(skp, x + dx * i, y, "%.1lf", GC->rtcc->PZMCCDIS.data[i].DV_REM / 0.3048); y++;
-			Text_GET_HHMM(skp, x + dx * i, y, GC->rtcc->PZMCCDIS.data[i].GET_LC); y++;
+			Text_GET_HHHMM(skp, x + dx * i, y, GC->rtcc->PZMCCDIS.data[i].GET_LC); y++;
 			Text(skp, x + dx * i, y, "%.3lf", GC->rtcc->PZMCCDIS.data[i].lat_IP*DEG); y++;
 			Text(skp, x + dx * i, y, "%.3lf", GC->rtcc->PZMCCDIS.data[i].lng_IP*DEG); y++;
 			Text(skp, x + dx * i, y, "%.1lf", length(GC->rtcc->PZMCCDIS.data[i].DV_LOPC / 0.3048)); y++;
@@ -6221,9 +6222,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			Text_Double(skp, W - CW, y * H / 14, "%.3lf", GC->rtcc->PZTTLIPL.elem.alpha_D*DEG); y++;
 			Text_Double(skp, W - CW, y * H / 14, "%.3lf", GC->rtcc->PZTTLIPL.elem.f*DEG); y++;
 			Text_Double(skp, W - CW, y * H / 14, "%.1lf", GC->rtcc->PZTPDDIS.dv_TLI); y++;
-			double secs;
-			int hh, mm;
-			OrbMech::SStoHHMMSS(GC->rtcc->PZTPDDIS.T_b, hh, mm, secs);
+			OrbMech::SStoMMSS(GC->rtcc->PZTPDDIS.T_b, mm, secs);
 			sprintf(Buffer, "%d:%02.0f", mm, secs);
 			skp->Text(W - CW, y * H / 14, Buffer, strlen(Buffer));
 		}
@@ -6433,8 +6432,8 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			Text(skp, 4, 16 + 3 * i, "%d", 2 * i + 1);
 			Text(skp, 4, 17 + 3 * i, "%d", 2 * i + 2);
-			Text_GET_HHMM(skp, 13, 16 + 3 * i, GC->rtcc->PZLRBTI.sol[2 * i].GETLOI);
-			Text_GET_HHMM(skp, 13, 17 + 3 * i, GC->rtcc->PZLRBTI.sol[2 * i + 1].GETLOI);
+			Text_GET_HHHMM(skp, 13, 16 + 3 * i, GC->rtcc->PZLRBTI.sol[2 * i].GETLOI);
+			Text_GET_HHHMM(skp, 13, 17 + 3 * i, GC->rtcc->PZLRBTI.sol[2 * i + 1].GETLOI);
 			Text(skp, 19, 16 + 3 * i, "%.0lf", GC->rtcc->PZLRBTI.sol[2 * i].DVLOI1);
 			Text(skp, 19, 17 + 3 * i, "%.0lf", GC->rtcc->PZLRBTI.sol[2 * i + 1].DVLOI1);
 			Text(skp, 26, 16 + 3 * i, "%.0lf", GC->rtcc->PZLRBTI.sol[2 * i].DVLOI2);
@@ -7449,7 +7448,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf_s(Buffer, "%.1lf %.1lf %.1lf", tab->Att_IMU.x, tab->Att_IMU.y, tab->Att_IMU.z);
 				Text(skp, 49, 7, Buffer);
 				Text(skp, 40, 8, "%.1lf", tab->DVC);
-				OrbMech::SStoHHMMSS(tab->BurnTime, hh, mm, secs, 0.1);
+				OrbMech::SStoMMSS(tab->BurnTime, mm, secs, 0.1);
 				sprintf_s(Buffer, "%02d:%04.1lf", mm, secs);
 				Text(skp, 49, 8, Buffer);
 				Text(skp, 40, 9, "%.1lf", tab->DVT);
@@ -7458,13 +7457,13 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				Text(skp, 49, 10, "%.1lf", tab->H_Retro);
 				Text_GET_HHHMMSSCS(skp, 49, 11, tab->GETI);
 				Text_GET_HHHMMSS(skp, 49, 12, tab->GMTI);
-				OrbMech::SStoHHMMSS(tab->RET400k, hh, mm, secs);
+				OrbMech::SStoMMSS(tab->RET400k, mm, secs);
 				sprintf_s(Buffer, "%d:%02.0lf", mm, secs);
 				Text(skp, 49, 13, Buffer);
 				Text(skp, 42, 14, "%.0lf", tab->V400k);
 				Text(skp, 49, 14, "%.2lf", tab->Gamma400k);
 				Text(skp, 49, 15, "%.1lf°", tab->BankAngle);
-				OrbMech::SStoHHMMSS(tab->RETRB, hh, mm, secs);
+				OrbMech::SStoMMSS(tab->RETRB, mm, secs);
 				sprintf_s(Buffer, "%d:%02.0lf", mm, secs);
 				Text(skp, 49, 16, Buffer);
 				Text_Latitude(skp, 40, 17, tab->lat_ML);
@@ -7974,7 +7973,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				sprintf_s(Buffer, "%.1lf %.1lf %.1lf", tab->Att_IMU_Sep.x, tab->Att_IMU_Sep.y, tab->Att_IMU_Sep.z);
 				Text(skp, 42, 6, Buffer);
 				Text(skp, 33, 7, "%.1lf", tab->DVC_Sep);
-				OrbMech::SStoHHMMSS(tab->BurnTime_Sep, hh, mm, secs, 0.1);
+				OrbMech::SStoMMSS(tab->BurnTime_Sep, mm, secs, 0.1);
 				sprintf_s(Buffer, "%02d:%04.1lf", mm, secs);
 				Text(skp, 42, 7, Buffer);
 				Text(skp, 33, 8, "%.1lf", tab->DVT_Sep);
@@ -8113,8 +8112,8 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			Text_GET_HHHMMSS(skp, 38, 5 + i, GC->rtcc->EZLANDU1.GETCA[GC->rtcc->EZLANDU1.curpage - 1][i]);
 			Text(skp, 43, 5 + i, "%.1lf", GC->rtcc->EZLANDU1.Lambda[GC->rtcc->EZLANDU1.curpage - 1][i]);
 			Text(skp, 50, 5 + i, "%.2lf", GC->rtcc->EZLANDU1.h[GC->rtcc->EZLANDU1.curpage - 1][i]);
-			Text_GET_HHMM(skp, 57, 5 + i, GC->rtcc->EZLANDU1.GETSR[GC->rtcc->EZLANDU1.curpage - 1][i]);
-			Text_GET_HHMM(skp, 64, 5 + i, GC->rtcc->EZLANDU1.GETSS[GC->rtcc->EZLANDU1.curpage - 1][i]);
+			Text_GET_HHHMM(skp, 57, 5 + i, GC->rtcc->EZLANDU1.GETSR[GC->rtcc->EZLANDU1.curpage - 1][i]);
+			Text_GET_HHHMM(skp, 64, 5 + i, GC->rtcc->EZLANDU1.GETSS[GC->rtcc->EZLANDU1.curpage - 1][i]);
 		}
 		if (GC->rtcc->EZLANDU1.err > 0)
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.cpp
@@ -146,63 +146,141 @@ namespace OrbMech{
 		return round(value / precision) * precision;
 	}
 
-	void SStoHHMMSS(double time, int &hours, int &minutes, double &seconds, double precision)
-	{
-		time = round_to(time, precision);
-
-		double mins;
-		hours = (int)trunc(time / 3600.0);
-		mins = fmod(time / 60.0, 60.0);
-		minutes = (int)trunc(mins);
-		seconds = (mins - minutes) * 60.0;
-	}
-
 	void SStoMMSS(double time, int &minutes, double &seconds, double precision)
 	{
+		//Only call with positive time
 		time = round_to(time, precision);
 
 		minutes = (int)trunc(time / 60.0);
 		seconds = (time / 60.0 - minutes) * 60.0;
 	}
 
-	// Format time to HHH:MM:SS.
-	void format_time(char *buf, double time)
+	void SStoHHMMSS(double time, int &hours, int &minutes, double &seconds, double precision)
 	{
-		buf[0] = 0; // Clobber
-		if (time < 0) { return; } // don't do that
+		//Only call with positive time
+		time = round_to(time, precision);
 
-		int hours, minutes;
+		hours = (int)trunc(time / 3600.0);
+		minutes = (int)trunc((time - 3600.0*hours) / 60.0);
+		seconds = time - (double)(3600 * hours + 60 * minutes);
+	}
+
+	void SStoDDHHMMSS(double time, int &days, int &hours, int &minutes, double &seconds, double precision)
+	{
+		//Only call with positive time
+		time = round_to(time, precision);
+
+		days = (int)trunc(time / 86400.0);
+		hours = (int)trunc((time - 86400.0*days) / 3600.0);
+		minutes = (int)trunc((time - 86400.0*days - 3600.0*hours) / 60.0);
+		seconds = time - (double)(86400*days + 3600*hours + 60*minutes);
+	}
+
+	void format_time_XMSS(char *buf, double time)
+	{
+		// Format time to XM:SS. (no leading zeros)
 		double seconds;
+		int minutes;
 
-		SStoHHMMSS(time, hours, minutes, seconds);
+		SStoMMSS(abs(time), minutes, seconds);
+		if (time < 0.0) minutes = -minutes;
+
+		sprintf(buf, "%d:%02.0lf", minutes, seconds);
+	}
+
+	void format_time_MMSSC(char *buf, double time)
+	{
+		// Format time to XM:SS.C
+		double seconds;
+		int minutes;
+
+		SStoMMSS(abs(time), minutes, seconds, 0.1);
+		if (time < 0.0) minutes = -minutes;
+
+		sprintf(buf, "%d:%02.1lf", minutes, seconds);
+	}
+
+	void format_time_HHHMM(char *buf, double time)
+	{
+		// Format time to HHH:MM
+		double seconds;
+		int hours, minutes;
+
+		SStoHHMMSS(abs(time), hours, minutes, seconds, 60.0);
+		if (time < 0.0) hours = -hours;
+
+		sprintf(buf, "%03d:%02d", hours, minutes);
+	}
+
+	void format_time_HHMMSS(char *buf, double time)
+	{
+		// Format time to HH:MM:SS.
+		double seconds;
+		int hours, minutes;
+
+		SStoHHMMSS(abs(time), hours, minutes, seconds);
+		if (time < 0.0) hours = -hours;
+
+		sprintf(buf, "%02d:%02d:%02.0lf", hours, minutes, seconds);
+	}
+
+	void format_time_HHHMMSS(char *buf, double time)
+	{
+		// Format time to HHH:MM:SS.
+		double seconds;
+		int hours, minutes;
+
+		SStoHHMMSS(abs(time), hours, minutes, seconds);
+		if (time < 0.0) hours = -hours;
 
 		sprintf(buf, "%03d:%02d:%02.0lf", hours, minutes, seconds);
 	}
 
-	// Format time to XXH:MM:SS. (no leading zeros)
 	void format_time_XXHMMSS(char *buf, double time)
 	{
-		buf[0] = 0; // Clobber
-		if (time < 0) { return; } // don't do that
-
-		int hours, minutes;
+		// Format time to XXH:MM:SS. (no leading zeros)
 		double seconds;
+		int hours, minutes;
 
-		SStoHHMMSS(time, hours, minutes, seconds);
+		SStoHHMMSS(abs(time), hours, minutes, seconds);
+		if (time < 0.0) hours = -hours;
 
 		sprintf(buf, "%d:%02d:%02.0lf", hours, minutes, seconds);
+	}
+
+	void format_time_HHHMMSSC(char *buf, double time)
+	{
+		// Format time to HHH:MM:SS.C
+		double seconds;
+		int hours, minutes;
+
+		SStoHHMMSS(abs(time), hours, minutes, seconds, 0.1);
+		if (time < 0.0) hours = -hours;
+
+		sprintf(buf, "%03d:%02d:%04.1lf", hours, minutes, seconds);
+	}
+
+	void format_time_HHHMMSSCS(char *buf, double time)
+	{
+		// Format time to HHH:MM:SS.CS
+		double seconds;
+		int hours, minutes;
+
+		SStoHHMMSS(abs(time), hours, minutes, seconds, 0.01);
+		if (time < 0.0) hours = -hours;
+
+		sprintf(buf, "%03d:%02d:%05.2lf", hours, minutes, seconds);
 	}
 
 	// Format precise time.
 	void format_time_prec(char *buf, double time)
 	{
-		buf[0] = 0; // Clobber
-		if (time < 0) { return; } // don't do that
-
 		int hours, minutes;
 		double seconds;
+		int length = 0;
 
-		SStoHHMMSS(time, hours, minutes, seconds, 0.01);
+		SStoHHMMSS(abs(time), hours, minutes, seconds, 0.01);
+		if (time < 0.0) hours = -hours;
 
 		sprintf(buf, "HRS XXX%03d\nMIN XXXX%02d\nSEC XX%05.2f", hours, minutes, seconds);
 	}
@@ -4539,37 +4617,6 @@ double GETfromMJD(double MJD, double GETBase)
 double MJDfromGET(double GET, double GETBase)
 {
 	return GETBase + GET / 24.0 / 3600.0;
-}
-
-void format_time_HHMMSS(char *buf, double time) {
-	buf[0] = 0; // Clobber
-	int hours, minutes, seconds;
-	bool neg = false;
-	if (time < 0)
-	{
-		time = abs(time);
-		neg = true;
-	}
-	hours = (int)(time / 3600);
-	minutes = (int)((time / 60) - (hours * 60));
-	seconds = (int)((time - (hours * 3600)) - (minutes * 60));
-	if (neg)
-	{
-		sprintf(buf, "-%03d:%02d:%02d", hours, minutes, seconds);
-	}
-	else
-	{
-		sprintf(buf, "%03d:%02d:%02d", hours, minutes, seconds);
-	}
-}
-
-void format_time_MMSS(char *buf, double time) {
-	buf[0] = 0; // Clobber
-	int minutes, seconds;
-	if (time < 0) { return; } // don't do that
-	minutes = (int)(time / 60);
-	seconds = (int)(time - (minutes * 60));
-	sprintf(buf, "%d:%02d", minutes, seconds);
 }
 
 void checkstar(const VECTOR3 *navstars, MATRIX3 REFSMMAT, VECTOR3 IMU, VECTOR3 R_C, double R_E, int &staroct, double &trunnion, double &shaft)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.h
@@ -297,8 +297,6 @@ namespace OrbMech {
 	VECTOR3 r_from_latlong(double lat, double lng, double r);
 	double GETfromMJD(double MJD, double GETBase);
 	double MJDfromGET(double GET, double GETBase);
-	void format_time_HHMMSS(char *buf, double time);
-	void format_time_MMSS(char *buf, double time);
 	bool groundstation(MATRIX3 Rot_J_B, VECTOR3 R, VECTOR3 V, double MJD, OBJHANDLE planet, double lat, double lng, bool rise, double &dt);
 	bool gslineofsight(VECTOR3 R, VECTOR3 V, VECTOR3 sun, OBJHANDLE planet, bool rise, double &v1);
 	int findNextAOS(MATRIX3 Rot_J_B, VECTOR3 R, VECTOR3 V, double MJD, OBJHANDLE planet);
@@ -434,13 +432,32 @@ namespace OrbMech {
 	void DROOTS(double A, double B, double C, double D, double E, int N, double *x, int &M, int &I);
 
 	//Time formatting functions
+	//To seconds
 	double HHMMSSToSS(int H, int M, int S);
 	double HHMMSSToSS(double H, double M, double S);
+	//Round to given precision
 	double round_to(double value, double precision = 1.0);
-	void SStoHHMMSS(double time, int &hours, int &minutes, double &seconds, double precision = 1.0);
+	//Split up seconds in minutes etc.
 	void SStoMMSS(double time, int &minutes, double &seconds, double precision = 1.0);
-	void format_time(char *buf, double time);
+	void SStoHHMMSS(double time, int &hours, int &minutes, double &seconds, double precision = 1.0);
+	void SStoDDHHMMSS(double time, int &days, int &hours, int &minutes, double &seconds, double precision = 1.0);
+	//Formatting time into a character array
+	//Time format XM:SS (no leading zeros)
+	void format_time_XMSS(char *buf, double time);
+	//Time format MM:SS.C
+	void format_time_MMSSC(char *buf, double time);
+	//Time format HH:MM
+	void format_time_HHHMM(char *buf, double time);
+	//Time format HH:MM:SS
+	void format_time_HHMMSS(char *buf, double time);
+	//Time format HHH:MM:SS
+	void format_time_HHHMMSS(char *buf, double time);
+	//Time format XXH:MM:SS (no leading zeros)
 	void format_time_XXHMMSS(char *buf, double time);
+	//Time format HHH:MM:SS.C
+	void format_time_HHHMMSSC(char *buf, double time);
+	//Time format HHH:MM:SS.CS
+	void format_time_HHHMMSSCS(char *buf, double time);
 	void format_time_prec(char *buf, double time);
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCCDisplayFormatting.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCCDisplayFormatting.cpp
@@ -22,6 +22,7 @@ See http://nassp.sourceforge.net/license/ for more details.
 **************************************************************************/
 
 #include "RTCCDisplayFormatting.h"
+#include "OrbMech.h"
 
 namespace rtcc
 {
@@ -183,19 +184,8 @@ namespace rtcc
 	void RTCCDynamicDisplayData::DFLTime(RTCCDisplay &disp, double val, int x, int y, oapi::Sketchpad::TAlign_horizontal align) const
 	{
 		char Buff[64];
-		format_time_rtcc(Buff, val);
+		OrbMech::format_time_HHHMMSS(Buff, val);
 
 		DisplayFormatting(disp, Buff, x, y, align);
-	}
-
-	void RTCCDynamicDisplayData::format_time_rtcc(char *buf, double time) const
-	{
-		buf[0] = 0; // Clobber
-		int hours, minutes, seconds;
-		if (time < 0) { return; } // don't do that
-		hours = (int)(time / 3600);
-		minutes = (int)((time / 60) - (hours * 60));
-		seconds = (int)((time - (hours * 3600)) - (minutes * 60));
-		sprintf_s(buf, 64, "%03d:%02d:%02d", hours, minutes, seconds);
 	}
 }

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCCDisplayFormatting.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCCDisplayFormatting.h
@@ -67,7 +67,6 @@ namespace rtcc
 		void DFLDouble(RTCCDisplay &disp, double val, const char* format, int x, int y, oapi::Sketchpad::TAlign_horizontal align = oapi::Sketchpad::RIGHT) const;
 		void DFLInteger(RTCCDisplay &disp, int val, const char* format, int x, int y, oapi::Sketchpad::TAlign_horizontal align = oapi::Sketchpad::RIGHT) const;
 		void DFLTime(RTCCDisplay &display, double val, int x, int y, oapi::Sketchpad::TAlign_horizontal align = oapi::Sketchpad::RIGHT) const;
-		void format_time_rtcc(char *buf, double time) const;
 	protected:
 	};
 }


### PR DESCRIPTION
Conversion of seconds to hours, minutes, seconds all in one place now. Remove duplication of time formatting code.

Testing involves checking MCC pads, RTCC MFD displays etc. if times are formatted correctly.