### PR TITLE
Correctly simulate the Apollo 13 failure of the O2 tank 2 quantity sensor at 46:45 GET

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/satswitches.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/satswitches.cpp
@@ -208,7 +208,23 @@ double SaturnCryoQuantityMeter::QueryValue()
 		if (Index == 1)
 			return Sat->O2Tank1QuantitySensor.Voltage();
 		else
-			return Sat->O2Tank2QuantitySensor.Voltage();
+		{
+			//
+			// Apollo 13 O2 tank 2 quantity display failed offscale high around 46:45.
+			//
+#define O2FAILURETIME	(46.0 * 3600.0 + 45.0 * 60.0)
+			double v = Sat->O2Tank2QuantitySensor.Voltage();
+			if (Sat->GetMission()->DoApollo13Failures())
+			{
+				if (Sat->GetMissionTime() >= (O2FAILURETIME + 5.0)) {
+					v = 5.05;
+				}
+				else if (Sat->GetMissionTime() >= O2FAILURETIME) {
+					v += (5.05 - value) * ((Sat->GetMissionTime() - O2FAILURETIME) / 5.0);
+				}
+			}
+			return v;
+		}
 	}
 }
 
@@ -224,20 +240,6 @@ void SaturnCryoQuantityMeter::DoDrawSwitch(double v, SURFHANDLE drawSurface)
 		if (Index == 1)
 			oapiBlt(drawSurface, NeedleSurface, 258, (129 - (int)(v * 20.6)), 0, 0, 10, 10, SURF_PREDEF_CK);
 		else {
-			//
-			// Apollo 13 O2 tank 2 quantity display failed offscale high around 46:45.
-			//
-
-#define O2FAILURETIME	(46.0 * 3600.0 + 45.0 * 60.0)
-
-			if (Sat->GetMission()->DoApollo13Failures()) {
-				if (Sat->GetMissionTime() >= (O2FAILURETIME + 5.0)) {
-					v = 1.05;
-				}
-				else if (Sat->GetMissionTime() >= O2FAILURETIME) {
-					v += (1.05 - value) * ((Sat->GetMissionTime() - O2FAILURETIME) / 5.0);
-				}
-			}
 			oapiBlt(drawSurface, NeedleSurface, 311, (129 - (int)(v * 20.6)), 10, 0, 10, 10, SURF_PREDEF_CK);
 		}
 	}


### PR DESCRIPTION
The old code is broken in two ways. First it only currently affects the 2D display code, so the failure would never be seen in the Virtual Cockpit. And second, the recent display fixes (part of the VC upgrade) change the meter from using 0.0 to 1.0 scale to instead use the 0V to 5V of the input sensor. The failure code put the display value to 1.05, which was offscale high with the old code, but now only about 20%.

The fixes are to move the failure code to the QueryValue function, which gets used by both 2D panel and VC, and to change the offscale high value from 1.05 to 5.05, so that it is above the 5 Volts.