### PR TITLE
Flashlight position follows the camera when using the Orbiter leaning feature

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -5779,9 +5779,11 @@ void Saturn::MoveFlashlight()
 	if (flashlightOn) { //Only move the light emmitter if the flashlight is on
 		//Huge thanks the Jordan64 for helping get the direction stuff working! :)
 
-		VECTOR3 flashlightDirGlobal, vesselPosGlobal;
+		VECTOR3 flashlightPosGlobal, flashlightDirGlobal, vesselPosGlobal;
 
-		GetCameraOffset(flashlightPos);
+		oapiCameraGlobalPos(&flashlightPosGlobal);
+		Global2Local(flashlightPosGlobal, flashlightPos);
+
 		oapiCameraGlobalDir(&flashlightDirGlobal);
 		GetGlobalPos(vesselPosGlobal);
 		Global2Local(vesselPosGlobal + flashlightDirGlobal, flashlightDirLocal);

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
@@ -3608,9 +3608,11 @@ void LEM::MoveFlashlight()
 	if (flashlightOn) { //Only move the light emmitter if the flashlight is on
 		//Huge thanks the Jordan64 for helping get the direction stuff working! :)
 
-		VECTOR3 flashlightDirGlobal, vesselPosGlobal;
+		VECTOR3 flashlightPosGlobal, flashlightDirGlobal, vesselPosGlobal;
 
-		GetCameraOffset(flashlightPos);
+		oapiCameraGlobalPos(&flashlightPosGlobal);
+		Global2Local(flashlightPosGlobal, flashlightPos);
+
 		oapiCameraGlobalDir(&flashlightDirGlobal);
 		GetGlobalPos(vesselPosGlobal);
 		Global2Local(vesselPosGlobal + flashlightDirGlobal, flashlightDirLocal);


### PR DESCRIPTION
The function to update the flashlight in CSM and LM got the flashlight position from the API function GetCameraOffset. The camera offset includes both the normal view position as well as the NASSP free camera feature (moving around with the arrow keys). It does not however take into account the Orbiter "leaning" feature using CTRL + ALT + arrow keys.

I have not found a function that returns the actual camera position in vessel coordinates, but as a slight workaround the oapiCameraGlobalPos function is used followed by a call of Global2Local to convert the global vector to local (vessel) coordinates. This makes the flashlight use the actual camera position in all cases and fixes the issue with the leaning feature.