### PR TITLE
Fix flood lights not working correctly when the VC is loaded while being paused; remove function updating the flood light position on every timestep as it is not required

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -1638,7 +1638,6 @@ void Saturn::clbkPreStep(double simt, double simdt, double mjd)
 	if ((oapiGetFocusObject() == GetHandle()) && (oapiCockpitMode() == COCKPIT_VIRTUAL) && (oapiCameraMode() == CAM_COCKPIT)) {
 		//We have focus on this vessel, and are in the VC
 		MoveFlashlight();
-		UpdateFloodLights();
 	}
 
 	sprintf(buffer, "End time(0) %lld", time(0)); 

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -1320,7 +1320,6 @@ public:
 	//
 	// FloodLight
 	//
-	void UpdateFloodLights();
 	PointLight* floodLight_P5;
 	PointLight* floodLight_P8;
 	PointLight* floodLight_P100;

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -807,6 +807,10 @@ bool Saturn::clbkLoadVC (int id)
 	vcFreeCamy = 0;
 	vcFreeCamz = 0;
 
+	//Get mesh offset
+	VECTOR3 ofs;
+	GetMeshOffset(vcidx, ofs);
+
 	//Flashlight
 	DelLightEmitter(flashlight);
 	flashlight = (::SpotLight*)AddSpotLight(flashlightPos, flashlightDirLocal, 3, 0, 0, 3, 0, RAD * 45, flashlightColor, flashlightColor, flashlightColor2);
@@ -815,21 +819,21 @@ bool Saturn::clbkLoadVC (int id)
 
 	//FloodLight Panel 5
 	DelLightEmitter(floodLight_P5);
-	floodLight_P5 = (::PointLight*)AddPointLight(floodLightPos_P5, 3, 0, 0, 3, floodLightColor_P5, floodLightColor_P5, floodLightColor2_P5);
+	floodLight_P5 = (::PointLight*)AddPointLight(floodLightPos_P5 + ofs, 3, 0, 0, 3, floodLightColor_P5, floodLightColor_P5, floodLightColor2_P5);
 	floodLight_P5->SetVisibility(LightEmitter::VIS_COCKPIT);
 	floodLight_P5->Activate(true);
 	floodLight_P5->SetIntensity(1);
 
 	//FloodLight Panel 8
 	DelLightEmitter(floodLight_P8);
-	floodLight_P8 = (::PointLight*)AddPointLight(floodLightPos_P8, 3, 0, 0, 3, floodLightColor_P8, floodLightColor_P8, floodLightColor2_P8);
+	floodLight_P8 = (::PointLight*)AddPointLight(floodLightPos_P8 + ofs, 3, 0, 0, 3, floodLightColor_P8, floodLightColor_P8, floodLightColor2_P8);
 	floodLight_P8->SetVisibility(LightEmitter::VIS_COCKPIT);
 	floodLight_P8->Activate(true);
 	floodLight_P8->SetIntensity(1);
 
 	//FloodLight Panel 100(LEB)
 	DelLightEmitter(floodLight_P100);
-	floodLight_P100 = (::PointLight*)AddPointLight(floodLightPos_P100, 3, 0, 0, 3, floodLightColor_P100, floodLightColor_P100, floodLightColor2_P100);
+	floodLight_P100 = (::PointLight*)AddPointLight(floodLightPos_P100 + ofs, 3, 0, 0, 3, floodLightColor_P100, floodLightColor_P100, floodLightColor2_P100);
 	floodLight_P100->SetVisibility(LightEmitter::VIS_COCKPIT);
 	floodLight_P100->Activate(true);
 	floodLight_P100->SetIntensity(1);
@@ -5758,22 +5762,6 @@ void Saturn::SetVCLighting(UINT meshidx, int material, int EmissionMode, double 
 		pCore->MeshMaterial(hMesh, material, EmissionMode, &value, true);
 #endif
 	}
-}
-
-void Saturn::UpdateFloodLights()
-{
-	VECTOR3 camPos;
-	VECTOR3 ofs;
-	GetCameraOffset(camPos);
-	GetMeshOffset(vcidx, ofs); // First get or VC Offset
-
-	// Debug string for finding Camera and VC mesh Position
-	//sprintf(oapiDebugString(), "%.3f  %.3f  %.3f ** %.3f  %.3f  %.3f ", camPos.x, camPos.y, camPos.z, ofs.x, ofs.y, ofs.z );
-
-	// Set the Floodlights 
-	floodLight_P5->SetPosition(ofs + floodLightPos_P5);
-	floodLight_P8->SetPosition(ofs + floodLightPos_P8);
-	floodLight_P100->SetPosition(ofs + floodLightPos_P100);
 }
 
 void Saturn::MoveFlashlight()

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -1432,7 +1432,6 @@ void LEM::clbkPreStep (double simt, double simdt, double mjd) {
 	if ((oapiGetFocusObject() == GetHandle()) && (oapiCockpitMode() == COCKPIT_VIRTUAL) && (oapiCameraMode() == CAM_COCKPIT)) {
 		//We have focus on this vessel, and are in the VC
 		MoveFlashlight();
-		UpdateFloodLights();
 	}
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -684,7 +684,6 @@ public:
 	bool flashlightOn;
 
 	// Floodlight LM Pilot
-	void UpdateFloodLights();
 	PointLight* floodLight_Left;
 
 	// Floodlight LM Commander

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemvc.cpp
@@ -740,16 +740,20 @@ bool LEM::clbkLoadVC (int id)
 	flashlight->SetVisibility(LightEmitter::VIS_COCKPIT);
 	flashlight->Activate(flashlightOn);
 
+	//Get mesh offset
+	VECTOR3 ofs;
+	GetMeshOffset(vcidx, ofs);
+
 	//FloodLight Right Pilot
 	DelLightEmitter(floodLight_Right);
-	floodLight_Right = (::PointLight*)AddPointLight(floodLightPos_Right, 3, 0, 0, 3, floodLightColor_Right, floodLightColor_Right, floodLightColor2_Right);
+	floodLight_Right = (::PointLight*)AddPointLight(floodLightPos_Right + ofs, 3, 0, 0, 3, floodLightColor_Right, floodLightColor_Right, floodLightColor2_Right);
 	floodLight_Right->SetVisibility(LightEmitter::VIS_COCKPIT);
 	floodLight_Right->Activate(true);
 	floodLight_Right->SetIntensity(1);
 
 	//FloodLight Left Commander
 	DelLightEmitter(floodLight_Left);
-	floodLight_Left = (::PointLight*)AddPointLight(floodLightPos_Left, 3, 0, 0, 3, floodLightColor_Left, floodLightColor_Left, floodLightColor2_Left);
+	floodLight_Left = (::PointLight*)AddPointLight(floodLightPos_Left + ofs, 3, 0, 0, 3, floodLightColor_Left, floodLightColor_Left, floodLightColor2_Left);
 	floodLight_Left->SetVisibility(LightEmitter::VIS_COCKPIT);
 	floodLight_Left->Activate(true);
 	floodLight_Left->SetIntensity(1);
@@ -3656,19 +3660,4 @@ void LEM::ToggleFlashlight()
 	if ((oapiCockpitMode() == COCKPIT_VIRTUAL) && (oapiCameraMode() == CAM_COCKPIT)) {
 		SetFlashlightOn(!flashlightOn);
 	}
-}
-
-void LEM::UpdateFloodLights()
-{
-	VECTOR3 camPos;
-	VECTOR3 ofs;
-	GetCameraOffset(camPos);
-	GetMeshOffset(vcidx, ofs); // First get or VC Offset
-
-	// Debug string for finding Camera and VC mesh Position
-//	sprintf(oapiDebugString(), "%.3f  %.3f  %.3f ** %.3f  %.3f  %.3f ", camPos.x, camPos.y, camPos.z, ofs.x, ofs.y, ofs.z );
-
-	// Set the Floodlights 
-	floodLight_Left->SetPosition(ofs + floodLightPos_Left);
-	floodLight_Right->SetPosition(ofs + floodLightPos_Right);
 }


### PR DESCRIPTION
Removing the UpdateFloodLights functions should be fine as the flood light positions are automatically updated by Orbiter with any CG shift. This could use some testing though, to confirm it works correctly in all cases. Test cases would be:

-Saturn launch
-Any staging
-Powered descent
-Long SPS burn