### PR TITLE
A few RTCC fixes

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -35331,7 +35331,7 @@ void RTCC::BMSVEC()
 
 	OELEMENTS coe;
 	double mu, r_apo, r_peri, R_E, r, v, lat, lng, gamma, azi, gmt;
-	int numvec = 0;
+	int err, numvec = 0;
 
 	EMSMISSInputTable emsmissin;
 	EphemerisData sv_comp[4];
@@ -35376,6 +35376,7 @@ void RTCC::BMSVEC()
 			//Error code 2 acceptable
 			if (outtab.ErrorCode > 2)
 			{
+				RTCCONLINEMON.IntBuffer[0] = intab.L;
 				BMGPRIME("BMSVEC", 10);
 				BZCCANOE.error = true;
 				goto RTCC_BMSVEC_1;
@@ -35417,7 +35418,9 @@ void RTCC::BMSVEC()
 	VECTOR3 U, V, W;
 
 	emsmissin.AuxTableIndicator = NULL;
-	emsmissin.CutoffIndicator = 1;
+	emsmissin.CutoffIndicator = 3;
+	emsmissin.EarthRelStopParam = 400000.0*0.3048; //EI
+	emsmissin.MoonRelStopParam = 0.0; //Impact
 	emsmissin.DensityMultOverrideIndicator = false;
 	emsmissin.DescentBurnIndicator = false;
 	emsmissin.EphemerisBuildIndicator = false;
@@ -35441,11 +35444,11 @@ void RTCC::BMSVEC()
 
 	if (med_s80.REF == BODY_EARTH)
 	{
-		csi_out = 0;
+		csi_out = 1;
 	}
 	else
 	{
-		csi_out = 2;
+		csi_out = 3;
 	}
 
 	for (int i = 0;i < numvec;i++)
@@ -35465,10 +35468,49 @@ void RTCC::BMSVEC()
 		//Propagate state vector
 		EMSMISS(&emsmissin);
 
-		//Convert to desired coordinate system
-		ELVCNV(emsmissin.NIAuxOutputTable.sv_cutoff, csi_out, sv_final[i]);
-		sv_final[i] = emsmissin.NIAuxOutputTable.sv_cutoff;
+		//Error checks
+		if (emsmissin.NIAuxOutputTable.ErrorCode)
+		{
+			if (emsmissin.NIAuxOutputTable.ErrorCode == 3)
+			{
+				//Maneuver error
+				RTCCONLINEMON.IntBuffer[0] = 1; //TBD: Does EMSMISS output the maneuver NI error code and where? 
+				RTCCONLINEMON.IntBuffer[1] = i + 1;
+				BMGPRIME("BMSVEC", 8);
+			}
+			else
+			{
+				//Other errors
+				RTCCONLINEMON.IntBuffer[0] = emsmissin.NIAuxOutputTable.ErrorCode;
+				RTCCONLINEMON.IntBuffer[1] = i + 1;
+				BMGPRIME("BMSVEC", 16);
+			}
+			BZCCANOE.error = true;
+			goto RTCC_BMSVEC_1;
+		}
+		else
+		{
+			if (emsmissin.NIAuxOutputTable.TerminationCode == 3)
+			{
+				//Termination on altitude
+				RTCCONLINEMON.IntBuffer[0] = i + 1;
+				BMGPRIME("BMSVEC", 1);
+				BZCCANOE.error = true;
+				goto RTCC_BMSVEC_1;
+			}
+		}
 
+		//Convert to desired coordinate system
+		err = ELVCNV(emsmissin.NIAuxOutputTable.sv_cutoff, csi_out, sv_final[i]);
+		if (err)
+		{
+			//Vector rotation error
+			RTCCONLINEMON.IntBuffer[0] = i + 1;
+			BMGPRIME("BMSVEC", 6);
+			BZCCANOE.error = true;
+			goto RTCC_BMSVEC_1;
+		}
+		//Calculate reference UVW vectors
 		if (i == 0)
 		{
 			U = unit(sv_final[i].R);
@@ -35483,6 +35525,11 @@ void RTCC::BMSVEC()
 		if (lng > PI)
 		{
 			lng -= PI2;
+		}
+		if (csi_out == 1)
+		{
+			//ECT longitude to geographic longitude
+			lng = OrbMech::LongitudeConversion(lng, sv_final[i].GMT, OrbMech::w_Earth, 0.0, true);
 		}
 
 		if (coe.e >= 1.0)
@@ -35787,10 +35834,28 @@ void RTCC::BMGPRIME(std::string source, int n)
 	switch (n)
 	{
 	case 1:
-		message.push_back("SPACECRAFT BELOW EI");
+		sprintf(Buffer, "SPACECRAFT BELOW EI, VECTOR %d", RTCCONLINEMON.IntBuffer[0]);
+		message.push_back(Buffer);
+		break;
+	case 6:
+		sprintf(Buffer, "VECTOR ROTATION ERROR, VECTOR %d", RTCCONLINEMON.IntBuffer[0]);
+		message.push_back(Buffer);
+		break;
+	case 8:
+		sprintf(Buffer, "BURN NI ERROR %d, VECTOR %d", RTCCONLINEMON.IntBuffer[0], RTCCONLINEMON.IntBuffer[1]);
+		message.push_back(Buffer);
 		break;
 	case 10:
-		message.push_back("INTERPOLATION ERROR");
+		sprintf(Buffer, "INTERPOLATION ERROR, VEHICLE %d", RTCCONLINEMON.IntBuffer[0]);
+		message.push_back(Buffer);
+		break;
+	case 12:
+		sprintf(Buffer, "EPHEMERIS FETCH ERROR %d, VECTOR %d", RTCCONLINEMON.IntBuffer[0], RTCCONLINEMON.IntBuffer[1]);
+		message.push_back(Buffer);
+		break;
+	case 16:
+		sprintf(Buffer, "MISC. NI ERROR %d, VECTOR %d", RTCCONLINEMON.IntBuffer[0], RTCCONLINEMON.IntBuffer[1]);
+		message.push_back(Buffer);
 		break;
 	case 24:
 		sprintf(Buffer, "ERROR NUMBER %d", RTCCONLINEMON.IntBuffer[0]);
@@ -37172,7 +37237,7 @@ void RTCC::EMDGLMST()
 		OrbMech::latlong_from_r(EZJGSTAR[EZJGSTBL.star1 - 1], dec, ra);
 		OrbMech::format_time_HHHMM(Buffer, ra / PI2 * 24.0*3600.0);
 		LOSTDisplayBuffer[14].assign(Buffer);
-		OrbMech::format_time_HHHMM(Buffer, dec*DEG*3600.0);
+		OrbMech::format_declination_HHMM(Buffer, dec*DEG*3600.0);
 		LOSTDisplayBuffer[15].assign(Buffer);
 	}
 	else
@@ -37186,7 +37251,7 @@ void RTCC::EMDGLMST()
 		OrbMech::latlong_from_r(EZJGSTAR[EZJGSTBL.star2 - 1], dec, ra);
 		OrbMech::format_time_HHHMM(Buffer, ra / PI2 * 24.0*3600.0);
 		LOSTDisplayBuffer[16].assign(Buffer);
-		OrbMech::format_time_HHHMM(Buffer, dec*DEG*3600.0);
+		OrbMech::format_declination_HHMM(Buffer, dec*DEG*3600.0);
 		LOSTDisplayBuffer[17].assign(Buffer);
 	}
 	else

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -1291,8 +1291,8 @@ void ARCore::GetStateVectorFromIU()
 		V = lvdc->DotS;
 		TAS = lvdc->TAS;
 	}
-	sv.R = tmul(GC->rtcc->GZLTRA.IU1_REFSMMAT, R);
-	sv.V = tmul(GC->rtcc->GZLTRA.IU1_REFSMMAT, V);
+	sv.R = R;
+	sv.V = V;
 	sv.GMT = TAS + GC->rtcc->GetIUClockZero();
 	sv.RBI = BODY_EARTH;
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -166,32 +166,32 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			for (int i = 0; i < GC->rtcc->TwoImpMultDispBuffer.Solutions; i++)
 			{
 				sprintf(Buffer, "%.1lf", GC->rtcc->TwoImpMultDispBuffer.data[i].DELV1);
-				skp->Text(CW * 7, CH * (12 + i), Buffer, strlen(Buffer));
+				Text(skp, 7, 12 + i, Buffer);
 				sprintf(Buffer, "%.1lf", GC->rtcc->TwoImpMultDispBuffer.data[i].YAW1);
-				skp->Text(CW * 14, CH * (12 + i), Buffer, strlen(Buffer));
+				Text(skp, 14, 12 + i, Buffer);
 				sprintf(Buffer, "%.1lf", GC->rtcc->TwoImpMultDispBuffer.data[i].PITCH1);
-				skp->Text(CW * 20, CH * (12 + i), Buffer, strlen(Buffer));
+				Text(skp, 20, 12 + i, Buffer);
 				GET_Display(Buffer, GC->rtcc->TwoImpMultDispBuffer.data[i].Time2, false);
-				skp->Text(CW * 30, CH * (12 + i), Buffer, strlen(Buffer));
+				Text(skp, 30, 12 + i, Buffer);
 				sprintf(Buffer, "%.1lf", GC->rtcc->TwoImpMultDispBuffer.data[i].DELV2);
-				skp->Text(CW * 37, CH * (12 + i), Buffer, strlen(Buffer));
+				Text(skp, 37, 12 + i, Buffer);
 				if (GC->rtcc->TwoImpMultDispBuffer.showTPI)
 				{
 					GET_Display(Buffer, GC->rtcc->TwoImpMultDispBuffer.data[i].T_TPI, false);
-					skp->Text(CW * 49, CH * (12 + i), Buffer, strlen(Buffer));
+					Text(skp, 49, 12 + i, Buffer);
 				}
 				else
 				{
 					sprintf(Buffer, "%.1lf", GC->rtcc->TwoImpMultDispBuffer.data[i].YAW2);
-					skp->Text(CW * 44, CH * (12 + i), Buffer, strlen(Buffer));
+					Text(skp, 44, 12 + i, Buffer);
 					sprintf(Buffer, "%.1lf", GC->rtcc->TwoImpMultDispBuffer.data[i].PITCH2);
-					skp->Text(CW * 50, CH * (12 + i), Buffer, strlen(Buffer));
+					Text(skp, 50, 12 + i, Buffer);
 				}
 
 				sprintf(Buffer, "%c", GC->rtcc->TwoImpMultDispBuffer.data[i].L);
-				skp->Text(CW * 52, CH * (12 + i), Buffer, strlen(Buffer));
+				Text(skp, 52, 12 + i, Buffer);
 				sprintf(Buffer, "%d", GC->rtcc->TwoImpMultDispBuffer.data[i].C);
-				skp->Text(CW * 56, CH * (12 + i), Buffer, strlen(Buffer));
+				Text(skp, 56, 12 + i, Buffer);
 			}
 		}
 		break;
@@ -2935,7 +2935,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		skp->Text(CW, 2 * H / 14, Buffer, strlen(Buffer));
 
 		OrbMech::SStoHHMMSS(G->t_LunarLiftoff, hh, mm, secs, 0.01);
-		Text(skp, 12, 10, "%+06d HRS", hh);
+		Text(skp, 12, 11, "%+06d HRS", hh);
 		Text(skp, 12, 12, "%+06d MIN TIG", mm);
 		Text(skp, 12, 13, "%+07.2f SEC", secs);
 		Text(skp, 12, 14, "%+07.1f V (HOR)", GC->rtcc->PZLTRT.InsertionHorizontalVelocity / 0.3048);
@@ -3794,7 +3794,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			GET_Display(Buffer, G->SVDesiredGET, false);
 		}
-		skp->Text(CW * 42, CH * 2, Buffer, strlen(Buffer));
+		Text(skp, 42, 2, Buffer);
 
 		for (int i = 0; i < 021; i++)
 		{
@@ -7633,7 +7633,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			skp->Text(CW, 4 * H / 14, Buffer, strlen(Buffer));
 			skp->Text(CW, 10 * H / 14, "MAX:", 4);
 			GET_Display(Buffer, GC->rtcc->med_f77.T_max, false);
-			skp->Text(CW * 5, 10 * H / 14, Buffer, strlen(Buffer));
+			skp->Text(CW * 6, 10 * H / 14, Buffer, strlen(Buffer));
 			if (GC->rtcc->med_f77.Site != "FCUA")
 			{
 				GET_Display(Buffer, GC->rtcc->med_f75_f77.T_Z, false);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LunarTargetingProgram.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LunarTargetingProgram.cpp
@@ -38,6 +38,7 @@ LunarTargetingProgramInput::LunarTargetingProgramInput()
 	lat_tgt = 0.0;
 	lng_tgt = 0.0;
 	TB8 = 0.0;
+	gmt_imp_tgt = 0.0;
 }
 
 LunarTargetingProgram::LunarTargetingProgram(RTCC *r) : RTCCModule(r)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.cpp
@@ -285,6 +285,18 @@ namespace OrbMech{
 		sprintf(buf, "HRS XXX%03d\nMIN XXXX%02d\nSEC XX%05.2f", hours, minutes, seconds);
 	}
 
+	void format_declination_HHMM(char *buf, double decl)
+	{
+		// Format declination to +HH:MM, input in arc seconds
+		double seconds;
+		int hours, minutes;
+
+		SStoHHMMSS(abs(decl), hours, minutes, seconds, 60.0);
+		if (decl < 0.0) hours = -hours;
+
+		sprintf(buf, "%+03d:%02d", hours, minutes);
+	}
+
 	void adbar_from_rv(double rmag, double vmag, double rtasc, double decl, double fpav, double az, VECTOR3 &R, VECTOR3 &V)
 	{
 		R = _V(cos(decl)*cos(rtasc), cos(decl)*sin(rtasc), sin(decl))*rmag;
@@ -4755,15 +4767,10 @@ void AOTStarAcquisition(VECTOR3 navstar, MATRIX3 REFSMMAT, VECTOR3 IMU, double A
 		theta = PI2 - theta;
 	}
 	YROT = PI2 + theta + AZ;
-	if (YROT >= PI2)
-	{
-		YROT -= PI2;
-	}
+	normalizeAngle(YROT);
+
 	SROT = YROT + 12.0*acos(C1);
-	if (SROT >= PI2)
-	{
-		SROT -= PI2;
-	}
+	normalizeAngle(SROT);
 }
 
 bool LMCOASCheckStar(VECTOR3 SI, MATRIX3 RMAT, VECTOR3 IMU, int Axis, double &EL, double &SPX)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/OrbMech.h
@@ -459,6 +459,8 @@ namespace OrbMech {
 	//Time format HHH:MM:SS.CS
 	void format_time_HHHMMSSCS(char *buf, double time);
 	void format_time_prec(char *buf, double time);
+	//Declination format +HH:MM
+	void format_declination_HHMM(char *buf, double decl);
 }
 
 inline CELEMENTS operator+(const CELEMENTS &a, const CELEMENTS &b)


### PR DESCRIPTION
Changes in this PR:
-Add Vector Compare Display error checks and messages on on-line monitor for being below entry interface, maneuver error, vector rotation errrors and other unspecified errors
-Vector Compare Display spherical coordinates (including latitude and longitude) are calculated in Earth/Moon fixed coordinates and not inertial coordinates
-RTCC calculation of AOT counter angles are enforced to be displayed as 0 to 360 degrees
-LOST display declination display with plus sign if the declination is positive
-IU state vectors are saved in platform coordinates and only converted to BRCS coordinates upon being saved in the vector evaluation table. A previous change included the conversion in the second step, but didn't remove it in the telemetry vector saving
-Fix some display centering issues in the RTCC MFD for the two-impulse multiple solution and AGC state vector uplink pages
-Fix minor formatting issue on RTCC MFD Ascent PAD and Abort Scan Table maximum time input
-Initialize lunar impact input for impact time to 0, it could previously show a random time initially