### PR TITLE
Fix Apollo 8 MCC-5 REFSMMAT Calc

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C_PRIME.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C_PRIME.cpp
@@ -1822,7 +1822,7 @@ bool RTCC::CalculationMTP_C_PRIME(int fcn, LPVOID &pad, char * upString, char * 
 		}
 		else
 		{
-			if (fcn == 203 || fcn == 206)
+			if (fcn == 206)
 			{
 				REFSMMATOpt refsopt;
 				refsopt.REFSMMATopt = 3;


### PR DESCRIPTION
Commit bdded33 removed the uplink of the calculated entry REFSMMAT for MCC-5 in Apollo 8, but does not remove the calculation of this REFSMMAT. Hence the CMC and PAD attitudes are in disagreement. This PR fixes this to remove that calculation for MCC-5, and just use the CMC REFSMMAT.

Testing Scenario: 
[A8 MCC-5.scn.txt](https://github.com/user-attachments/files/20144198/A8.MCC-5.scn.txt)
