### PR TITLE
Fix Cue Card Clickspots + RTCC Display Change

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -1722,15 +1722,15 @@ void Saturn::RegisterActiveAreas() {
 
 	// Front of floodlight
 	oapiVCRegisterArea(AID_VC_CUE_CARD_LOCATION_15, PANEL_REDRAW_NEVER, PANEL_MOUSE_LBDOWN);
-	oapiVCSetAreaClickmode_Quadrilateral(AID_VC_CUE_CARD_LOCATION_15, _V(0.270, 0.995, -0.331) + ofs, _V(0.350, 0.995, -0.331) + ofs, _V(0.270, 0.863, -0.26) + ofs, _V(0.350, 0.863, -0.26) + ofs);
+	oapiVCSetAreaClickmode_Quadrilateral(AID_VC_CUE_CARD_LOCATION_15, _V(0.270, 0.995, -0.26) + ofs, _V(0.350, 0.995, -0.26) + ofs, _V(0.270, 0.863, -0.331) + ofs, _V(0.350, 0.863, -0.331) + ofs);
 
 	// Next to panel 229
 	oapiVCRegisterArea(AID_VC_CUE_CARD_LOCATION_16, PANEL_REDRAW_NEVER, PANEL_MOUSE_LBDOWN);
-	oapiVCSetAreaClickmode_Quadrilateral(AID_VC_CUE_CARD_LOCATION_16, _V(1.076, 0.125, -0.04) + ofs, _V(1.075, 0.020, -0.04) + ofs, _V(1.075, 0.02, -0.23) + ofs, _V(1.076, 0.09, -0.23) + ofs);
+	oapiVCSetAreaClickmode_Quadrilateral(AID_VC_CUE_CARD_LOCATION_16, _V(1.076, 0.125, -0.04) + ofs, _V(1.075, 0.020, -0.04) + ofs, _V(1.076, 0.09, -0.23) + ofs, _V(1.075, 0.02, -0.23) + ofs);
 
 	// Above window 5
 	oapiVCRegisterArea(AID_VC_CUE_CARD_LOCATION_17, PANEL_REDRAW_NEVER, PANEL_MOUSE_LBDOWN);
-	oapiVCSetAreaClickmode_Quadrilateral(AID_VC_CUE_CARD_LOCATION_17, _V(0.95, 0.953, 0.08) + ofs, _V(1.02, 0.885, 0.06) + ofs, _V(1.12, 0.964, -0.144) + ofs, _V(1.026, 1.06, -0.117) + ofs);
+	oapiVCSetAreaClickmode_Quadrilateral(AID_VC_CUE_CARD_LOCATION_17, _V(0.95, 0.953, 0.08) + ofs, _V(1.02, 0.885, 0.06) + ofs, _V(1.026, 1.06, -0.117) + ofs, _V(1.12, 0.964, -0.144) + ofs);
 }
 
 // --------------------------------------------------------------

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -8874,11 +8874,11 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		}
 		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
 		skp->Text(W - CW, 5 * H / 14, "IMU Angles:", 11);
-		sprintf(Buffer, "OGA: %+.2lf°", G->IMUParkingAngles.x * DEG);
+		sprintf(Buffer, "OGA: %+07.2lf°", G->IMUParkingAngles.x * DEG);
 		skp->Text(W - CW, 6 * H / 14, Buffer, strlen(Buffer));
-		sprintf(Buffer, "IGA: %+.2lf°", G->IMUParkingAngles.y * DEG);
+		sprintf(Buffer, "IGA: %+07.2lf°", G->IMUParkingAngles.y * DEG);
 		skp->Text(W - CW, 7 * H / 14, Buffer, strlen(Buffer));
-		sprintf(Buffer, "MGA: %+.2lf°", G->IMUParkingAngles.z * DEG);
+		sprintf(Buffer, "MGA: %+07.2lf°", G->IMUParkingAngles.z * DEG);
 		skp->Text(W - CW, 8 * H / 14, Buffer, strlen(Buffer));
 		break;
 	}


### PR DESCRIPTION
The main change of this PR affects the clickspots for ASTP, some of them were positioned incorrectly, as seen below with a before/after:

## Above Window 5
<img src="https://github.com/user-attachments/assets/f54e91c2-15ed-454e-9e07-c742cda5d57b" height="200" />
<img src="https://github.com/user-attachments/assets/efe306ec-5cf2-40a2-9bec-5d36a8ab4f76" height="200" /><br/>

## Next to Panel 229
<img src="https://github.com/user-attachments/assets/859152b1-9f07-4d3b-8811-b4f8942607cc" height="200" />
<img src="https://github.com/user-attachments/assets/d3e31abd-b387-441d-a94d-5ec78291d356" height="200" /><br/>

## Floodlight
<img src="https://github.com/user-attachments/assets/ee70941f-51ee-417e-84f7-f60cc444f2d9" height="200" />
<img src="https://github.com/user-attachments/assets/9ea08bd7-b2b4-4f7b-964e-f028853ab6a5" height="200" />

---

This PR also changes the IMU parking angles page in the RTCC to always show 5 digits, making it easier to enter into the LGC:

![image](https://github.com/user-attachments/assets/b7bcf440-3e34-48ec-8830-080b71631b6e)


