### PR TITLE
CSM VC: Panel 12 clickspots active in all LEB view positions

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -1476,7 +1476,8 @@ void Saturn::RegisterActiveAreas() {
 			oapiVCRegisterArea(AID_VC_TW_P10_01 + i, PANEL_REDRAW_ALWAYS, PANEL_MOUSE_DOWN);
 			oapiVCSetAreaClickmode_Spherical(AID_VC_TW_P10_01 + i, P10_TW_POS[i] + P10_TWCLICK + ofs, TW);
 		}
-
+	}
+	if (viewpos >= SATVIEW_GNPANEL && viewpos <= SATVIEW_LOWER_CENTER) {
 		// Panel 12
 		for (i = 0; i < P12_ROTCOUNT; i++)
 		{


### PR DESCRIPTION
Previously the panel 12 clickspots were only accessible in the SATVIEW_LOWER_CENTER view position, which is between the center seat and the tunnel. Panel 10 has issues with the MDC switches being clicked in the LEB view positions, but I don't seen any such issues with panel 12. So these are the view positions where the panel 12 clickspots are now active and (still) inactive:

Active:
-G&N panel
-LEB left
-LEB right
-Tunnel
-Lower center (between center seat and tunnel, it was only active in this view positions before this PR)

Inactive:
-Left seat
-Center seat
-Right seat
-Left docking window
-Right docking window
-Side hatch
-Upper center (Above side hatch)