### PR TITLE
Add ORDEAL slew switch keybinds

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -3848,6 +3848,22 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 					bRecovery = true;
 				}
 				return 1;
+			case OAPI_KEY_O:
+				if (ordealState.Closed()) {
+					ORDEALSlewSwitch.SwitchTo(THREEPOSSWITCH_UP, true);
+				}
+				return 1;
+			case OAPI_KEY_L:
+				if (ordealState.Closed()) {
+					ORDEALSlewSwitch.SwitchTo(THREEPOSSWITCH_DOWN, true);
+				}
+				return 1;
+			}
+		} else {
+			switch (key) {
+			case OAPI_KEY_O:
+			case OAPI_KEY_L:
+				ORDEALSlewSwitch.SwitchTo(THREEPOSSWITCH_CENTER, true);
 			}
 		}
 		return 0;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -1060,6 +1060,27 @@ int LEM::clbkConsumeBufferedKey(DWORD key, bool down, char *keystate) {
 		}
 	}
 
+	if (!KEYMOD_SHIFT(keystate) && !KEYMOD_CONTROL(keystate) && KEYMOD_ALT(keystate))
+	{
+		if (down) {
+			switch (key) {
+			case OAPI_KEY_O:
+				ORDEALSlewSwitch.SwitchTo(THREEPOSSWITCH_UP, true);
+				break;
+			case OAPI_KEY_L:
+				ORDEALSlewSwitch.SwitchTo(THREEPOSSWITCH_DOWN, true);
+				break;
+			}
+		} else {
+			switch (key) {
+			case OAPI_KEY_O:
+			case OAPI_KEY_L:
+				ORDEALSlewSwitch.SwitchTo(THREEPOSSWITCH_CENTER, true);
+				break;
+			}
+		}
+	}
+
 	if (down){
 		switch(key){
 			// Valid shaft positions should be:


### PR DESCRIPTION
Fixes #1443 

Adds `Alt-O` to slew ORDEAL up and `Alt-L` to slew it down.