### PR TITLE
Powered Descent Abort Program: Disable periapsis height limit in CSI maneuver calculation

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -12206,6 +12206,7 @@ bool RTCC::PoweredDescentAbortProgram(PDAPOpt opt, PDAPResults &res)
 	conopt.E = 26.6*RAD;
 	conopt.K_CDH = 0;
 	conopt.GMT_TPI = opt.GMT_TPI;
+	conopt.h_min = -OrbMech::R_Moon; //Disables limit
 	GMT_LAND = opt.GMT_LAND;
 
 	res.R_amin = length(opt.R_LS) + opt.h_amin;


### PR DESCRIPTION
The calculation for the powered descent abort constants iterates on the CSI maneuver solutions (RTCC rendezvous processor called SPQ) and the resulting Delta H at CDH. This processor recently got an overhaul with additional error checks. One check that is now enforced is a minimum periapsis altitude limit. In the process of iterating on insertion velocity and the required CSI maneuver the Powered Descent Abort Program (PDAP) might generate a trajectory that causes the SPQ to run into this limit. This makes the calculation for the abort constants fail in the Apollo 12 MCC, see the attached scenario.

The solution is to disable the SPQ limit in the PDAP calculation. Due to converging on the desired Delta H at CDH the PDAP will automatically generate a reasonable solution with a safe perilune altitude, so this is not an issue.

[Apollo 12 +105h 59m 09.18s.scn.txt](https://github.com/user-attachments/files/20644718/Apollo.12.%2B105h.59m.09.18s.scn.txt)