### PR TITLE
A few RTCC fixes

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -11987,6 +11987,7 @@ void RTCC::LunarAscentProcessor(const LunarAscentProcessorInputs &in, LunarAscen
 	m1 = in.m0;
 	t_total_old = t_total;
 	integ.Init(unit(R));
+	out.ErrorCode = 0;
 
 	while (stop == false)
 	{
@@ -11999,6 +12000,11 @@ void RTCC::LunarAscentProcessor(const LunarAscentProcessorInputs &in, LunarAscen
 		//Accumulate DV
 		dv += Thrust / m1 * (t_total - t_total_old);
 		t_total_old = t_total;
+		if (m1 < SystemParameters.MCVLWT)
+		{
+			out.ErrorCode = 2;
+			break;
+		}
 	}
 
 	//Calculate output parameters
@@ -16203,7 +16209,7 @@ int RTCC::PMMLAI(PMMLAIInput in, RTCCNIAuxOutputTable &aux, EphemerisDataTable2 
 	aux.DV_cTO = 0.0;
 	aux.DV_TO = 0.0;
 	aux.DV_U = 0.0;
-	aux.MainFuelUsed = asc_out.m1 - in.m0;
+	aux.MainFuelUsed = in.m0 - asc_out.m1;
 	aux.P_G = 0.0;
 	aux.RCSFuelUsed = 0.0;
 	aux.CSI = 2;
@@ -16247,7 +16253,7 @@ int RTCC::PMMLAI(PMMLAIInput in, RTCCNIAuxOutputTable &aux, EphemerisDataTable2 
 		E->Header.TR = E->table.back().GMT;
 	}
 
-	return 0;
+	return asc_out.ErrorCode;
 }
 
 int RTCC::PMMLDI(PMMLDIInput in, RTCCNIAuxOutputTable &aux, EphemerisDataTable2 *E)
@@ -16911,6 +16917,11 @@ void RTCC::EMSEPH(int QUEID, StateVectorTableEntry &sv, int &L, double PresentGM
 	{
 		EMSMISS(&InTable);
 
+		if (InTable.NIAuxOutputTable.ErrorCode)
+		{
+			//TBD: Handle errors
+		}
+
 		if (QUEID == 2)
 		{
 			//Store ephemeris
@@ -17114,8 +17125,17 @@ void RTCC::EMSEPH(int QUEID, StateVectorTableEntry &sv, int &L, double PresentGM
 		//Write headers
 		table->EPHEM.Header.NumVec = table->EPHEM.table.size();
 		table->EPHEM.Header.Offset = 0;
-		table->EPHEM.Header.TL = table->EPHEM.table.front().GMT;
-		table->EPHEM.Header.TR = table->EPHEM.table.back().GMT;
+
+		if (table->EPHEM.table.size() == 0U)
+		{
+			table->EPHEM.Header.TL = 0.0;
+			table->EPHEM.Header.TR = 0.0;
+		}
+		else
+		{
+			table->EPHEM.Header.TL = table->EPHEM.table.front().GMT;
+			table->EPHEM.Header.TR = table->EPHEM.table.back().GMT;
+		}
 		table->MANTIMES.TUP = table->EPHEM.Header.TUP;
 
 		if (L == RTCC_MPT_CSM)
@@ -21326,6 +21346,7 @@ int RTCC::PMMXFR(int id, void *data)
 				}
 				inp->ConfigurationChangeIndicator = rtetab->ConfigurationChangeIndicator;
 				inp->EndConfiguration = rtetab->EndConfiguration;
+				inp->DockingAngle = rtetab->DockingAngle;
 				
 				BurnParm75 = rtetab->DV_XDV.x;
 				BurnParm76 = rtetab->DV_XDV.y;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -2307,6 +2307,7 @@ struct RTEDigitalSolutionTable
 	bool HeadsUpDownIndicator = false;
 	int ConfigurationChangeIndicator = 0;
 	int EndConfiguration = 0;
+	double DockingAngle = 0.0;
 };
 
 struct ELVCTRInputTable
@@ -2497,6 +2498,8 @@ public:
 		EphemerisData sv_Ins;
 		//LM mass at insertion
 		double m1;
+		//Error codes. 0 = no error, 2 = weight is below minimum allowed
+		int ErrorCode;
 	};
 
 	void LunarAscentProcessor(const LunarAscentProcessorInputs &in, LunarAscentProcessorOutputs &out);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LDPP.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/LDPP.cpp
@@ -1469,7 +1469,7 @@ void LDPP::CNODE(EphemerisData sv_A, EphemerisData sv_P, double &t_m, VECTOR3 &d
 		{
 			return;
 		}
-		sv_P = PositionMatch(sv_P, sv_A, mu);
+		sv_P = PositionMatch(sv_A, sv_P, mu);
 		GMT_CN = sv_A.GMT;
 	} while (ICT <= 3);
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCCSystemParameters.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCCSystemParameters.h
@@ -408,6 +408,8 @@ struct RTCCSystemParameters
 		MCVTB2 = 1.0;
 		MCVDTM = 2.0;
 		MCCRAM = 0.5;
+		MCVCWT = 19246.4*0.45359237;
+		MCVLWT = 3828.0*0.45359237;
 
 		MCTCT1 = 196.6 * 4.4482216152605;
 		MCTCT2 = 393.2 * 4.4482216152605;
@@ -1008,6 +1010,10 @@ struct RTCCSystemParameters
 	double MCVDTM;
 	//Converts RHO*AREA/MASS to .5 RHO*AREA/MASS in Er. (eventually in Er at least...)
 	double MCCRAM;
+	//CSM limiting weight for fuel exhaustion test (0.8 of dry weight)
+	double MCVCWT;
+	//LM limiting weight for fuel exhaustion test
+	double MCVLWT;
 
 	//Thrust of CSM RCS+X (2 quads)
 	double MCTCT1;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCC_EMSMISS.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCC_EMSMISS.cpp
@@ -630,8 +630,16 @@ void RTCC_EMSMISS::WriteEphemerisHeaders()
 			EphemerisTableIndicatorList[ii]->Header.NumVec = EphemerisTableIndicatorList[ii]->table.size();
 			EphemerisTableIndicatorList[ii]->Header.Offset = 0;
 			EphemerisTableIndicatorList[ii]->Header.Status = 0;
-			EphemerisTableIndicatorList[ii]->Header.TL = EphemerisTableIndicatorList[ii]->table.front().GMT;
-			EphemerisTableIndicatorList[ii]->Header.TR = EphemerisTableIndicatorList[ii]->table.back().GMT;
+			if (EphemerisTableIndicatorList[ii]->table.size() == 0U)
+			{
+				EphemerisTableIndicatorList[ii]->Header.TL = 0.0;
+				EphemerisTableIndicatorList[ii]->Header.TR = 0.0;
+			}
+			else
+			{
+				EphemerisTableIndicatorList[ii]->Header.TL = EphemerisTableIndicatorList[ii]->table.front().GMT;
+				EphemerisTableIndicatorList[ii]->Header.TR = EphemerisTableIndicatorList[ii]->table.back().GMT;
+			}
 			EphemerisTableIndicatorList[ii]->Header.TUP = mpt->CommonBlock.TUP;
 			EphemerisTableIndicatorList[ii]->Header.VEH = intab->VehicleCode;
 		}
@@ -1021,7 +1029,7 @@ void RTCC_EMSMISS::CallAscentIntegrator()
 		{
 			gmt_sv = state.StateVector.GMT;
 		}
-		if (pRTCC->ELFECH(gmt_sv, RTCC_MPT_CSM, SV))
+		if (pRTCC->EMSFFV(gmt_sv, RTCC_MPT_CSM, SV))
 		{
 			nierror = 1;
 			return;
@@ -1034,6 +1042,5 @@ void RTCC_EMSMISS::CallAscentIntegrator()
 	integin.v_LH = mpt->mantable[i].dV_LVLH.z;
 	integin.v_LV = mpt->mantable[i].dV_LVLH.x;
 
-	nierror = 0;
-	pRTCC->PMMLAI(integin, AuxTableIndicator, &tempephemtable);
+	nierror = pRTCC->PMMLAI(integin, AuxTableIndicator, &tempephemtable);
 }


### PR DESCRIPTION
-A few more checks on ephemeris tables being empty when their left and right limit are written
-Uninitialized memory was used for the docking angle when putting a RTE maneuver on the MPT
-Lunar ascent integrator (when used for ephemeris generation) can use CSM state vector beyond ephemeris limits (useful for prelaunch mission planning)
-Lunar ascent integrator now has an error check on fuel exhaustion (but not processed correctly yet during ephemeris generation)
-Lunar ascent integrator previously returned the negative of the APS fuel used (bad LM mass after insertion)
-Fix LDPP plane change calculations

Suggested test procedure for the two main lunar ascent bugs:

Propellant used for ascent: Put the ascent maneuver on the MPT in any scenario, the MPT display should show a wrong, large DV remaining due to using a negative amount of propellant. Checkout Monitor after ascent shows a wrong LM mass, higher than before liftoff. The PR fixes this.

Wrong CSM state vector: This one is more difficult to test. It has to be a scenario in Earth orbit or before launch. All CSM and LM maneuvers before lunar ascent on the MPT. Then the ascent maneuver should use a bad CSM state vector and show a weird DV remaining, some DMT values might also be wrong. Potentially it runs into a newly added error check and an online monitor message is written. This behavior is also fixed by the PR.