### PR TITLE
Improve connecting/disconnecting of Saturn/launchpad umbilical classes in various cases like pad aborts or vessels being deleted

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/IUUmbilical.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/IUUmbilical.cpp
@@ -31,34 +31,29 @@ IUUmbilical::IUUmbilical(IUUmbilicalInterface *ml)
 {
 	IuUmb = ml;
 	iu = NULL;
-	IUUmbilicalConnected = false;
 }
 
 IUUmbilical::~IUUmbilical()
 {
+	Disconnect();
 }
 
 void IUUmbilical::Connect(IU *iu)
 {
 	if (iu)
 	{
-		this->iu = iu;
-		iu->ConnectUmbilical(this);
-		IUUmbilicalConnected = true;
+		iu->IuUmb = this;
 	}
+	this->iu = iu;
 }
 
 void IUUmbilical::Disconnect()
 {
-	if (!IUUmbilicalConnected) return;
-
-	iu->DisconnectUmbilical();
-	IUUmbilicalConnected = false;
-}
-
-void IUUmbilical::AbortDisconnect()
-{
-	IUUmbilicalConnected = false;
+	if (iu)
+	{
+		iu->IuUmb = NULL;
+		iu = NULL;
+	}
 }
 
 bool IUUmbilical::ESEGetCommandVehicleLiftoffIndicationInhibit()
@@ -153,161 +148,161 @@ bool IUUmbilical::ESEGetEDSLVCutoffSimulate(int n)
 
 void IUUmbilical::SetEDSLiftoffEnableA()
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetEDS()->SetEDSLiftoffEnableA();
 }
 
 void IUUmbilical::SetEDSLiftoffEnableB()
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetEDS()->SetEDSLiftoffEnableB();
 }
 
 void IUUmbilical::EDSLiftoffEnableReset()
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetEDS()->LiftoffEnableReset();
 }
 
 void IUUmbilical::SwitchFCCPowerOn()
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetControlDistributor()->SetFCCPower(true);
 }
 
 void IUUmbilical::SwitchFCCPowerOff()
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetControlDistributor()->SetFCCPower(false);
 }
 
 void IUUmbilical::SwitchQBallPowerOn()
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetControlDistributor()->SetQBallPower(true);
 }
 
 void IUUmbilical::SwitchQBallPowerOff()
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetControlDistributor()->SetQBallPower(false);
 }
 
 bool IUUmbilical::AllSIEnginesRunning()
 {
-	if (!IUUmbilicalConnected) return false;
+	if (!iu) return false;
 
 	return iu->GetEDS()->GetAllSIEnginesRunning();
 }
 
 bool IUUmbilical::IsEDSUnsafeA()
 {
-	if (!IUUmbilicalConnected) return false;
+	if (!iu) return false;
 
 	return iu->GetEDS()->IsEDSUnsafeA();
 }
 
 bool IUUmbilical::IsEDSUnsafeB()
 {
-	if (!IUUmbilicalConnected) return false;
+	if (!iu) return false;
 
 	return iu->GetEDS()->IsEDSUnsafeB();
 }
 
 bool IUUmbilical::GetEDSSCCutoff1()
 {
-	if (!IUUmbilicalConnected) return false;
+	if (!iu) return false;
 
 	return iu->GetEDS()->GetLVEnginesCutoffFromSC1();
 }
 
 bool IUUmbilical::GetEDSSCCutoff2()
 {
-	if (!IUUmbilicalConnected) return false;
+	if (!iu) return false;
 
 	return iu->GetEDS()->GetLVEnginesCutoffFromSC2();
 }
 
 bool IUUmbilical::GetEDSSCCutoff3()
 {
-	if (!IUUmbilicalConnected) return false;
+	if (!iu) return false;
 
 	return iu->GetEDS()->GetLVEnginesCutoffFromSC3();
 }
 
 bool IUUmbilical::GetEDSAutoAbortBus()
 {
-	if (!IUUmbilicalConnected) return false;
+	if (!iu) return false;
 
 	return iu->GetEDS()->GetAutoAbort();
 }
 
 bool IUUmbilical::GetEDSExcessiveRollRateIndication()
 {
-	if (!IUUmbilicalConnected) return false;
+	if (!iu) return false;
 
 	return iu->GetEDS()->GetExcessiveRollRateIndication();
 }
 
 bool IUUmbilical::GetEDSExcessivePitchYawRateIndication()
 {
-	if (!IUUmbilicalConnected) return false;
+	if (!iu) return false;
 
 	return iu->GetEDS()->GetExcessivePitchYawRateIndication();
 }
 
 bool IUUmbilical::GetLVDCOutputRegisterDiscrete(int bit)
 {
-	if (!IUUmbilicalConnected) return false;
+	if (!iu) return false;
 
 	return iu->GetLVDA()->GetOutputRegisterBit(bit);
 }
 
 bool IUUmbilical::FCCPowerIsOn()
 {
-	if (!IUUmbilicalConnected) return false;
+	if (!iu) return false;
 
 	return iu->GetControlDistributor()->GetFCCPowerOn();
 }
 
 void IUUmbilical::SetControlSignalProcessorPower(bool set)
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetControlDistributor()->SetControlSignalProcessorPowerOn(set);
 }
 
 void IUUmbilical::EDSGroupNo1Reset()
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetControlDistributor()->ResetBus1();
 }
 
 void IUUmbilical::EDSGroupNo2Reset()
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetControlDistributor()->ResetBus2();
 }
 
 void IUUmbilical::SwitchSelector(int stage, int channel)
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetControlDistributor()->SwitchSelector(stage, channel);
 }
 
 void IUUmbilical::LVDCPrepareToLaunch()
 {
-	if (!IUUmbilicalConnected) return;
+	if (!iu) return;
 
 	iu->GetLVDA()->PrepareToLaunch();
 }

--- a/Orbitersdk/samples/ProjectApollo/src_launch/IUUmbilical.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/IUUmbilical.h
@@ -33,12 +33,8 @@ public:
 	IUUmbilical(IUUmbilicalInterface *ml);
 	~IUUmbilical();
 
-	bool IsIUUmbilicalConnected() { return IUUmbilicalConnected; }
-
 	void Connect(IU* iu);
 	void Disconnect();
-	//Called by IU during a pad abort. Technically doesn't disconnect IU umbilical
-	virtual void AbortDisconnect();
 
 	//From ML to SLV
 	void SetEDSLiftoffEnableA();
@@ -84,9 +80,8 @@ public:
 	virtual bool ESEGetQBallSimulateCmd();
 	virtual bool ESEGetEDSAutoAbortSimulate(int n);
 	virtual bool ESEGetEDSLVCutoffSimulate(int n);
-protected:
-	IU* iu;
-	IUUmbilicalInterface* IuUmb;
 
-	bool IUUmbilicalConnected;
+	IU* iu;
+protected:
+	IUUmbilicalInterface* IuUmb;
 };

--- a/Orbitersdk/samples/ProjectApollo/src_launch/SCMUmbilical.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/SCMUmbilical.cpp
@@ -34,43 +34,44 @@ SCMUmbilical::SCMUmbilical(TailUmbilicalInterface *ml) : TailUmbilical(ml)
 
 SCMUmbilical::~SCMUmbilical()
 {
+	Disconnect();
 }
 
 void SCMUmbilical::Connect(SIBSystems *sib)
 {
 	if (sib)
 	{
-		this->sib = sib;
-		sib->ConnectUmbilical(this);
-		UmbilicalConnected = true;
+		sib->SCMUmb = this;
 	}
+	this->sib = sib;
 }
 
 void SCMUmbilical::Disconnect()
 {
-	if (!UmbilicalConnected) return;
-
-	sib->DisconnectUmbilical();
-	UmbilicalConnected = false;
+	if (sib)
+	{
+		sib->SCMUmb = NULL;
+		sib = NULL;
+	}
 }
 
 bool SCMUmbilical::SIStageLogicCutoff()
 {
-	if (!UmbilicalConnected) return false;
+	if (!sib) return false;
 
 	return sib->GetEngineStop();
 }
 
 void SCMUmbilical::SetEngineStart(int eng)
 {
-	if (!UmbilicalConnected) return;
+	if (!sib) return;
 
 	sib->SetEngineStart(eng);
 }
 
 void SCMUmbilical::SIGSECutoff(bool cut)
 {
-	if (!UmbilicalConnected) return;
+	if (!sib) return;
 
 	sib->GSEEnginesCutoff(cut);
 }

--- a/Orbitersdk/samples/ProjectApollo/src_launch/SCMUmbilical.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/SCMUmbilical.h
@@ -34,8 +34,6 @@ public:
 	SCMUmbilical(TailUmbilicalInterface *ml);
 	~SCMUmbilical();
 
-	bool IsUmbilicalConnected() { return UmbilicalConnected; }
-
 	void Connect(SIBSystems* sic);
 	void Disconnect();
 
@@ -44,6 +42,6 @@ public:
 	void SetEngineStart(int eng);
 	void SIGSECutoff(bool cut);
 
-protected:
 	SIBSystems* sib;
+protected:
 };

--- a/Orbitersdk/samples/ProjectApollo/src_launch/TSMUmbilical.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/TSMUmbilical.cpp
@@ -34,43 +34,44 @@ TSMUmbilical::TSMUmbilical(TailUmbilicalInterface *ml) : TailUmbilical(ml)
 
 TSMUmbilical::~TSMUmbilical()
 {
+	Disconnect();
 }
 
 void TSMUmbilical::Connect(SICSystems *sic)
 {
 	if (sic)
 	{
-		this->sic = sic;
-		sic->ConnectUmbilical(this);
-		UmbilicalConnected = true;
+		sic->TSMUmb = this;
 	}
+	this->sic = sic;
 }
 
 void TSMUmbilical::Disconnect()
 {
-	if (!UmbilicalConnected) return;
-
-	sic->DisconnectUmbilical();
-	UmbilicalConnected = false;
+	if (sic)
+	{
+		sic->TSMUmb = NULL;
+		sic = NULL;
+	}
 }
 
 bool TSMUmbilical::SIStageLogicCutoff()
 {
-	if (!UmbilicalConnected) return false;
+	if (!sic) return false;
 
 	return sic->GetEngineStop();
 }
 
 void TSMUmbilical::SetEngineStart(int eng)
 {
-	if (!UmbilicalConnected) return;
+	if (!sic) return;
 
 	sic->SetEngineStart(eng);
 }
 
 void TSMUmbilical::SIGSECutoff(bool cut)
 {
-	if (!UmbilicalConnected) return;
+	if (!sic) return;
 
 	sic->GSEEnginesCutoff(cut);
 }

--- a/Orbitersdk/samples/ProjectApollo/src_launch/TSMUmbilical.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/TSMUmbilical.h
@@ -34,8 +34,6 @@ public:
 	TSMUmbilical(TailUmbilicalInterface *ml);
 	~TSMUmbilical();
 
-	bool IsUmbilicalConnected() { return UmbilicalConnected; }
-
 	void Connect(SICSystems* sic);
 	void Disconnect();
 
@@ -43,6 +41,8 @@ public:
 	bool SIStageLogicCutoff();
 	void SetEngineStart(int eng);
 	void SIGSECutoff(bool cut);
-protected:
+
 	SICSystems* sic;
+protected:
+
 };

--- a/Orbitersdk/samples/ProjectApollo/src_launch/TailUmbilical.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/TailUmbilical.cpp
@@ -27,17 +27,12 @@ See http://nassp.sourceforge.net/license/ for more details.
 
 TailUmbilical::TailUmbilical(TailUmbilicalInterface *ml) : TailUmb(ml)
 {
-	UmbilicalConnected = false;
+
 }
 
 TailUmbilical::~TailUmbilical()
 {
 
-}
-
-void TailUmbilical::AbortDisconnect()
-{
-	UmbilicalConnected = false;
 }
 
 bool TailUmbilical::ESEGetSIThrustOKSimulate(int eng, int n)

--- a/Orbitersdk/samples/ProjectApollo/src_launch/TailUmbilical.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/TailUmbilical.h
@@ -34,9 +34,6 @@ public:
 
 	virtual void Disconnect() = 0;
 
-	//Called by IU during a pad abort. Technically doesn't disconnect IU umbilical
-	virtual void AbortDisconnect();
-
 	//From SLV to ML
 	virtual bool ESEGetSIThrustOKSimulate(int eng, int n);
 
@@ -45,6 +42,5 @@ public:
 	virtual void SetEngineStart(int eng) = 0;
 	virtual void SIGSECutoff(bool cut) = 0;
 protected:
-	bool UmbilicalConnected;
 	TailUmbilicalInterface* TailUmb;
 };

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/iu.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/iu.cpp
@@ -59,10 +59,7 @@ ControlSignalProcessor(this)
 
 IU::~IU()
 {
-	if (IuUmb)
-	{
-		IuUmb->AbortDisconnect();
-	}
+	DisconnectUmbilical();
 }
 
 void IU::SetMissionInfo(bool crewed, bool sccontpowered)
@@ -253,19 +250,18 @@ bool IU::DCSUplink(int type, void *upl)
 
 bool IU::IsUmbilicalConnected()
 {
-	if (IuUmb && IuUmb->IsIUUmbilicalConnected()) return true;
+	if (IuUmb) return true;
 
 	return false;
 }
 
-void IU::ConnectUmbilical(IUUmbilical *umb)
-{
-	IuUmb = umb;
-}
-
 void IU::DisconnectUmbilical()
 {
-	IuUmb = NULL;
+	if (IuUmb)
+	{
+		IuUmb->iu = NULL;
+		IuUmb = NULL;
+	}
 }
 
 void IU::DisconnectIU()

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/iu.h
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/iu.h
@@ -282,9 +282,6 @@ public:
 	bool GetSCControlPoweredFlight() { return SCControlPoweredFlight; }
 	VECTOR3 GetTheodoliteAlignment(double azimuth);
 
-	virtual void ConnectUmbilical(IUUmbilical *umb);
-	virtual void DisconnectUmbilical();
-
 	virtual bool DCSUplink(int type, void *upl);
 
 	IUToCSMCommandConnector* GetCommandConnector() { return &commandConnector; }
@@ -324,7 +321,9 @@ public:
 	virtual bool ESEGetSICOutboardEnginesCantInhibit() { return false; }
 	virtual bool ESEGetSICOutboardEnginesCantSimulate() { return false; }
 
+	IUUmbilical *IuUmb;
 protected:
+	void DisconnectUmbilical();
 
 	int State;
 
@@ -363,8 +362,6 @@ protected:
 	IUAuxiliaryPowerDistributor2 AuxiliaryPowerDistributor2;
 	//601A24
 	IUControlSignalProcessor ControlSignalProcessor;
-
-	IUUmbilical *IuUmb;
 };
 
 class IU1B :public IU

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/s1bsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/s1bsystems.cpp
@@ -310,6 +310,11 @@ SIBSystems::SIBSystems(VESSEL *v, THRUSTER_HANDLE *h1, PROPELLANT_HANDLE &h1prop
 	SCMUmb = NULL;
 }
 
+SIBSystems::~SIBSystems()
+{
+	DisconnectUmbilical();
+}
+
 void SIBSystems::SaveState(FILEHANDLE scn) {
 	oapiWriteLine(scn, SISYSTEMS_START_STRING);
 
@@ -801,11 +806,6 @@ void SIBSystems::SwitchSelector(int channel)
 	}
 }
 
-void SIBSystems::ConnectUmbilical(SCMUmbilical *umb)
-{
-	SCMUmb = umb;
-}
-
 void SIBSystems::DisconnectUmbilical()
 {
 	SCMUmb = NULL;
@@ -813,7 +813,7 @@ void SIBSystems::DisconnectUmbilical()
 
 bool SIBSystems::IsUmbilicalConnected()
 {
-	if (SCMUmb && SCMUmb->IsUmbilicalConnected()) return true;
+	if (SCMUmb) return true;
 
 	return false;
 }

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/s1bsystems.h
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/s1bsystems.h
@@ -78,6 +78,7 @@ class SIBSystems
 {
 public:
 	SIBSystems(VESSEL *v, THRUSTER_HANDLE *h1, PROPELLANT_HANDLE &h1prop, Pyro &SIB_SIVB_Sep, Sound &LaunchS, Sound &SShutS);
+	~SIBSystems();
 	void Timestep(double misst, double simdt);
 	void SaveState(FILEHANDLE scn);
 	void LoadState(FILEHANDLE scn);
@@ -108,12 +109,12 @@ public:
 	virtual bool GetEngineStop();
 	bool FireRetroRockets();
 
-	virtual void ConnectUmbilical(SCMUmbilical *umb);
-	virtual void DisconnectUmbilical();
-	bool IsUmbilicalConnected();
+	SCMUmbilical *SCMUmb;
 protected:
 	double GetSumThrust();
 	bool ESEGetSIBThrustOKSimulate(int eng, int n);
+	void DisconnectUmbilical();
+	bool IsUmbilicalConnected();
 
 	VESSEL *vessel;
 	PROPELLANT_HANDLE &main_propellant;
@@ -200,6 +201,4 @@ protected:
 	bool ThrustOK[24];
 
 	bool OutboardEnginesCutoffSignal;
-
-	SCMUmbilical *SCMUmb;
 };

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/s1csystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/s1csystems.cpp
@@ -295,10 +295,7 @@ SICSystems::SICSystems(VESSEL *v, THRUSTER_HANDLE *f1, PROPELLANT_HANDLE &f1prop
 
 SICSystems::~SICSystems()
 {
-	if (TSMUmb)
-	{
-		TSMUmb->AbortDisconnect();
-	}
+	DisconnectUmbilical();
 }
 
 void SICSystems::SaveState(FILEHANDLE scn) {
@@ -600,19 +597,17 @@ bool SICSystems::GetEngineStop()
 	return false;
 }
 
-void SICSystems::ConnectUmbilical(TSMUmbilical *umb)
-{
-	TSMUmb = umb;
-}
-
 void SICSystems::DisconnectUmbilical()
 {
-	TSMUmb = NULL;
+	if (TSMUmb)
+	{
+		TSMUmb = NULL;
+	}
 }
 
 bool SICSystems::IsUmbilicalConnected()
 {
-	if (TSMUmb && TSMUmb->IsUmbilicalConnected()) return true;
+	if (TSMUmb) return true;
 
 	return false;
 }

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/s1csystems.h
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/s1csystems.h
@@ -106,14 +106,13 @@ public:
 
 	virtual bool GetEngineStop();
 
-	virtual void ConnectUmbilical(TSMUmbilical *umb);
-	virtual void DisconnectUmbilical();
-	bool IsUmbilicalConnected();
+	TSMUmbilical *TSMUmb;
 protected:
-
 	bool TripleVoting(bool vote1, bool vote2, bool vote3);
 	double GetSumThrust();
 	bool ESEGetSICThrustOKSimulate(int eng, int n);
+	void DisconnectUmbilical();
+	bool IsUmbilicalConnected();
 
 	VESSEL *vessel;
 	PROPELLANT_HANDLE &main_propellant;
@@ -140,6 +139,4 @@ protected:
 	bool PointLevelSensorArmed;
 
 	bool ThrustOK[15];
-
-	TSMUmbilical *TSMUmb;
 };


### PR DESCRIPTION
This PR changes the connecting/disconnecting behavior of the umbilical classes for the IU, S-IB and S-IC to work more like our general connector class.

The reason for this change is an (apparent) different deletion order of vessels in Open Orbiter which causes a crash of the simulation on exiting it. This PR also deletes some special code handling pad aborts where the disconnection of the umbilical isn't caused as usual by a call of the Disconnect function. With this change the order of deletion of the umbilical/systems classes and the source of the disconnect should not matter at all.

Testing for this PR should all be possible with scenarios shortly before launch. If the Saturn launches normally then the umbilical connect (on scenario load) works correctly. Disconnects can be tested with normal launches and pad aborts. There should be no crash on scenario exit. There wasn't any crash in the Orbiter Beta anyway. This PR is mostly for Open Orbiter and a good cleanup of some bad workarounds.

This change is also mostly temporary as the WIP branch for Saturn V docked stages (#1382) actually changes the umbilicals to use the connector class.