### PR TITLE
Further fixes for umbilical disconnect (causing CTD when closing an Orbiter sim session)

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_saturn/s1bsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/s1bsystems.cpp
@@ -808,7 +808,11 @@ void SIBSystems::SwitchSelector(int channel)
 
 void SIBSystems::DisconnectUmbilical()
 {
-	SCMUmb = NULL;
+	if (SCMUmb)
+	{
+		SCMUmb->sib = NULL;
+		SCMUmb = NULL;
+	}
 }
 
 bool SIBSystems::IsUmbilicalConnected()

--- a/Orbitersdk/samples/ProjectApollo/src_saturn/s1csystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_saturn/s1csystems.cpp
@@ -601,6 +601,7 @@ void SICSystems::DisconnectUmbilical()
 {
 	if (TSMUmb)
 	{
+		TSMUmb->sic = NULL;
 		TSMUmb = NULL;
 	}
 }


### PR DESCRIPTION
Testing involves any Saturn V scenario before launch. Random crashes can happen in TSMUmbilical::Disconnect because the SICSystems "sic" has already been deleted but the pointer has not been nulled, so the TSMUmbilical::Disconnect code will try to do "sic->TSMUmb = NULL;", which can cause an access violation.