### PR TITLE
Add vector panel summary entry capability; fix a few AGOP inputs

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -26763,7 +26763,7 @@ bool RTCC::GMGMED(char *str)
 	}
 	else if (medtype == 'S')
 	{
-		err = BMQDCMED(code, MEDSequence);
+		BMQDCMED(code, MEDSequence, err, param);
 	}
 	else if (medtype == 'U')
 	{
@@ -35305,14 +35305,21 @@ void RTCC::CMMRFMAT(int L, int id, int addr)
 	block->UpdateNo++;
 }
 
-int RTCC::BMQDCMED(std::string med, std::vector<std::string> data)
+void RTCC::BMQDCMED(std::string med, std::vector<std::string> data, int &err, unsigned &param)
 {
+	std::vector<rtcc::MEDProcessingOptions> opt;
+	rtcc::MEDProcessingOutput out;
+
+	err = 0;
+	param = 0;
+
 	//LM Position Vector Table (Should be in BMLMED instead)
 	if (med == "72")
 	{
 		if (data.size() != 2)
 		{
-			return 1;
+			err = 1;
+			return;
 		}
 		int id1;
 		if (data[0] == "BEST")
@@ -35333,7 +35340,8 @@ int RTCC::BMQDCMED(std::string med, std::vector<std::string> data)
 		}
 		else
 		{
-			return 2;
+			err = 2;
+			return;
 		}
 		int id2;
 		if (data[1] == "PNGCS")
@@ -35350,33 +35358,113 @@ int RTCC::BMQDCMED(std::string med, std::vector<std::string> data)
 		}
 		else
 		{
-			return 2;
+			err = 2;
+			return;
 		}
 		BZLAND.lat[id1] = BZLAND.lat[id2];
 		BZLAND.lng[id1] = BZLAND.lng[id2];
 		BZLAND.rad[id1] = BZLAND.rad[id2];
+	}
+	//Specify vector comparison parameter
+	else if (med == "80")
+	{
+
+	}
+	//Vector Panel Summary Entry
+	else if (med == "84")
+	{
+		if (data.size() < 10)
+		{
+			err = 1;
+			return;
+		}
+
+		//Item 1: Vehicle
+		rtcc::AddTextMEDItem(opt, 1, { "CSM", "LEM" });
+		//Item 2: X
+		rtcc::AddDoubleMEDItem(opt, 1, true, true, SystemParameters.MCCMCU, -60.0, 60.0);
+		//Item 3: Y
+		rtcc::AddDoubleMEDItem(opt, 1, true, true, SystemParameters.MCCMCU, -60.0, 60.0);
+		//Item 4: Z
+		rtcc::AddDoubleMEDItem(opt, 1, true, true, SystemParameters.MCCMCU, -60.0, 60.0);
+		//Item 5: XDOT
+		rtcc::AddDoubleMEDItem(opt, 1, true, true, SystemParameters.MCCMCU / 3600.0, -60.0, 60.0);
+		//Item 6: YDOT
+		rtcc::AddDoubleMEDItem(opt, 1, true, true, SystemParameters.MCCMCU / 3600.0, -60.0, 60.0);
+		//Item 7: ZDOT
+		rtcc::AddDoubleMEDItem(opt, 1, true, true, SystemParameters.MCCMCU / 3600.0, -60.0, 60.0);
+		//Item 8: GMT
+		rtcc::AddTimeMEDItem(opt, 1, true, false);
+		//Item 9: Vector ID
+		rtcc::AddTextMEDItem(opt, 1, {data[8]});
+		//Item 10: Reference
+		rtcc::AddTextMEDItem(opt, 1, {"ECI", "ECT", "MCI", "MCT", "EMP"});
+		//Item 11: Lunar Surface Indicator
+		rtcc::AddTextMEDItem(opt, 2, { "", "S" }, 0);
+
+		err = rtcc::GenericMEDProcessing(opt, data, out);
+		if (err)
+		{
+			param = out.errorItem;
+			return;
+		}
+		StateVectorTableEntry sv;
+		EphemerisData2 svtemp, svtemp2;
+
+		svtemp.R = _V(out.Values[1].d, out.Values[2].d, out.Values[3].d);
+		svtemp.V = _V(out.Values[4].d, out.Values[5].d, out.Values[6].d);
+		svtemp.GMT = out.Values[7].d;
+
+		sv.VectorCode = data[8];
+		if (data[8].size() != 7U)
+		{
+			err = 1;
+			param = 9;
+			return;
+		}
+		sv.ID = atoi(data[8].substr(4, 3).c_str());
+		if (out.Values[9].i <= 1)
+		{
+			sv.Vector.RBI = BODY_EARTH;
+		}
+		else
+		{
+			sv.Vector.RBI = BODY_MOON;
+		}
+		sv.LandingSiteIndicator = (out.Values[10].i == 0 ? false : true);
+		//Convert
+		if (ELVCNV(svtemp, out.Values[9].i, sv.Vector.RBI == BODY_EARTH ? RTCC_COORDINATES_ECI : RTCC_COORDINATES_MCI, svtemp2))
+		{
+			err = 2;
+			param = 10;
+			return;
+		}
+		sv.Vector.R = svtemp2.R;
+		sv.Vector.V = svtemp2.V;
+		sv.Vector.GMT = svtemp2.GMT;
+
+		BMSVPS(3, sv);
 	}
 	//Simulate vector control and DC PBI's
 	else if (med == "99")
 	{
 		if (data.size() != 1)
 		{
-			return 1;
+			err = 1;
+			return;
 		}
 
 		int code;
 		if (sscanf(data[0].c_str(), "%d", &code) != 1)
 		{
-			return 2;
+			err = 2;
+			return;
 		}
 		if (code >= 300 && code <= 335)
 		{
 			BMSVPS(0, code);
 		}
-
-		return 0;
 	}
-	return 0;
 }
 
 int RTCC::BMSVPSVectorFetch(const std::string &vecid, EphemerisData &sv_out)
@@ -35422,6 +35510,99 @@ int RTCC::GetStateVectorTableEntry(std::string VectorType, int mpt)
 		val += 6;
 	}
 	return val;
+}
+
+void RTCC::BMSVPS(int queid, const StateVectorTableEntry &sv)
+{
+	// S84 MED?
+	if (queid != 3)
+	{
+		//Error 1: An unrecognizable queue ID was detected
+		RTCCONLINEMON.IntBuffer[0] = 1;
+		BMGPRIME("BMSVPS", 24);
+		return;
+	}
+	if (sv.VectorCode.size() != 7)
+	{
+		RTCCONLINEMON.IntBuffer[0] = 9;
+		BMGPRIME("BMSVPS", 24);
+		return;
+	}
+	// Useable or evaluation
+	bool eval;
+	StateVectorTableEntry *tab;
+	if (sv.VectorCode[3] == 'E')
+	{
+		tab = &BZEVLVEC.data[0];
+		eval = true;
+	}
+	else if (sv.VectorCode[3] == 'U')
+	{
+		tab = &BZUSEVEC.data[0];
+		eval = false;
+	}
+	else
+	{
+		RTCCONLINEMON.IntBuffer[0] = 9;
+		BMGPRIME("BMSVPS", 24);
+		return;
+	}
+	// CSM vs LM
+	int offset;
+	if (sv.VectorCode[1] == 'C')
+	{
+		offset = 0;
+	}
+	else if (sv.VectorCode[1] == 'L')
+	{
+		if (eval)
+		{
+			offset = 4;
+		}
+		else
+		{
+			offset = 6;
+		}
+	}
+	else
+	{
+		RTCCONLINEMON.IntBuffer[0] = 9;
+		BMGPRIME("BMSVPS", 24);
+		return;
+	}
+	// CMC, LGC, AGS or IU
+	int comp;
+	if (sv.VectorCode[0] == 'C')
+	{
+		comp = 0;
+	}
+	else if (sv.VectorCode[0] == 'L')
+	{
+		comp = 1;
+	}
+	else if (sv.VectorCode[0] == 'A')
+	{
+		comp = 2;
+	}
+	else if (sv.VectorCode[0] == 'I')
+	{
+		comp = 3;
+	}
+	else
+	{
+		RTCCONLINEMON.IntBuffer[0] = 9;
+		BMGPRIME("BMSVPS", 24);
+		return;
+	}
+	//High-speed
+	if (sv.VectorCode[2] != 'H')
+	{
+		RTCCONLINEMON.IntBuffer[0] = 9;
+		BMGPRIME("BMSVPS", 24);
+		return;
+	}
+	//Store
+	tab[offset + comp] = sv;
 }
 
 void RTCC::BMSVPS(int queid, int PBIID)

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -2779,10 +2779,11 @@ public:
 	void BMGPRIME(std::string source, int n);
 	void BMGPRIME(std::string source, std::vector<std::string> message);
 	//D.C. MED Decoder
-	int BMQDCMED(std::string med, std::vector<std::string> data);
+	void BMQDCMED(std::string med, std::vector<std::string> data, int &err, unsigned &param);
 	//Vector Comparison Control
 	void BMSVEC();
 	//Vector Panel Summary Control
+	void BMSVPS(int queid, const StateVectorTableEntry &sv);
 	void BMSVPS(int queid, int PBIID);
 	int BMSVPSVectorFetch(const std::string &vecid, EphemerisData &sv_out);
 	int GetStateVectorTableEntry(std::string VectorType, int mpt);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -5291,7 +5291,7 @@ int ARCore::subThread()
 		in.Option = GC->AGOP_Option;
 		in.Mode = GC->AGOP_Mode;
 		in.AdditionalOption = GC->AGOP_AdditionalOption;
-		in.DeltaT = GC->AGOP_TimeStep;
+		in.DeltaT = GC->AGOP_TimeStep*60.0;
 
 		bool statevectorrequired = true;
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -1739,7 +1739,7 @@ void ApolloRTCCMFD::menuSetAGOPInput()
 		{
 			GenericIntInput(&GC->AGOP_Stars[0], "Enter star ID in decimal format (1-400):", NULL, 1, 400);
 		}
-		else if (GC->AGOP_Option == 6)
+		else if (GC->AGOP_Option == 4 || GC->AGOP_Option == 6)
 		{
 			GC->AGOP_HeadsUp = !GC->AGOP_HeadsUp;
 		}
@@ -10207,6 +10207,11 @@ void ApolloRTCCMFD::SetMEDInputPageP14()
 	SetMEDInputPage("P14");
 }
 
+void ApolloRTCCMFD::SetMEDInputPageS84()
+{
+	SetMEDInputPage("S84");
+}
+
 void AddMEDInputTitle(MEDInputPage &MEDInputData, std::string MEDCode, std::string Title)
 {
 	MEDInputData.MEDCode = MEDCode;
@@ -10358,8 +10363,11 @@ void ApolloRTCCMFD::SetMEDInputPage(std::string med)
 			AddMEDInput(page.table, "YDOT:", "Velocity in Earth radii per hour:", "0.0", "ER/hr");
 			AddMEDInput(page.table, "ZDOT:", "Velocity in Earth radii per hour:", "0.0", "ER/hr");
 			AddMEDInput(page.table, "GMT:", "GMT of vector (format HHH:MM:SS.TH):", "000:00:00.00", "GMT");
+			AddMEDInput(page.table, "ID:", "Vector ID (any slot in vector panel)", "ILHE001", "");
 			AddMEDInput(page.table, "Reference:", "Coordinate system of vector (ECI, ECT, MCI, MCT or EMP)", "ECI", "");
 			AddMEDInput(page.table, "Lunar Surf.:", "Lunar Surface Indicator (S if vector is on the surface of Moon):", "", "");
+
+			page.display = 97;
 		}
 
 		ActiveMEDInputPage = GC->MEDInputData.size();

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -852,6 +852,7 @@ public:
 	void SetMEDInputPageM75();
 	void SetMEDInputPageP13();
 	void SetMEDInputPageP14();
+	void SetMEDInputPageS84();
 	void SetMEDInputPage(std::string med);
 	void menuMEDInputCalc();
 	void menuInputMEDData();

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -9445,6 +9445,14 @@ void ApolloRTCCMFD::AGOPDisplayOption4(oapi::Sketchpad*skp)
 		skp->Text(CW * 16, 9 * H / 22, Buffer, strlen(Buffer));
 	}
 
+	//Landmark
+	sprintf(Buffer, "Lat: %.3lf°", GC->AGOP_Lat*DEG);
+	skp->Text(CW * 2, 11 * H / 22, Buffer, strlen(Buffer));
+	sprintf(Buffer, "Lng: %.3lf°", GC->AGOP_Lng*DEG);
+	skp->Text(CW * 2, 12 * H / 22, Buffer, strlen(Buffer));
+	sprintf(Buffer, "Alt: %.2lf NM", GC->AGOP_Alt / 1852.0);
+	skp->Text(CW * 2, 13 * H / 22, Buffer, strlen(Buffer));
+
 	if (GC->AGOP_Mode >= 4)
 	{
 		//Fixed antenna position

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
@@ -3310,7 +3310,7 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 		{ "Move to CSM usable table", 0, 'U' },
 		{ "CSM ground tracking vector", 0, 'G' },
 		{ "CSM trajectory update", 0, 'C' },
-		{ "", 0, ' ' },
+		{ "VPS vector entry", 0, 'Q' },
 
 		{ "General MED request", 0, 'M' },
 		{ "Move to LM evaluation table", 0, 'F' },
@@ -3327,7 +3327,7 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 	RegisterFunction("UV", OAPI_KEY_U, &ApolloRTCCMFD::menuMoveToUsableTableCSM);
 	RegisterFunction("DC", OAPI_KEY_G, &ApolloRTCCMFD::menuMPTTrajectoryUpdateCSM);
 	RegisterFunction("TUP", OAPI_KEY_C, &ApolloRTCCMFD::menuEphemerisUpdateCSM);
-	RegisterFunction("", OAPI_KEY_Q, &ApolloRTCCMFD::menuVoid);
+	RegisterFunction("S84", OAPI_KEY_Q, &ApolloRTCCMFD::SetMEDInputPageS84);
 
 	RegisterFunction("MED", OAPI_KEY_M, &ApolloRTCCMFD::menuGeneralMEDRequest);
 	RegisterFunction("EV", OAPI_KEY_F, &ApolloRTCCMFD::menuMoveToEvalTableLEM);


### PR DESCRIPTION
Add capability to enter state vectors on the vector panel summary display:

<img width="848" height="260" alt="image" src="https://github.com/user-attachments/assets/8f19655d-a594-4376-b5e3-db03ce56d43e" />

Also fixes a few AGOP inputs, mostly for option 4 (antenna pointing).