### PR TITLE
LM S-BD Steerable Updates

### DIFF
--- a/Config/ProjectApollo/LEMSystems.cfg
+++ b/Config/ProjectApollo/LEMSystems.cfg
@@ -862,11 +862,9 @@
 	</RADIATOR>	
 	
 	#LM S-BD
-	<RADIATOR> LEM-SBand-Steerable-Antenna <2.06  1.21 -0.39> 233.15 C
+	<RADIATOR> LEM-SBand-Steerable-Antenna <2.06  1.21 -0.39> 233.15
 		0.03 0.5 10000.0
 	</RADIATOR>
-	
-	<HEATLOAD> 	SBDANTHEAT 	LEM-SBand-Steerable-Antenna
 	
 	#LM RR
 	<RADIATOR> LEM-RR-Antenna <0.0 0.35 0.2> 233.15 C
@@ -874,7 +872,7 @@
 	</RADIATOR>
 	
 	#LM LR
-	<RADIATOR> LEM-LR-Antenna <0.0 -0.3 -0.2> 233.15 C
+	<RADIATOR> LEM-LR-Antenna <0.0 -0.3 -0.2> 233.15
 		0.04 0.5 19731.27
 	</RADIATOR>
 	
@@ -1131,7 +1129,10 @@
 	<HEATLOAD> LRHEAT		LEM-LR-Antenna	
 	
 	#RR Heat	
-	<HEATLOAD> RRHEAT		LEM-RR-Antenna	
+	<HEATLOAD> RRHEAT		LEM-RR-Antenna
+
+    #S-BD Steerable Heat
+	<HEATLOAD> 	SBDANTHEAT 	LEM-SBand-Steerable-Antenna
 	
 	#Glycol Pump Heat
 	<HEATLOAD> GLYPUMP1HEAT		PRIMGLYCOLPUMPMANIFOLD

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
@@ -2701,6 +2701,7 @@ LEM_SteerableAnt::LEM_SteerableAnt()
 	pitch = 0.0;
 	yaw = 0.0;
 	moving = false;
+	driverateratio = 0.0;
 	hpbw_factor = 0.0;
 	SignalStrength = 0.0;
 
@@ -2765,12 +2766,6 @@ void LEM_SteerableAnt::Timestep(double simdt){
 	sband_proc_last[1] = sband_proc[1];
 
 	moving = false;
-
-	if (!IsPowered())
-	{
-		SignalStrength = 0.0;
-		return;
-	}
 
 	double AzimuthErrorSignal, ElevationErrorSignal;
 	double AzimuthErrorSignalNorm, ElevationErrorSignalNorm;
@@ -2844,6 +2839,8 @@ void LEM_SteerableAnt::Timestep(double simdt){
 		}
 		moving = true;
 	}
+
+	driverateratio = ((abs(pitchrate) / MaxServoRate) + (abs(yawrate) / MaxServoRate)) / 2.0;  //allows power draw based on drive rates
 
 	//sprintf(oapiDebugString(), "pitchrate: %f deg/sec, yawrate: %f deg/sec", pitchrate*DEG, yawrate*DEG);
 
@@ -2938,20 +2935,21 @@ void LEM_SteerableAnt::Timestep(double simdt){
 void LEM_SteerableAnt::SystemTimestep(double simdt)
 {
 	// Do we have power?
-	if (IsPowered()) {
-
-		lem->SBD_ANT_AC_CB.DrawPower(4); 	
+	if (IsPowered())
+	{
+		lem->SBD_ANT_AC_CB.DrawPower(4);
 		lem->COMM_SBAND_ANT_CB.DrawPower(0.83);
 		antheatload->GenerateHeat(4 + 0.83);
-
 	}
 
 	if (moving)
 	{
-		lem->SBD_ANT_AC_CB.DrawPower(27.9); 	//Need a source on this moving draw
-		lem->COMM_SBAND_ANT_CB.DrawPower(7.6);  //Need a source on this moving draw
-		//antheatload->GenerateHeat(0);		//Will add this once loads above are checked and sourced
+		lem->SBD_ANT_AC_CB.DrawPower(27.9 * driverateratio); 			//Need a source on this moving draw (currently AOH performance summary)
+		lem->COMM_SBAND_ANT_CB.DrawPower(7.6 * driverateratio);			//Need a source on this moving draw (currently AOH performance summary)
+		antheatload->GenerateHeat((27.9 + 7.6) * driverateratio);
 	}
+
+	//sprintf(oapiDebugString(),"Drive Rate Ratio %.01f", driverateratio);
 }
 
 bool LEM_SteerableAnt::IsPowered()

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.cpp
@@ -2767,108 +2767,110 @@ void LEM_SteerableAnt::Timestep(double simdt){
 
 	moving = false;
 
-	double AzimuthErrorSignal, ElevationErrorSignal;
-	double AzimuthErrorSignalNorm, ElevationErrorSignalNorm;
-
-	//actual Azimuth and Elevation error signals came from phase differences not signal strength
-	//both are be a function of tracking error though so this works
-	AzimuthErrorSignal = (HornSignalStrength[1] - HornSignalStrength[0])*0.25;
-	ElevationErrorSignal = (HornSignalStrength[3] - HornSignalStrength[2])*0.25;
-
-	//normalize Azimuth and Elevation error signals
-	if (SignalStrength > 0.0)
+	if (IsPowered())
 	{
-		AzimuthErrorSignalNorm = AzimuthErrorSignal / SignalStrength;
-		ElevationErrorSignalNorm = ElevationErrorSignal / SignalStrength;
-	}
-	else //prevent division by zero
-	{
-		AzimuthErrorSignalNorm = 0;
-		ElevationErrorSignalNorm = 0;
-	}
+		double AzimuthErrorSignal, ElevationErrorSignal;
+		double AzimuthErrorSignalNorm, ElevationErrorSignalNorm;
 
-	double pitchrate = 0.0;
-	double yawrate = 0.0;
+		//actual Azimuth and Elevation error signals came from phase differences not signal strength
+		//both are be a function of tracking error though so this works
+		AzimuthErrorSignal = (HornSignalStrength[1] - HornSignalStrength[0]) * 0.25;
+		ElevationErrorSignal = (HornSignalStrength[3] - HornSignalStrength[2]) * 0.25;
 
-	double PitchSlew, YawSlew;
-
-	const double TrkngCtrlGain = 270; //arbitrary; tuned high enough maintain track during maneuvers up to slew rate, but not cause osculation.
-	const double TrkngRatelGain = 4.0; //
-	const double MaxServoRate = 20 * RAD;
-
-	//sprintf(oapiDebugString(), "AzimuthErrorSignal: %f, ElevationErrorSignal: %f", AzimuthErrorSignal, ElevationErrorSignal);
-
-	//Slew Mode
-	if (lem->Panel12AntTrackModeSwitch.GetState() == THREEPOSSWITCH_DOWN)
-	{
-		PitchSlew = (lem->Panel12AntPitchKnob.GetValue()*15.0 - 75.0)*RAD;
-		YawSlew = (lem->Panel12AntYawKnob.GetValue()*15.0 - 90.0)*RAD;
-	}
-	//Auto Tracking
-	else if (lem->Panel12AntTrackModeSwitch.GetState() == THREEPOSSWITCH_UP)
-	{
-		PitchSlew = pitch + (TrkngCtrlGain*ElevationErrorSignalNorm*exp(-simdt*10));
-		YawSlew = yaw + (TrkngCtrlGain*AzimuthErrorSignalNorm*exp(-simdt*10));
-	}
-	else
-	{
-		PitchSlew = pitch;
-		YawSlew = yaw;
-	}
-
-	
-	//sprintf(oapiDebugString(), "PitchSlew: %f, YawSlew: %f", PitchSlew*DEG, YawSlew*DEG);
-
-	//set antenna slew-rates
-	if (abs(PitchSlew - pitch) > 0.0001)
-	{
-		pitchrate = (PitchSlew - pitch)*TrkngRatelGain;
-		if (abs(pitchrate) > MaxServoRate)
+		//normalize Azimuth and Elevation error signals
+		if (SignalStrength > 0.0)
 		{
-			pitchrate = MaxServoRate *pitchrate / abs(pitchrate);
+			AzimuthErrorSignalNorm = AzimuthErrorSignal / SignalStrength;
+			ElevationErrorSignalNorm = ElevationErrorSignal / SignalStrength;
 		}
-		moving = true;
-	}
-
-	if (abs(YawSlew - yaw) > 0.0001)
-	{
-		yawrate = (YawSlew - yaw)*TrkngRatelGain;
-		if (abs(yawrate) > MaxServoRate)
+		else //prevent division by zero
 		{
-			yawrate = MaxServoRate *yawrate / abs(yawrate);
+			AzimuthErrorSignalNorm = 0;
+			ElevationErrorSignalNorm = 0;
 		}
-		moving = true;
+
+		double pitchrate = 0.0;
+		double yawrate = 0.0;
+
+		double PitchSlew, YawSlew;
+
+		const double TrkngCtrlGain = 270; //arbitrary; tuned high enough maintain track during maneuvers up to slew rate, but not cause osculation.
+		const double TrkngRatelGain = 4.0; //
+		const double MaxServoRate = 20 * RAD;
+
+		//sprintf(oapiDebugString(), "AzimuthErrorSignal: %f, ElevationErrorSignal: %f", AzimuthErrorSignal, ElevationErrorSignal);
+
+		//Slew Mode
+		if (lem->Panel12AntTrackModeSwitch.GetState() == THREEPOSSWITCH_DOWN)
+		{
+			PitchSlew = (lem->Panel12AntPitchKnob.GetValue() * 15.0 - 75.0) * RAD;
+			YawSlew = (lem->Panel12AntYawKnob.GetValue() * 15.0 - 90.0) * RAD;
+		}
+		//Auto Tracking
+		else if (lem->Panel12AntTrackModeSwitch.GetState() == THREEPOSSWITCH_UP)
+		{
+			PitchSlew = pitch + (TrkngCtrlGain * ElevationErrorSignalNorm * exp(-simdt * 10));
+			YawSlew = yaw + (TrkngCtrlGain * AzimuthErrorSignalNorm * exp(-simdt * 10));
+		}
+		else
+		{
+			PitchSlew = pitch;
+			YawSlew = yaw;
+		}
+
+
+		//sprintf(oapiDebugString(), "PitchSlew: %f, YawSlew: %f", PitchSlew*DEG, YawSlew*DEG);
+
+		//set antenna slew-rates
+		if (abs(PitchSlew - pitch) > 0.0001)
+		{
+			pitchrate = (PitchSlew - pitch) * TrkngRatelGain;
+			if (abs(pitchrate) > MaxServoRate)
+			{
+				pitchrate = MaxServoRate * pitchrate / abs(pitchrate);
+			}
+			moving = true;
+		}
+
+		if (abs(YawSlew - yaw) > 0.0001)
+		{
+			yawrate = (YawSlew - yaw) * TrkngRatelGain;
+			if (abs(yawrate) > MaxServoRate)
+			{
+				yawrate = MaxServoRate * yawrate / abs(yawrate);
+			}
+			moving = true;
+		}
+
+		driverateratio = ((abs(pitchrate) / MaxServoRate) + (abs(yawrate) / MaxServoRate)) / 2.0;  //allows power draw based on drive rates
+
+		//sprintf(oapiDebugString(), "pitchrate: %f deg/sec, yawrate: %f deg/sec", pitchrate*DEG, yawrate*DEG);
+
+		//Drive Antenna
+		pitch += pitchrate * simdt;
+		yaw += yawrate * simdt;
+
+		//sprintf(oapiDebugString(), "pitch: %f pitchrate %f, yaw: %f yawrate %f %d", pitch*DEG, pitchrate*DEG, yaw*DEG, yawrate*DEG, moving);
+
+		//Antenna Limits
+		if (pitch > 255.0 * RAD)
+		{
+			pitch = 255.0 * RAD;
+		}
+		else if (pitch < -75.0 * RAD)
+		{
+			pitch = -75.0 * RAD;
+		}
+
+		if (yaw > 87.0 * RAD)
+		{
+			yaw = 87.0 * RAD;
+		}
+		else if (yaw < -87.0 * RAD)
+		{
+			yaw = -87.0 * RAD;
+		}
 	}
-
-	driverateratio = ((abs(pitchrate) / MaxServoRate) + (abs(yawrate) / MaxServoRate)) / 2.0;  //allows power draw based on drive rates
-
-	//sprintf(oapiDebugString(), "pitchrate: %f deg/sec, yawrate: %f deg/sec", pitchrate*DEG, yawrate*DEG);
-
-	//Drive Antenna
-	pitch += pitchrate*simdt;
-	yaw += yawrate*simdt;
-
-	//sprintf(oapiDebugString(), "pitch: %f pitchrate %f, yaw: %f yawrate %f %d", pitch*DEG, pitchrate*DEG, yaw*DEG, yawrate*DEG, moving);
-
-	//Antenna Limits
-	if (pitch > 255.0*RAD)
-	{
-		pitch = 255.0*RAD;
-	}
-	else if (pitch < -75.0*RAD)
-	{
-		pitch = -75.0*RAD;
-	}
-
-	if (yaw > 87.0*RAD)
-	{
-		yaw = 87.0*RAD;
-	}
-	else if (yaw < -87.0*RAD)
-	{
-		yaw = -87.0*RAD;
-	}
-
 	//Signal Strength
 
 	double relang[4];

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_telecom.h
@@ -364,6 +364,7 @@ protected:
 	double	sband_proc_last[2];
 
 	bool moving;
+	double driverateratio;
 	double hpbw_factor;
 
 	const MATRIX3 NBSA = _M(cos(45.0*RAD), -sin(45.0*RAD), 0.0, sin(45.0*RAD), cos(45.0*RAD), 0.0, 0.0, 0.0, 1.0);


### PR DESCRIPTION
- Remove lack of signal strength if unpowered (RF should run through independent of the electronics package, also moving switch from AUTO to SLEW through OFF would cause a drop in signal)

- Remove "cardioid" from antenna so it evenly heats and cools (electronics are omnidirectional)

- Base movement power draw/heat generation on drive rates