### PR TITLE
Fix two MPT bugs with executed maneuvers; also fix a RTCC MFD bug

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -16703,7 +16703,7 @@ void RTCC::PMMFUD(int veh, unsigned man, int action, std::string StationID)
 			PMXSPT("PMMFUD", 42);
 			return;
 		}
-
+		//Compute and store new number of the TLI (TBD), the deorbit (TBD), last executed, last frozen, and remaining maneuvers
 		if (mpt->LastExecutedManeuver > 0)
 		{
 			mpt->LastExecutedManeuver -= man;
@@ -16712,7 +16712,7 @@ void RTCC::PMMFUD(int veh, unsigned man, int action, std::string StationID)
 		{
 			mpt->LastFrozenManeuver -= man;
 		}
-
+		//Move up the area, weight, begin time, end time sets in header to their proper place
 		for (unsigned i = man;i < mpt->ManeuverNum;i++)
 		{
 			mpt->TimeToBeginManeuver[i - man] = mpt->TimeToBeginManeuver[i];
@@ -16722,9 +16722,13 @@ void RTCC::PMMFUD(int veh, unsigned man, int action, std::string StationID)
 		}
 
 		mpt->ManeuverNum -= man;
+		//Store in header the configuration code, docking angle, areas, vehicle weights, and fuel weights from descriptive block of last maneuver to be deleted
 		mpt->DeltaDockingAngle = mpt->mantable[man - 1].DockingAngle;
 		mpt->ConfigurationArea = mpt->mantable[man - 1].TotalAreaAfter;
+		//Leave TUP intact
+		int TUP = mpt->CommonBlock.TUP;
 		mpt->CommonBlock = mpt->mantable[man - 1].CommonBlock;
+		mpt->CommonBlock.TUP = TUP;
 		//TBD: Compute and store new GET to begin venting
 
 		for (unsigned i = 0;i < man;i++)
@@ -17147,6 +17151,7 @@ void RTCC::EMSEPH(int QUEID, StateVectorTableEntry &sv, int &L, double PresentGM
 	{
 		table->EPHEM.table.clear();
 		table->MANTIMES.Table.clear();
+		table->LUNRSTAY.LunarStayBeginGMT = table->LUNRSTAY.LunarStayEndGMT = -1.0;
 	}
 
 	RTCCNIAuxOutputTable aux;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -1162,6 +1162,8 @@ void ApolloRTCCMFD::menuSetLSUpdateMenu()
 
 void ApolloRTCCMFD::menuSetTITransferPage()
 {
+	marker = 0;
+	markermax = 11;
 	SelectPage(54);
 }
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -10000,7 +10000,7 @@ void ApolloRTCCMFD::PrintUllage(char *Buffer, int Thruster, bool Use4Jets, doubl
 	}
 	else
 	{
-		sprintf_s(Buffer, 127, "");
+		sprintf_s(Buffer, 127, "N/A");
 	}
 }
 


### PR DESCRIPTION
- When an executed maneuver is being history deleted its trajectory update number was copied (as part of a struct of common data) from the maneuver data to the MPT header. Executed maneuvers are not integrated through with new trajectory updates, so the stored trajectory update number could be a lower number than the current trajectory update. This could lead to inconsistent numbers between tables (MPT vs. ephemeris table) which leads to errors on certain displays (e.g. error 3 on the checkout monitor). This has been corrected.
- The lunar stay begin and end times were not reset on trajectory updates. If there was an executed powered descent maneuver on the MPT (on the surface at present time), that maneuver is being deleted and a new on-orbit trajectory update is performed, the lunar stay begin/end times were still as if the powered descent is on the MPT. Now these times are reset/regenerated on every trajectory update.
- Fix Two Impulse transfer page input marker
- Show N/A instead of blank in the PrintUllage function

Terminology:

Executed maneuver = maneuver on the MPT that has already been executed, i.e. its time of ignition is before present time
History deletion = deletion of executed maneuver