### PR TITLE
Disable SPS gauging power at CM/SM separation

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/sps.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/sps.cpp
@@ -342,6 +342,7 @@ double SPSPropellantSource::GetOxidUnbalanceLB() {
 
 bool SPSPropellantSource::IsGaugingPowered() {
 
+	if (our_vessel->GetStage() > CSM_LEM_STAGE) return false;
 	if (DCPower.Voltage() < SP_MIN_DCVOLTAGE) return false;
 
 	if (!ACPower) return false;


### PR DESCRIPTION
This should freeze the SPS propellant displays to their values at sep.