### PR TITLE
Add code for handling P30 REFSMMATs with MPT enabled; delete old current REFSMMAT indicator

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -602,8 +602,8 @@ ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
 
 	//screen = 0;
 	REFSMMAT_LVLH_Time = 0.0;
+	REFSMMAT_ManNum = 1;
 	REFSMMATopt = 4;
-	REFSMMATcur = 4;
 	manpadopt = 0;
 	lemdescentstage = true;
 	mptinitmode = 3;
@@ -2786,9 +2786,7 @@ int ARCore::subThread()
 	break;
 	case 4:	//REFSMMAT Calculation
 	{
-		REFSMMATOpt opt;
 		int mptveh;
-
 		if (IsCSMCalculation)
 		{
 			mptveh = RTCC_MPT_CSM;
@@ -2798,6 +2796,61 @@ int ARCore::subThread()
 			mptveh = RTCC_MPT_LM;
 		}
 
+		if (GC->MissionPlanningActive)
+		{
+			if (REFSMMATopt == 0)
+			{
+				// Use MED
+				std::string medtype, veh, mannum, head, medstring;
+				REFSMMATLocker* refs;
+				int id;
+
+				if (mptveh == RTCC_MPT_CSM)
+				{
+					medtype = "G11";
+					veh = "CSM";
+					refs = &GC->rtcc->EZJGMTX1;
+				}
+				else
+				{
+					medtype = "G21";
+					veh = "LEM";
+					refs = &GC->rtcc->EZJGMTX3;
+				}
+				id = refs->data[RTCC_REFSMMAT_TYPE_DMT - 1].ID;
+
+				char Buff[128];
+				sprintf(Buff, "%d", REFSMMAT_ManNum);
+				mannum.assign(Buff);
+				if (REFSMMATHeadsUp)
+				{
+					head = "U";
+				}
+				else
+				{
+					head = "D";
+				}
+				medstring = medtype + "," + veh + ",DMT," + mannum + ",DES," + head + ";";
+				sprintf(Buff, "%s", medstring.c_str());
+				GC->rtcc->GMGMED(Buff);
+				//Check if REFSMMAT ID changed
+				if (id == refs->data[RTCC_REFSMMAT_TYPE_DMT - 1].ID)
+				{
+					Result = DONE;
+					break;
+				}
+				//Move REFSMMAT from DMT to CUR
+				medstring = "G00," + veh + ",DMT," + veh + ",CUR;";
+				sprintf(Buff, "%s", medstring.c_str());
+				GC->rtcc->GMGMED(Buff);
+
+				Result = DONE;
+				break;
+			}
+		}
+
+
+		REFSMMATOpt opt;
 		opt.dV_LVLH = dV_LVLH;
 		opt.LSAzi = GC->rtcc->med_k18.psi_DS*RAD;
 		opt.LSLat = GC->rtcc->BZLAND.lat[RTCC_LMPOS_BEST];
@@ -2885,7 +2938,7 @@ int ARCore::subThread()
 		{
 			opt.useSV = true;
 
-			if (REFSMMATopt == 0 || REFSMMATopt == 1 || REFSMMATopt == 2)
+			if (REFSMMATopt == 1 || REFSMMATopt == 2)
 			{
 				//SV at specified time
 				double GMT = GC->rtcc->GMTfromGET(opt.REFSMMATTime);
@@ -2967,11 +3020,6 @@ int ARCore::subThread()
 		{
 			GC->rtcc->EMGSTSTM(3, REFSMMAT, RTCC_REFSMMAT_TYPE_CUR, GC->rtcc->RTCCPresentTimeGMT());
 		}
-
-		//sprintf(oapiDebugString(), "%f, %f, %f, %f, %f, %f, %f, %f, %f", REFSMMAT.m11, REFSMMAT.m12, REFSMMAT.m13, REFSMMAT.m21, REFSMMAT.m22, REFSMMAT.m23, REFSMMAT.m31, REFSMMAT.m32, REFSMMAT.m33);
-
-		REFSMMATcur = REFSMMATopt;
-
 		Result = DONE;
 	}
 	break;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
@@ -300,8 +300,8 @@ public:
 
 	//REFSMMAT PAGE
 	double REFSMMAT_LVLH_Time;
+	int REFSMMAT_ManNum;	//Maneuver number for P30 REFSMMAT
 	int REFSMMATopt; //Displayed REFSMMAT page: 0 = P30 Maneuver, 1 = P30 Retro, 2 = LVLH, 3 = Lunar Entry, 4 = Launch, 5 = Landing Site, 6 = PTC, 7 = Attitude, 8 = LS during TLC
-	int REFSMMATcur; //Currently saved REFSMMAT
 	bool REFSMMATHeadsUp;
 
 	//ENTRY PAGE

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -252,7 +252,6 @@ void ApolloRTCCMFD::WriteStatus(FILEHANDLE scn) const
 	//oapiWriteScenario_int(scn, "SCREEN", G->screen);
 	papiWriteScenario_bool(scn, "VESSELISDOCKED", G->vesselisdocked);
 	papiWriteScenario_double(scn, "SXTSTARDTIME", G->sxtstardtime);
-	oapiWriteScenario_int(scn, "REFSMMATcur", G->REFSMMATcur);
 	oapiWriteScenario_int(scn, "REFSMMATopt", G->REFSMMATopt);
 	papiWriteScenario_double(scn, "REFSMMAT_LVLH_Time", G->REFSMMAT_LVLH_Time);
 	papiWriteScenario_bool(scn, "REFSMMATHeadsUp", G->REFSMMATHeadsUp);
@@ -305,7 +304,6 @@ void ApolloRTCCMFD::ReadStatus(FILEHANDLE scn)
 		//papiReadScenario_int(line, "SCREEN", G->screen);
 		papiReadScenario_bool(line, "VESSELISDOCKED", G->vesselisdocked);
 		papiReadScenario_double(line, "SXTSTARDTIME", G->sxtstardtime);
-		papiReadScenario_int(line, "REFSMMATcur", G->REFSMMATcur);
 		papiReadScenario_int(line, "REFSMMATopt", G->REFSMMATopt);
 		papiReadScenario_double(line, "REFSMMAT_LVLH_Time", G->REFSMMAT_LVLH_Time);
 		papiReadScenario_bool(line, "REFSMMATHeadsUp", G->REFSMMATHeadsUp);
@@ -4025,7 +4023,14 @@ void ApolloRTCCMFD::menuCyclePreferredGDCStarSet()
 
 void ApolloRTCCMFD::REFSMMATTimeDialogue()
 {
-	if (G->REFSMMATopt == 2)
+	if (G->REFSMMATopt == 0)
+	{
+		if (GC->MissionPlanningActive)
+		{
+			GenericIntInput(&G->REFSMMAT_ManNum, "Enter maneuver number (1-15):", NULL, 1, 15);
+		}
+	}
+	else if (G->REFSMMATopt == 2)
 	{
 		bool REFSMMATGETInput(void *id, char *str, void *data);
 		oapiOpenInputBox("Choose the GET (Format: hhh:mm:ss)", REFSMMATGETInput, 0, 20, (void*)this);
@@ -6782,8 +6787,6 @@ void ApolloRTCCMFD::GetREFSMMATfromAGC()
 		GC->rtcc->EMSLSUPP(1, 1);
 		GeneralMEDRequest("G00,LEM,TLM,LEM,CUR;");
 	}
-
-	G->REFSMMATcur = G->REFSMMATopt;
 
 	//sprintf(oapiDebugString(), "%f, %f, %f, %f, %f, %f, %f, %f, %f", G->REFSMMAT.m11, G->REFSMMAT.m12, G->REFSMMAT.m13, G->REFSMMAT.m21, G->REFSMMAT.m22, G->REFSMMAT.m23, G->REFSMMAT.m31, G->REFSMMAT.m32, G->REFSMMAT.m33);
 }

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -701,17 +701,24 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			{
 				skp->Text(CW, 4 * H / 14, "P30 Retro", 9);
 			}
-
-			GET_Display(Buffer, G->P30TIG);
-			skp->Text(CW, 6 * H / 14, Buffer, strlen(Buffer));
-			skp->SetTextAlign(oapi::Sketchpad::RIGHT);
-			skp->Text(W - CW, 4 * H / 14, "DV Vector", 9);
-			AGC_Display(Buffer, G->dV_LVLH.x / 0.3048);
-			skp->Text(W - CW, 5 * H / 14, Buffer, strlen(Buffer));
-			AGC_Display(Buffer, G->dV_LVLH.y / 0.3048);
-			skp->Text(W - CW, 6 * H / 14, Buffer, strlen(Buffer));
-			AGC_Display(Buffer, G->dV_LVLH.z / 0.3048);
-			skp->Text(W - CW, 7 * H / 14, Buffer, strlen(Buffer));
+			if (GC->MissionPlanningActive && G->REFSMMATopt == 0)
+			{
+				sprintf(Buffer, "Maneuver: %d", G->REFSMMAT_ManNum);
+				skp->Text(CW, 6 * H / 14, Buffer, strlen(Buffer));
+			}
+			else
+			{
+				GET_Display(Buffer, G->P30TIG);
+				skp->Text(CW, 6 * H / 14, Buffer, strlen(Buffer));
+				skp->SetTextAlign(oapi::Sketchpad::RIGHT);
+				skp->Text(W - CW, 4 * H / 14, "DV Vector", 9);
+				AGC_Display(Buffer, G->dV_LVLH.x / 0.3048);
+				skp->Text(W - CW, 5 * H / 14, Buffer, strlen(Buffer));
+				AGC_Display(Buffer, G->dV_LVLH.y / 0.3048);
+				skp->Text(W - CW, 6 * H / 14, Buffer, strlen(Buffer));
+				AGC_Display(Buffer, G->dV_LVLH.z / 0.3048);
+				skp->Text(W - CW, 7 * H / 14, Buffer, strlen(Buffer));
+			}
 		}
 		else if (G->REFSMMATopt == 2)
 		{
@@ -773,10 +780,6 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		else if (G->REFSMMATopt == 7)
 		{
 			skp->Text(CW, 4 * H / 14, "REFS from Att", 13);
-
-			skp->Text(CW, 9 * H / 21, "Cur REFSMMAT:", 13);
-			REFSMMATName(Buffer, G->REFSMMATcur);
-			skp->Text(CW, 10 * H / 21, Buffer, strlen(Buffer));
 
 			skp->Text(CW, 12 * H / 21, "Attitude:", 9);
 			sprintf(Buffer, "%+07.2f R", G->VECangles.x*DEG);


### PR DESCRIPTION
The logic with MPT enabled first generates a DMT REFSMMAT (using MED logic, either G11 for the CSM, or G21 for the LEM) and then moves the DMT REFSMMAT to the CUR REFSMMAT with MED G00.

Instead of TIG and DV as input and the old REFSMMATCalc function being used this new MPT logic now just takes a maneuver number as input and acts as if these two MEDs were called.