### PR TITLE
RTCC MFD fixes

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -3990,8 +3990,8 @@ public:
 	{
 		EphemerisData sv_man_bef[4];
 		VECTOR3 V_man_after[4];
-		int num_man;
-		int plan[4];
+		int num_man = 0;
+		int plan[4]; //Maneuver vehicle. 1 = CSM, 3 = LEM
 		std::string code[4];
 	} PZLDPELM;
 

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -1053,7 +1053,7 @@ void ARCore::TransferTIToMPT()
 	startSubthread(38);
 }
 
-void ARCore::Transfer_SPQ_Or_DKI_To_MPT()
+void ARCore::Transfer_LDP_Or_SPQ_Or_DKI_To_MPT()
 {
 	startSubthread(39);
 }
@@ -1061,11 +1061,6 @@ void ARCore::Transfer_SPQ_Or_DKI_To_MPT()
 void ARCore::MPTDirectInputCalc()
 {
 	startSubthread(41);
-}
-
-void ARCore::TransferDescentPlanToMPT()
-{
-	startSubthread(42);
 }
 
 void ARCore::TransferPoweredDescentToMPT()
@@ -4614,7 +4609,7 @@ int ARCore::subThread()
 		Result = DONE;
 	}
 	break;
-	case 39: //Transfer SPQ or DKI to MPT
+	case 39: //Transfer SPQ, DKI or descent planning to MPT
 	{
 		if (GC->MissionPlanningActive)
 		{
@@ -4623,34 +4618,59 @@ int ARCore::subThread()
 		}
 		else
 		{
-			int plan;
+			EphemerisData sv_before;
+			VECTOR3 V_after;
+			int MAN_VEH;
 
-			plan = GC->rtcc->med_m70.Plan;
-
-			if (plan > 0) plan--; //For DKI
-
-			if (plan < 0 || plan > 6)
+			if (GC->rtcc->med_m70.Plan < 0)
 			{
-				//Error
-				Result = DONE;
-				break;
+				//Descent Plan
+				if (GC->rtcc->PZLDPELM.num_man == 0)
+				{
+					//Error
+					Result = DONE;
+					break;
+				}
+
+				sv_before = GC->rtcc->PZLDPELM.sv_man_bef[0];
+				V_after = GC->rtcc->PZLDPELM.V_man_after[0];
+				MAN_VEH = GC->rtcc->PZLDPELM.plan[0];
 			}
-
-			RTCC::DKIDataBlock *block = &GC->rtcc->PZDKIT.Block[plan];
-
-			if (block->PlanStatus == 0)
+			else
 			{
-				//Error
-				Result = DONE;
-				break;
-			}
+				//SPQ or DKI
+				int plan;
 
-			RTCC::DKIElementsBlock *elem = &GC->rtcc->PZDKIELM.Block[plan];
+				plan = GC->rtcc->med_m70.Plan;
+				if (plan > 0) plan--; //For DKI
+
+				if (plan > 6)
+				{
+					//Error
+					Result = DONE;
+					break;
+				}
+
+				RTCC::DKIDataBlock* block = &GC->rtcc->PZDKIT.Block[plan];
+
+				if (block->PlanStatus == 0)
+				{
+					//Error
+					Result = DONE;
+					break;
+				}
+
+				RTCC::DKIElementsBlock* elem = &GC->rtcc->PZDKIELM.Block[plan];
+
+				sv_before = elem->SV_before[0].sv;
+				MAN_VEH = block->Display[0].VEH;
+				V_after = elem->V_after[0];
+			}
 
 			PMMMPTInput in;
 
 			//Get all required data for PMMMPT and error checking
-			if (GetVesselParameters(block->Display[0].VEH == RTCC_MPT_CSM, vesselisdocked, GC->rtcc->med_m70.ManData[0].Thruster, in.CONFIG, in.VC, in.CSMWeight, in.LMWeight))
+			if (GetVesselParameters(MAN_VEH == RTCC_MPT_CSM, vesselisdocked, GC->rtcc->med_m70.ManData[0].Thruster, in.CONFIG, in.VC, in.CSMWeight, in.LMWeight))
 			{
 				//Error
 				Result = DONE;
@@ -4662,8 +4682,8 @@ int ARCore::subThread()
 			in.IgnitionTimeOption = GC->rtcc->med_m70.ManData[0].TimeFlag;
 			in.Thruster = GC->rtcc->med_m70.ManData[0].Thruster;
 
-			in.sv_before = elem->SV_before[0].sv;
-			in.V_aft = elem->V_after[0];
+			in.sv_before = sv_before;
+			in.V_aft = V_after;
 			if (GC->rtcc->med_m70.ManData[0].UllageDT < 0)
 			{
 				in.DETU = GC->rtcc->SystemParameters.MCTNDU;
@@ -4781,45 +4801,8 @@ int ARCore::subThread()
 		Result = DONE;
 	}
 	break;
-	case 42: //Transfer Descent Plan to MPT
+	case 42: //Spare
 	{
-		if (GC->MissionPlanningActive)
-		{
-			std::vector<std::string> str;
-			GC->rtcc->PMMMED("70", str);
-		}
-		else
-		{
-			SV sv_pre, sv_post, sv_tig;
-			double attachedMass = 0.0;
-
-			VESSEL *v;
-			if (GC->rtcc->PZLDPELM.plan[0] == RTCC_MPT_CSM)
-			{
-				v = GC->rtcc->pCSM;
-			}
-			else
-			{
-				v = GC->rtcc->pLM;
-			}
-
-			if (v == NULL)
-			{
-				Result = DONE;
-				break;
-			}
-
-			SV sv_now = GC->rtcc->StateVectorCalc(v);
-			sv_tig = GC->rtcc->coast(sv_now, GC->rtcc->PZLDPDIS.GETIG[0] - OrbMech::GETfromMJD(sv_now.MJD, GC->rtcc->CalcGETBase()));
-
-			if (vesselisdocked)
-			{
-				attachedMass = GC->rtcc->GetDockedVesselMass(v);
-			}
-
-			GC->rtcc->PoweredFlightProcessor(sv_tig, GC->rtcc->PZLDPDIS.GETIG[0], GC->rtcc->med_m70.ManData[0].Thruster, attachedMass, GC->rtcc->PZLDPDIS.DVVector[0] * 0.3048, true, P30TIG, dV_LVLH, sv_pre, sv_post);
-		}
-
 		Result = DONE;
 	}
 	break;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
@@ -168,8 +168,7 @@ public:
 	void SkylabSaturnIBLaunchCalc();
 	void SkylabSaturnIBLaunchUplink();
 	void TransferTIToMPT();
-	void Transfer_SPQ_Or_DKI_To_MPT();
-	void TransferDescentPlanToMPT();
+	void Transfer_LDP_Or_SPQ_Or_DKI_To_MPT();
 	void TransferPoweredDescentToMPT();
 	void TransferPoweredAscentToMPT();
 	void TransferGPMToMPT();

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -3316,16 +3316,9 @@ void ApolloRTCCMFD::set_RTEDManualDV(VECTOR3 DV)
 	GC->rtcc->med_f81.XDV = DV * 0.3048;
 }
 
-void ApolloRTCCMFD::menuTransferSPQorDKIToMPT()
+void ApolloRTCCMFD::menuTransferLDPOrSPQorDKIToMPT()
 {
-	if (GC->rtcc->med_m70.Plan >= 0)
-	{
-		G->Transfer_SPQ_Or_DKI_To_MPT();
-	}
-	else
-	{
-		G->TransferDescentPlanToMPT();
-	}
+	G->Transfer_LDP_Or_SPQ_Or_DKI_To_MPT();
 }
 
 void ApolloRTCCMFD::menuBackToSPQorDKIPage()
@@ -3334,7 +3327,7 @@ void ApolloRTCCMFD::menuBackToSPQorDKIPage()
 	{
 		menuSetSPQPage();
 	}
-	else if (GC->rtcc->med_m70.Plan == 1)
+	else if (GC->rtcc->med_m70.Plan >= 1)
 	{
 		menuSetDKIPage();
 	}
@@ -4937,8 +4930,17 @@ void ApolloRTCCMFD::menuMPTUpdate()
 
 void ApolloRTCCMFD::menuMPTTrajectoryUpdateCSM()
 {
+	if (GC->rtcc->pCSM)
+	{
+		sprintf(Buffer, "%s", GC->rtcc->pCSM->GetName());
+	}
+	else
+	{
+		sprintf(Buffer, "");
+	}
+
 	bool DifferentialCorrectionSolutionCSMInput(void* id, char *str, void *data);
-	oapiOpenInputBox("Choose vessel for the CSM ground tracking solution (leave blank for CSM selected on config page):", DifferentialCorrectionSolutionCSMInput, 0, 50, (void*)this);
+	oapiOpenInputBox("Choose vessel for the CSM ground tracking solution:", DifferentialCorrectionSolutionCSMInput, Buffer, 50, (void*)this);
 }
 
 bool DifferentialCorrectionSolutionCSMInput(void* id, char *str, void *data)
@@ -4952,8 +4954,17 @@ bool DifferentialCorrectionSolutionCSMInput(void* id, char *str, void *data)
 
 void ApolloRTCCMFD::menuMPTTrajectoryUpdateLEM()
 {
+	if (GC->rtcc->pLM)
+	{
+		sprintf(Buffer, "%s", GC->rtcc->pLM->GetName());
+	}
+	else
+	{
+		sprintf(Buffer, "");
+	}
+
 	bool DifferentialCorrectionSolutionLEMInput(void* id, char *str, void *data);
-	oapiOpenInputBox("Choose vessel for the LM ground tracking solution (leave blank for LM selected on config page):", DifferentialCorrectionSolutionLEMInput, 0, 50, (void*)this);
+	oapiOpenInputBox("Choose vessel for the LM ground tracking solution:", DifferentialCorrectionSolutionLEMInput, Buffer, 50, (void*)this);
 }
 
 bool DifferentialCorrectionSolutionLEMInput(void* id, char *str, void *data)
@@ -4965,34 +4976,20 @@ bool DifferentialCorrectionSolutionLEMInput(void* id, char *str, void *data)
 	return false;
 }
 
-bool ApolloRTCCMFD::set_DifferentialCorrectionSolution(char *str, bool csm)
+bool ApolloRTCCMFD::set_DifferentialCorrectionSolution(char* str, bool csm)
 {
 	//To update display immediately
 	GC->rtcc->VectorPanelSummaryBuffer.gmt = -10000000000000.0;
 
 	OBJHANDLE hVessel;
-	VESSEL *v = NULL;
+	VESSEL* v = NULL;
 
-	if (strcmp(str, "") == 0) //If str is empty, use CSM or LM from config page
+	hVessel = oapiGetVesselByName(str);
+	if (hVessel)
 	{
-		if (csm)
-		{
-			v = GC->rtcc->pCSM;
-		}
-		else
-		{
-			v = GC->rtcc->pLM;
-		}
+		v = oapiGetVesselInterface(hVessel);
 	}
-	else //Otherwise use the input string to get the vessel name
-	{
-		hVessel = oapiGetVesselByName(str);
-		if (hVessel)
-		{
-			v = oapiGetVesselInterface(hVessel);
-		}
-		else return false;
-	}
+	else return false;
 
 	if (v)
 	{
@@ -5164,7 +5161,7 @@ bool MoveToUsableTableLEMInput(void* id, char *str, void *data)
 void ApolloRTCCMFD::menuEphemerisUpdateCSM()
 {
 	bool EphemerisUpdateCSMInput(void* id, char *str, void *data);
-	oapiOpenInputBox("Move CSM vector to ephemeris update. Input: CMC, LGC, AGS, IU, HSR or DC", EphemerisUpdateCSMInput, 0, 50, (void*)this);
+	oapiOpenInputBox("Move CSM vector to ephemeris update. Input: CMC, LGC, AGS, IU, HSR or DC", EphemerisUpdateCSMInput, "DC", 50, (void*)this);
 }
 
 bool EphemerisUpdateCSMInput(void* id, char *str, void *data)
@@ -5211,7 +5208,7 @@ bool EphemerisUpdateCSMInput(void* id, char *str, void *data)
 void ApolloRTCCMFD::menuEphemerisUpdateLEM()
 {
 	bool EphemerisUpdateLEMInput(void* id, char *str, void *data);
-	oapiOpenInputBox("Move LEM vector to ephemeris update. Input: CMC, LGC, AGS, IU, HSR or DC", EphemerisUpdateLEMInput, 0, 50, (void*)this);
+	oapiOpenInputBox("Move LEM vector to ephemeris update. Input: CMC, LGC, AGS, IU, HSR or DC", EphemerisUpdateLEMInput, "DC", 50, (void*)this);
 }
 
 bool EphemerisUpdateLEMInput(void* id, char *str, void *data)

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -516,7 +516,7 @@ public:
 	bool set_ChooseTIThruster(std::string th);
 	void menuTransferTIToMPT();
 	void menuSetSPQorDKIRTransferPage();
-	void menuTransferSPQorDKIToMPT();
+	void menuTransferLDPOrSPQorDKIToMPT();
 	void menuBackToSPQorDKIPage();
 	void menuChooseSPQDKIThruster();
 	bool set_ChooseSPQDKIThruster(std::string th);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
@@ -1905,7 +1905,7 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 	RegisterFunction("", OAPI_KEY_F, &ApolloRTCCMFD::menuVoid);
 	RegisterFunction("", OAPI_KEY_P, &ApolloRTCCMFD::menuVoid);
 	RegisterFunction("", OAPI_KEY_U, &ApolloRTCCMFD::menuVoid);
-	RegisterFunction("CLC", OAPI_KEY_C, &ApolloRTCCMFD::menuTransferSPQorDKIToMPT);
+	RegisterFunction("CLC", OAPI_KEY_C, &ApolloRTCCMFD::menuTransferLDPOrSPQorDKIToMPT);
 	RegisterFunction("BCK", OAPI_KEY_B, &ApolloRTCCMFD::menuBackToSPQorDKIPage);
 
 


### PR DESCRIPTION
-Combine LDPP with SPQ/DKI maneuver transfer in non-MPT mode 
-Simplify vector panel summary inputs

Things to test:
-The LDPP transfer page used outdated code (and didn't output ullage data for the Maneuver PAD). It has now been combined with the SPQ/DKI transfer logic, like it works in MPT mode. So testing should involve LDPP, SPQ and DKI transfers.
-The DC buttons on the Vector Panel Summary now default to the selected CSM/LM names, instead of automatically using these selected vessels if the input is left blank. TUP button now defaults to "DC". Testing should involve checking if these buttons still do what they are supposed to.
