### PR TITLE
RTCC fixes and improvements

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C_PRIME.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C_PRIME.cpp
@@ -1814,7 +1814,7 @@ bool RTCC::CalculationMTP_C_PRIME(int fcn, LPVOID &pad, char * upString, char * 
 			sprintf(upMessage, "%s has been scrubbed.", manname);
 
 			//Entry prediction without maneuver
-			EntryUpdateCalc(sv, PZREAP.RRBIAS, true, &res);
+			EntryUpdateCalc(ConvertSVtoEphemData(sv), PZREAP.RRBIAS, true, res);
 
 			res.dV_LVLH = _V(0, 0, 0);
 			res.P30TIG = entopt.TIGguess;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
@@ -2219,7 +2219,7 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 		if (scrubbed)
 		{
 			//Entry prediction without maneuver
-			EntryUpdateCalc(sv, PZREAP.RRBIAS, true, &res);
+			EntryUpdateCalc(ConvertSVtoEphemData(sv), PZREAP.RRBIAS, true, res);
 
 			res.dV_LVLH = _V(0, 0, 0);
 			res.P30TIG = entopt.TIGguess;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
@@ -2616,7 +2616,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 			if (scrubbed)
 			{
 				//Entry prediction without maneuver
-				EntryUpdateCalc(sv, PZREAP.RRBIAS, true, &res);
+				EntryUpdateCalc(ConvertSVtoEphemData(sv), PZREAP.RRBIAS, true, res);
 
 				res.dV_LVLH = _V(0, 0, 0);
 				res.P30TIG = entopt.TIGguess;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
@@ -3471,7 +3471,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID& pad, char* upString, char* upDesc,
 				if (scrubbed)
 				{
 					//Entry prediction without maneuver
-					EntryUpdateCalc(sv, PZREAP.RRBIAS, true, &res);
+					EntryUpdateCalc(ConvertSVtoEphemData(sv), PZREAP.RRBIAS, true, res);
 
 					res.dV_LVLH = _V(0, 0, 0);
 					res.P30TIG = entopt.TIGguess;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -793,6 +793,8 @@ MPTManeuver::MPTManeuver()
 	V_BO = _V(0, 0, 0);
 	GMT_BO = 0.0;
 
+	W_B = 0.0;
+	W_IG = 0.0;
 	TotalMassAfter = 0.0;
 	TotalAreaAfter = 0.0;
 	MainEngineFuelUsed = 0.0;
@@ -908,6 +910,8 @@ void MPTManeuver::SaveState(FILEHANDLE scn, char *start_str, char *end_str)
 	papiWriteScenario_vec(scn, "R_1", R_1);
 	papiWriteScenario_vec(scn, "V_1", V_1);
 	papiWriteScenario_double(scn, "GMT_1", GMT_1);
+	papiWriteScenario_double(scn, "W_B", W_B);
+	papiWriteScenario_double(scn, "W_IG", W_IG);
 	papiWriteScenario_double(scn, "TotalMassAfter", TotalMassAfter);
 	papiWriteScenario_double(scn, "TotalAreaAfter", TotalAreaAfter);
 	papiWriteScenario_double(scn, "MainEngineFuelUsed", MainEngineFuelUsed);
@@ -1029,6 +1033,8 @@ void MPTManeuver::LoadState(FILEHANDLE scn, char *end_str)
 		papiReadScenario_vec(line, "R_1", R_1);
 		papiReadScenario_vec(line, "V_1", V_1);
 		papiReadScenario_double(line, "GMT_1", GMT_1);
+		papiReadScenario_double(line, "W_B", W_B);
+		papiReadScenario_double(line, "W_IG", W_IG);
 		papiReadScenario_double(line, "TotalMassAfter", TotalMassAfter);
 		papiReadScenario_double(line, "TotalAreaAfter", TotalAreaAfter);
 		papiReadScenario_double(line, "MainEngineFuelUsed", MainEngineFuelUsed);
@@ -9390,46 +9396,68 @@ RTCC_PMMLLWP_22_19:
 	}
 }
 
-void RTCC::EntryUpdateCalc(SV sv0, double entryrange, bool highspeed, EntryResults *res)
+int RTCC::EntryUpdateCalc(EphemerisData sv0, double entryrange, bool highspeed, EntryResults &res)
 {
-	OBJHANDLE hEarth;
-	VECTOR3 REI, VEI, UREI, R3, V3, R05G, V05G;
-	double EntryInterface, RCON, dt2, MJD_EI, lambda, phi, GMT_l, vEI, t32, dt22, EMSAlt, t2;
+	//INPUTS:
+	//sv0: Input state vector, should be before EI
+	//entryrange: Desired entry range, nautical miles
+	//highspeed: false = Earth orbit entry EMS altitude, true = lunar return EMS altitude
+	//OUTPUTS:
+	//res: Flight-path angle at EI, range, splashdown latitude, splashdown longitude, EI velocity, EI GET, 0.05g GET
+	//return value: Error if non-zero
 
-	hEarth = oapiGetObjectByName("Earth");
+	EphemerisData sv_EI, sv_05G;
+	VECTOR3 UREI;
+	double lambda, phi, GMT_l, vEI, EMSAlt;
 
-	EntryInterface = 400000.0 * 0.3048;
-	RCON = OrbMech::R_Earth + EntryInterface;
+	//Reset outputs
+	res.ReA = res.RTGO = res.latitude = res.longitude = res.VIO = res.GET400K = res.GET05G = 0.0;
+
+	//Set EMS altitude
 	if (highspeed)
 	{
-		EMSAlt = 297431.0*0.3048;
+		EMSAlt = 297431.0 * 0.3048;
 	}
 	else
 	{
-		EMSAlt = 284643.0*0.3048;
+		EMSAlt = 284643.0 * 0.3048;
 	}
 
-	dt2 = OrbMech::time_radius_integ(SystemParameters.AGCEpoch, sv0.R, sv0.V, sv0.MJD, RCON, -1, sv0.gravref, hEarth, REI, VEI);
-	MJD_EI = sv0.MJD + dt2 / 24.0 / 3600.0;
-	t2 = (sv0.MJD - CalcGETBase()) * 24.0 * 3600.0 + dt2;	//EI time in seconds from launch
+	//Find entry interface altitude
+	EMMENIInputTable in;
 
-	UREI = unit(REI);
-	vEI = length(VEI);
-	res->ReA = asin(dotp(UREI, VEI) / vEI);
+	in.AnchorVector = sv0;
+	in.EarthRelStopParam = 400000.0 * 0.3048;
+	in.StopParamRefFrame = 0;
+	in.CutoffIndicator = 3;
 
-	t32 = OrbMech::time_radius(REI, VEI, RCON - 30480.0, -1, OrbMech::mu_Earth);
-	OrbMech::rv_from_r0v0(REI, VEI, t32, R3, V3, OrbMech::mu_Earth);
-	dt22 = OrbMech::time_radius(R3, V3, length(R3) - (300000.0 * 0.3048 - EMSAlt), -1, OrbMech::mu_Earth);
-	OrbMech::rv_from_r0v0(R3, V3, dt22, R05G, V05G, OrbMech::mu_Earth);
+	EMMENI(in);
 
-	res->RTGO = EntryCalculations::LNDING(REI, VEI, OrbMech::GETfromMJD(MJD_EI, GetGMTBase()), SystemParameters.MCLAMD, 0.3, 2, entryrange, lambda, phi, GMT_l);
+	if (in.TerminationCode != 3) return 1;
+	sv_EI = in.sv_cutoff;
 
-	res->latitude = phi;
-	res->longitude = lambda;
+	// Find EMS init altitude
+	in.AnchorVector = sv_EI;
+	in.EarthRelStopParam = EMSAlt;
+	in.StopParamRefFrame = 0;
+	in.CutoffIndicator = 3;
 
-	res->VIO = length(V05G);
-	res->GET400K = t2;
-	res->GET05G = t2 + t32 + dt22;
+	EMMENI(in);
+
+	if (in.TerminationCode != 3) return 1;
+	sv_05G = in.sv_cutoff;
+
+	//Calculate output data
+	UREI = unit(sv_EI.R);
+	vEI = length(sv_EI.V);
+	res.ReA = asin(dotp(UREI, sv_EI.V) / vEI);
+	res.RTGO = EntryCalculations::LNDING(sv_EI.R, sv_EI.V, sv_EI.GMT, SystemParameters.MCLAMD, 0.3, 2, entryrange, lambda, phi, GMT_l);
+	res.latitude = phi;
+	res.longitude = lambda;
+	res.VIO = length(sv_05G.V);
+	res.GET400K = GETfromGMT(sv_EI.GMT);
+	res.GET05G = GETfromGMT(sv_05G.GMT);
+	return 0;
 }
 
 double RTCC::CalculateTPITimes(SV sv0, int tpimode, double t_TPI_guess, double dt_TPI_sunrise)
@@ -15971,7 +15999,7 @@ void RTCC::EMMDYNMC(int L, int queid, int ind, double param)
 
 //Space Digitals
 
-int RTCC::EMDSPACENoMPT(SV sv0, int queid, double gmt, double incl, double ascnode)
+int RTCC::EMDSPACENoMPT(VehicleDataBlock sv0, int queid, double gmt, double incl, double ascnode)
 {
 	//queid:
 	//3 = MED Column 1
@@ -15980,11 +16008,11 @@ int RTCC::EMDSPACENoMPT(SV sv0, int queid, double gmt, double incl, double ascno
 
 	EZSPACE.errormessage = "";
 
-	EphemerisData sv = ConvertSVtoEphemData(sv0);
+	EphemerisData sv = sv0.sv;
 
 	//Generate display values for current state vector
 	EZSPACE.GET = GETfromGMT(sv.GMT);
-	EZSPACE.WEIGHT = sv0.mass * LBS*1000.0;
+	EZSPACE.WEIGHT = sv0.Weight * LBS*1000.0;
 	EZSPACE.GMTV = 0.0;
 	EZSPACE.GETV = EZSPACE.GETAxis = 0.0;
 
@@ -16043,7 +16071,7 @@ int RTCC::EMDSPACENoMPT(SV sv0, int queid, double gmt, double incl, double ascno
 			mu = OrbMech::mu_Moon;
 		}
 
-		EZSPACE.WT = sv0.mass * LBS*1000.0;
+		EZSPACE.WT = sv0.Weight * LBS*1000.0;
 
 		int csi_out;
 		if (sv.RBI == BODY_EARTH)
@@ -18081,6 +18109,7 @@ int RTCC::PMMLAI(PMMLAIInput in, RTCCNIAuxOutputTable &aux, EphemerisDataTable2 
 	aux.sv_FF.GMT = asc_out.sv_IG.GMT;
 	aux.sv_FF.RBI = asc_out.sv_IG.RBI;
 	aux.V_G = aux.A_T*asc_out.dv;
+	aux.WTINIT = in.m0;
 	aux.WTEND = asc_out.m1;
 	aux.WTENGON = asc_in.m0;
 	aux.W_CSM = 0.0;
@@ -18153,6 +18182,7 @@ int RTCC::PMMLDI(PMMLDIInput in, RTCCNIAuxOutputTable &aux, EphemerisDataTable2 
 	aux.sv_FF.GMT = sv_PDI.sv.GMT;
 	aux.sv_FF.RBI = sv_PDI.sv.RBI;
 	aux.V_G = _V(1, 0, 0)*dv;
+	aux.WTINIT = in.sv.Weight;
 	aux.WTEND = sv_land.Weight;
 	aux.WTENGON = sv_PDI.Weight;
 	aux.W_CSM = 0.0;
@@ -18330,6 +18360,7 @@ void RTCC::PMMFUD(int veh, unsigned man, int action, std::string StationID)
 		int TUP = mpt->CommonBlock.TUP;
 		mpt->CommonBlock = mpt->mantable[man - 1].CommonBlock;
 		mpt->CommonBlock.TUP = TUP;
+		mpt->TotalInitMass = mpt->CommonBlock.CSMMass + mpt->CommonBlock.LMAscentMass + mpt->CommonBlock.LMDescentMass + mpt->CommonBlock.SIVBMass;
 		//TBD: Compute and store new GET to begin venting
 
 		for (unsigned i = 0;i < man;i++)
@@ -36574,6 +36605,8 @@ void RTCC::PMMDMT(int L, unsigned man, RTCCNIAuxOutputTable *aux)
 	//mptman->GMTFrozen = mpt->GMTAV;
 	//mptman->StationIDFrozen = mpt->StationID;
 	mptman->CommonBlock.TUP = abs(mpt->CommonBlock.TUP);
+	mptman->W_B = aux->WTINIT;
+	mptman->W_IG = aux->WTENGON;
 
 	//Update fuel masses
 	double WDOT, T, F;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -1417,6 +1417,10 @@ struct MPTManeuver
 	VECTOR3 V_1;
 	double GMT_1;
 	
+	//Total configuration weight at maneuver initiation
+	double W_B;
+	//Total configuration weight at main engine on
+	double W_IG;
 	double TotalMassAfter;
 	double TotalAreaAfter;
 	double MainEngineFuelUsed;
@@ -2536,7 +2540,7 @@ public:
 
 	void LunarAscentProcessor(const LunarAscentProcessorInputs &in, LunarAscentProcessorOutputs &out);
 	bool PoweredDescentProcessor(VECTOR3 R_LS, double TLAND, VehicleDataBlock sv, RTCCNIAuxOutputTable &aux, EphemerisDataTable2 *E, VehicleDataBlock &sv_PDI, VehicleDataBlock &sv_land, double &dv);
-	void EntryUpdateCalc(SV sv0, double entryrange, bool highspeed, EntryResults *res);
+	int EntryUpdateCalc(EphemerisData sv0, double entryrange, bool highspeed, EntryResults &res);
 	void PMMDKI(SPQOpt &opt, SPQResults &res);
 	//Velocity maneuver performer
 	void PCMVMR(AEGDataBlock &CHASER, AEGDataBlock &TARGET, double DELVX, double DELVY, double DELVZ, double mu, double &Pitch, double &Yaw, int I);
@@ -2849,7 +2853,7 @@ public:
 	void EMMDYNMC(int L, int queid, int ind = 0, double param = 0.0);
 	//FDO Space Digitals
 	int EMDSPACE(int queid, int option = 0, double val = 0.0, double incl = 0.0, double ascnode = 0.0);
-	int EMDSPACENoMPT(SV sv0, int queid, double gmt, double incl = 0.0, double ascnode = 0.0);
+	int EMDSPACENoMPT(VehicleDataBlock sv0, int queid, double gmt, double incl = 0.0, double ascnode = 0.0);
 	//Orbit Station Contact Generation Control
 	void EMSTAGEN(int L);
 	//Generalized Contact Generator

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -865,11 +865,11 @@ void ARCore::EntryUpdateCalc()
 
 	if (v == NULL) return;
 
-	SV sv0;
+	EphemerisData sv0;
 	EntryResults res;
 
-	sv0 = GC->rtcc->StateVectorCalc(v);
-	GC->rtcc->EntryUpdateCalc(sv0, entryrange, true, &res);
+	sv0 = GC->rtcc->StateVectorCalcEphem(v);
+	GC->rtcc->EntryUpdateCalc(sv0, entryrange, true, res);
 
 	GC->rtcc->RZDBSC1.lat_T = res.latitude;
 	GC->rtcc->RZDBSC1.lng_T = res.longitude;
@@ -3362,7 +3362,7 @@ int ARCore::subThread()
 			break;
 		}
 
-		SV sv0 = GC->rtcc->StateVectorCalc(v);
+		VehicleDataBlock sv0 = GC->rtcc->StateVectorCalcDataBlock(v);
 		GC->rtcc->EMDSPACENoMPT(sv0, SpaceDigitalsOption + 2, GC->rtcc->GMTfromGET(SpaceDigitalsGET));
 
 		Result = DONE;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/CSMLMGuidanceSim.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/CSMLMGuidanceSim.cpp
@@ -525,6 +525,7 @@ PMMRKJ_LABEL_22C:
 		Aux->X_B = X_B;
 		Aux->Y_B = Y_B;
 		Aux->Z_B = Z_B;
+		Aux->WTINIT = TArr.CAPWT;
 		Aux->WTENGON = WTENGON;
 		Aux->WTEND = WT;
 		Aux->MainFuelUsed = MAINFUELUSED;


### PR DESCRIPTION
-Use more up-to-date functions for EntryUpdateCalc
-Save weights at maneuver begin and main engine on in MPT
-Fix MPT bug where deleting an executed undocking maneuver does not update the total initial weight to the undocked value

Testing: Splashdown update in RTCC MFD (for the EntryUpdateCalc function) should work like before and this specific MPT condition should be tested, if it now works correctly.