### PR TITLE
RTCC fixes

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C_PRIME.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_C_PRIME.cpp
@@ -195,7 +195,7 @@ bool RTCC::CalculationMTP_C_PRIME(int fcn, LPVOID &pad, char * upString, char * 
 		entopt.RV_MCC = sv2;
 		entopt.dv_max = 7000.0*0.3048;
 
-		EntryTargeting(&entopt, &res); //Target load for uplink
+		EntryTargeting(entopt, res);
 
 		opt.TIG = res.P30TIG;
 		opt.dV_LVLH = res.dV_LVLH;
@@ -375,7 +375,7 @@ bool RTCC::CalculationMTP_C_PRIME(int fcn, LPVOID &pad, char * upString, char * 
 		entopt.vessel = calcParams.src;
 		entopt.dv_max = 7000.0*0.3048;
 
-		EntryTargeting(&entopt, &res);//dV_LVLH, P30TIG, latitude, longitude, RET, RTGO, VIO, ReA, prec); //Target load for uplink
+		EntryTargeting(entopt, res);
 
 		opt.TIG = res.P30TIG;
 		opt.dV_LVLH = res.dV_LVLH;
@@ -1782,7 +1782,7 @@ bool RTCC::CalculationMTP_C_PRIME(int fcn, LPVOID &pad, char * upString, char * 
 		entopt.type = 3;
 
 		//Calculate corridor control burn
-		EntryTargeting(&entopt, &res);
+		EntryTargeting(entopt, res);
 
 		//If time to EI is more than 24 hours and the splashdown longitude is not within 2° of desired, then perform a longitude control burn
 		if (MCCtime < calcParams.EI - 24.0*3600.0 && abs(res.longitude - entopt.lng) > 2.0*RAD)
@@ -1790,7 +1790,7 @@ bool RTCC::CalculationMTP_C_PRIME(int fcn, LPVOID &pad, char * upString, char * 
 			entopt.type = 1;
 			entopt.t_Z = res.GET400K;
 
-			EntryTargeting(&entopt, &res);
+			EntryTargeting(entopt, res);
 		}
 
 		//Apollo 8 Mission Rules

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_F.cpp
@@ -192,7 +192,7 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 		entopt.vessel = calcParams.src;
 		entopt.RV_MCC = sv1;
 
-		EntryTargeting(&entopt, &res); //Target load for uplink
+		EntryTargeting(entopt, res);
 
 		opt.TIG = res.P30TIG;
 		opt.dV_LVLH = res.dV_LVLH;
@@ -2172,7 +2172,7 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 		entopt.type = 3; //Unspecified area
 
 		//Calculate corridor control burn
-		EntryTargeting(&entopt, &res);
+		EntryTargeting(entopt, res);
 
 		//If time to EI is more than 24 hours and the splashdown longitude is not within 2° of desired, then perform a longitude control burn
 		if (MCCtime < calcParams.EI - 24.0*3600.0 && abs(res.longitude - entopt.lng) > 2.0*RAD)
@@ -2180,7 +2180,7 @@ bool RTCC::CalculationMTP_F(int fcn, LPVOID &pad, char * upString, char * upDesc
 			entopt.type = 1;
 			entopt.t_Z = res.GET400K;
 
-			EntryTargeting(&entopt, &res);
+			EntryTargeting(entopt, res);
 		}
 
 		//Apollo 10 Mission Rules

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_G.cpp
@@ -242,7 +242,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		entopt.vessel = calcParams.src;
 		entopt.RV_MCC = sv1;
 
-		EntryTargeting(&entopt, &res); //Target load for uplink
+		EntryTargeting(entopt, res);
 
 		opt.TIG = res.P30TIG;
 		opt.dV_LVLH = res.dV_LVLH;
@@ -2569,7 +2569,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 		entopt.type = 3;
 
 		//Calculate corridor control burn
-		EntryTargeting(&entopt, &res);
+		EntryTargeting(entopt, res);
 
 		//If time to EI is more than 24 hours and the splashdown longitude is not within 2° of desired, then perform a longitude control burn
 		if (MCCtime < calcParams.EI - 24.0*3600.0 && abs(res.longitude - entopt.lng) > 2.0*RAD)
@@ -2577,7 +2577,7 @@ bool RTCC::CalculationMTP_G(int fcn, LPVOID &pad, char * upString, char * upDesc
 			entopt.type = 1;
 			entopt.t_Z = res.GET400K;
 
-			EntryTargeting(&entopt, &res);
+			EntryTargeting(entopt, res);
 		}
 
 		//Apollo 11 Mission Rules

--- a/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/RTCC_Mission_H1.cpp
@@ -335,7 +335,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID& pad, char* upString, char* upDesc,
 		entopt.vessel = calcParams.src;
 		entopt.RV_MCC = sv1;
 
-		EntryTargeting(&entopt, &res); //Target load for uplink
+		EntryTargeting(entopt, res);
 
 		opt.TIG = res.P30TIG;
 		opt.dV_LVLH = res.dV_LVLH;
@@ -394,7 +394,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID& pad, char* upString, char* upDesc,
 		entopt.TIGguess = form->GETI[0] = OrbMech::HHMMSSToSS(8, 0, 0);
 		entopt.t_Z = OrbMech::HHMMSSToSS(25.0, 43.0, 0.0);
 		entopt.RV_MCC = sv1;
-		EntryTargeting(&entopt, &res);
+		EntryTargeting(entopt, res);
 		form->dVT[0] = length(res.dV_LVLH) / 0.3048;
 		form->GET400K[0] = res.GET05G;
 		form->lng[0] = round(res.longitude * DEG);
@@ -470,7 +470,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID& pad, char* upString, char* upDesc,
 			entopt.TIGguess = form->GETI[0] = OrbMech::HHMMSSToSS(15, 0, 0);
 			entopt.t_Z = OrbMech::HHMMSSToSS(50.0, 6.0, 0.0);
 			entopt.RV_MCC = sv2;
-			EntryTargeting(&entopt, &res);
+			EntryTargeting(entopt, res);
 			form->dVT[0] = length(res.dV_LVLH) / 0.3048;
 			form->GET400K[0] = res.GET05G;
 			form->lng[0] = round(res.longitude * DEG);
@@ -480,7 +480,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID& pad, char* upString, char* upDesc,
 			entopt.TIGguess = form->GETI[0] = OrbMech::HHMMSSToSS(25, 0, 0);
 			entopt.t_Z = OrbMech::HHMMSSToSS(74.0, 12.0, 0.0);
 			entopt.RV_MCC = sv1;
-			EntryTargeting(&entopt, &res);
+			EntryTargeting(entopt, res);
 			form->dVT[0] = length(res.dV_LVLH) / 0.3048;
 			form->GET400K[0] = res.GET05G;
 			form->lng[0] = round(res.longitude * DEG);
@@ -488,7 +488,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID& pad, char* upString, char* upDesc,
 			entopt.TIGguess = form->GETI[1] = OrbMech::HHMMSSToSS(35, 0, 0);
 			entopt.t_Z = OrbMech::HHMMSSToSS(73.0, 39.0, 0.0);
 			entopt.RV_MCC = sv2;
-			EntryTargeting(&entopt, &res);
+			EntryTargeting(entopt, res);
 			form->dVT[1] = length(res.dV_LVLH) / 0.3048;
 			form->GET400K[1] = res.GET05G;
 			form->lng[1] = round(res.longitude * DEG);
@@ -496,7 +496,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID& pad, char* upString, char* upDesc,
 			entopt.TIGguess = form->GETI[2] = OrbMech::HHMMSSToSS(45, 0, 0);
 			entopt.t_Z = OrbMech::HHMMSSToSS(97.0, 58.0, 0.0);
 			entopt.RV_MCC = sv2;
-			EntryTargeting(&entopt, &res);
+			EntryTargeting(entopt, res);
 			form->dVT[2] = length(res.dV_LVLH) / 0.3048;
 			form->GET400K[2] = res.GET05G;
 			form->lng[2] = round(res.longitude * DEG);
@@ -504,7 +504,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID& pad, char* upString, char* upDesc,
 			entopt.TIGguess = form->GETI[3] = OrbMech::HHMMSSToSS(60, 0, 0);
 			entopt.t_Z = OrbMech::HHMMSSToSS(122.0, 01.0, 0.0);
 			entopt.RV_MCC = sv2;
-			EntryTargeting(&entopt, &res);
+			EntryTargeting(entopt, res);
 			form->dVT[3] = length(res.dV_LVLH) / 0.3048;
 			form->GET400K[3] = res.GET05G;
 			form->lng[3] = round(res.longitude * DEG);
@@ -3418,7 +3418,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID& pad, char* upString, char* upDesc,
 		}
 
 		entopt.type = 3;
-		EntryTargeting(&entopt, &res);
+		EntryTargeting(entopt, res);
 
 		if (fcn != 205)
 		{
@@ -3432,7 +3432,7 @@ bool RTCC::CalculationMTP_H1(int fcn, LPVOID& pad, char* upString, char* upDesc,
 			{
 				entopt.type = 1;
 				entopt.t_Z = res.GET400K;
-				EntryTargeting(&entopt, &res);
+				EntryTargeting(entopt, res);
 			}
 
 			//Apollo 11 Mission Rules

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -2866,7 +2866,7 @@ void RTCC::AP11BlockData(AP11BLKOpt *opt, P37PAD &pad)
 		entopt.lng = opt->lng[i];
 		entopt.t_Z = opt->T_Z[i];
 
-		EntryTargeting(&entopt, &res);
+		EntryTargeting(entopt, res);
 
 		pad.dVT[i] = length(res.dV_LVLH) / 0.3048;
 		pad.GET400K[i] = res.GET05G;
@@ -2927,83 +2927,113 @@ void RTCC::BlockDataProcessor(EarthEntryOpt *opt, EntryResults *res)
 	RZRFTT.Primary.DeltaV = res->dV_LVLH;
 }
 
-void RTCC::EntryTargeting(EntryOpt *opt, EntryResults *res)
+void RTCC::EntryTargeting(const EntryOpt &opt, EntryResults &res)
 {
-	RTEEarth* entry;
-	double GET, LINE[10];
-	bool stop;
-	SV sv;
+	double LINE[10], GMT, GMT_TIG;
+	SV sv_tig;
 
-	stop = false;
+	GMT = OrbMech::GETfromMJD(opt.RV_MCC.MJD, GetGMTBase());
+	GMT_TIG = GMTfromGET(opt.TIGguess);
 
-	sv = opt->RV_MCC;
-	GET = (sv.MJD - CalcGETBase())*24.0*3600.0;
-
-	if (opt->entrylongmanual)
+	if (opt.entrylongmanual)
 	{
 		LINE[0] = PI05;
-		LINE[1] = opt->lng;
+		LINE[1] = opt.lng;
 		LINE[2] = -PI05;
-		LINE[3] = opt->lng;
+		LINE[3] = opt.lng;
 		LINE[4] = 1e10;
 		LINE[5] = 1e10;
 	}
 	else
 	{
-		if (opt->ATPLine < 0 || opt->ATPLine>4)
+		if (opt.ATPLine < 0 || opt.ATPLine>4)
 		{
 			return;
 		}
 
 		for (int i = 0;i < 10;i++)
 		{
-			LINE[i] = PZREAP.ATPCoordinates[opt->ATPLine][i];
+			LINE[i] = PZREAP.ATPCoordinates[opt.ATPLine][i];
 		}
 	}
 
-	entry = new RTEEarth(this, ConvertSVtoEphemData(sv), GetGMTBase(), SystemParameters.MCLAMD, GMTfromGET(opt->TIGguess), GMTfromGET(opt->t_Z), opt->type);
-	//Check for error (state vector not in Earth SOI)
-	if (entry->errorstate)
+	//Propagate to TIG
+	sv_tig = coast(opt.RV_MCC, GMT_TIG - GMT);
+
+	if (sv_tig.gravref == hEarth)
 	{
-		return;
-	}
+		bool stop;
 
-	entry->READ(PZREAP.RRBIAS, opt->dv_max, PZREAP.TGTLN + 1, 37500.0*0.3048);
-	entry->ATP(LINE);
-	while (!stop)
-	{
-		stop = entry->EntryIter();
-	}
+		stop = false;
 
-	res->dV_LVLH = entry->Entry_DV;
-	res->P30TIG = GETfromGMT(entry->sv_ig.GMT);
-	res->latitude = entry->EntryLatcor;
-	res->longitude = entry->EntryLngcor;
-	res->GET400K = GETfromGMT(entry->t2);
-	res->GET05G = GETfromGMT(entry->EntryRET);
-	res->RTGO = entry->EntryRTGO;
-	res->VIO = entry->EntryVIO;
-	res->ReA = entry->EntryAng;
-	res->precision = entry->precision;
+		RTEEarth rte(this, ConvertSVtoEphemData(sv_tig), GetGMTBase(), SystemParameters.MCLAMD, GMTfromGET(opt.TIGguess), GMTfromGET(opt.t_Z), opt.type);
 
-	delete entry;
+		//Check for error
+		if (rte.errorstate)
+		{
+			return;
+		}
 
-	double TIG_imp, LMmass;
-	VECTOR3 DV_imp;
+		rte.READ(PZREAP.RRBIAS, opt.dv_max, PZREAP.TGTLN + 1, 37500.0 * 0.3048);
+		rte.ATP(LINE);
+		while (!stop)
+		{
+			stop = rte.EntryIter();
+		}
 
-	TIG_imp = res->P30TIG;
-	DV_imp = res->dV_LVLH;
+		res.dV_LVLH = rte.Entry_DV;
+		res.P30TIG = GETfromGMT(rte.sv_ig.GMT);
+		res.latitude = rte.EntryLatcor;
+		res.longitude = rte.EntryLngcor;
+		res.GET400K = GETfromGMT(rte.t2);
+		res.GET05G = GETfromGMT(rte.EntryRET);
+		res.RTGO = rte.EntryRTGO;
+		res.VIO = rte.EntryVIO;
+		res.ReA = rte.EntryAng;
+		res.precision = rte.precision;
 
-	if (opt->csmlmdocked)
-	{
-		LMmass = GetDockedVesselMass(opt->vessel);
+		double TIG_imp, LMmass;
+		VECTOR3 DV_imp;
+
+		TIG_imp = res.P30TIG;
+		DV_imp = res.dV_LVLH;
+
+		if (opt.csmlmdocked)
+		{
+			LMmass = GetDockedVesselMass(opt.vessel);
+		}
+		else
+		{
+			LMmass = 0.0;
+		}
+
+		PoweredFlightProcessor(sv_tig, TIG_imp, opt.enginetype, LMmass, DV_imp, true, res.P30TIG, res.dV_LVLH, res.sv_preburn, res.sv_postburn);
 	}
 	else
 	{
-		LMmass = 0.0;
-	}
+		//Temporary fix for TIG being in lunar SOI
+		RTEMoonOpt moonopt;
 
-	PoweredFlightProcessor(opt->RV_MCC, TIG_imp, opt->enginetype, LMmass, DV_imp, true, res->P30TIG, res->dV_LVLH, res->sv_preburn, res->sv_postburn);
+		moonopt.vessel = opt.vessel;
+		moonopt.TIGguess = opt.TIGguess;
+		moonopt.EntryLng = opt.lng;
+		moonopt.RV_MCC = sv_tig;
+		moonopt.csmlmdocked = opt.csmlmdocked;
+		moonopt.entrylongmanual = opt.entrylongmanual;
+		moonopt.enginetype = opt.enginetype;
+		if (opt.type == 1)
+		{
+			moonopt.SMODE = 14;
+		}
+		else
+		{
+			moonopt.SMODE = 16;
+		}
+		moonopt.t_zmin = opt.t_Z;
+		moonopt.ATPLine = opt.ATPLine;
+
+		RTEMoonTargeting(&moonopt, &res);
+	}
 }
 
 void RTCC::PMSTICN(const TwoImpulseOpt &opt, TwoImpulseResuls &res)
@@ -7339,8 +7369,18 @@ void RTCC::RTEMoonTargeting(RTEMoonOpt *opt, EntryResults *res)
 
 	arr.SMODEI = opt->SMODE;
 	arr.alpha_SID0 = SystemParameters.MCLAMD;
-	arr.TZMINI = GMTfromGET(TZMINI);
-	arr.TZMAXI = 0.0; //TBD
+	if (opt->SMODE == 14 || opt->SMODE == 34)
+	{
+		//ATP
+		arr.TZMINI = GMTfromGET(TZMINI);
+		arr.TZMAXI = 0.0;
+	}
+	else
+	{
+		//UA
+		arr.TZMINI = GMTfromGET(PZREAP.TZMIN * 3600.0);
+		arr.TZMAXI = GMTfromGET(PZREAP.TZMAX * 3600.0);
+	}
 	arr.IRMAXI = PZREAP.IRMAX;
 	arr.URMAXI = PZREAP.VRMAX;
 	arr.RRBI = PZREAP.RRBIAS;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -36966,8 +36966,9 @@ void RTCC::PMMDMT(int L, unsigned man, RTCCNIAuxOutputTable *aux)
 			K = 0.0;
 			R_E = BZLAND.rad[RTCC_LMPOS_BEST];
 
-			mptman->h_BI = length(sv_BI_true.R) - BZLAND.rad[RTCC_LMPOS_BEST];
-			mptman->lat_BI = asin(sv_BI_true.R.z / sv_BI_true.R.x);
+			double r = length(sv_BI_true.R);
+			mptman->h_BI = r - BZLAND.rad[RTCC_LMPOS_BEST];
+			mptman->lat_BI = asin(sv_BI_true.R.z / r);
 		}
 
 		mptman->lng_BI = atan2(sv_BI_true.R.y, sv_BI_true.R.x) - K * OrbMech::w_Earth*sv_BI_true.GMT;

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -2454,7 +2454,7 @@ public:
 	void PMSTICN(const TwoImpulseOpt &opt, TwoImpulseResuls &res);
 	double FindDH(VehicleDataBlock sv_A, VehicleDataBlock sv_P, double GMT_guess, double DH);
 	MATRIX3 REFSMMATCalc(REFSMMATOpt *opt);
-	void EntryTargeting(EntryOpt *opt, EntryResults *res);//VECTOR3 &dV_LVLH, double &P30TIG, double &latitude, double &longitude, double &GET05G, double &RTGO, double &VIO, double &ReA, int &precision);
+	void EntryTargeting(const EntryOpt &opt, EntryResults &res);
 	void BlockDataProcessor(EarthEntryOpt *opt, EntryResults *res);
 	//RTCC module name PMMEPP
 	void TranslunarInjectionProcessor(bool mpt, EphemerisData *sv = NULL, PLAWDTOutput *WeightsTable = NULL);

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCC_EMSMISS.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/RTCC_EMSMISS.cpp
@@ -360,7 +360,7 @@ void RTCC_EMSMISS::UpdateWeightsTableAndSVAfterManeuver()
 
 		OtherCommonBlock = pRTCC->MPTDockingManeuver(intab->VehicleCode, state.StateVector.GMT, plawdtout);
 
-		if (plawdtout.Err)
+		if (plawdtout.Err == 1 || plawdtout.Err == 2)
 		{
 			ErrorCode = 4;
 			return;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/rtcc_library_programs.cpp
@@ -2045,6 +2045,7 @@ RTCC_PLAWDT_9_T:
 	out.SIVBWeight = in.SIVBWeight;
 	out.LMAscWeight = in.LMAscWeight;
 	out.LMDscWeight = in.LMDscWeight;
+	out.CC = in.Num;
 	goto RTCC_PLAWDT_M_5;
 }
 


### PR DESCRIPTION
-Fix latitude on DMT when in lunar orbit
-Fix false error conditions with MPT docking maneuver
-EntryTargeting function (used by the MCC for Earth-orbit Return-to-Earth calculations) now has a path for lunar SOI cases, so that it can always return a solution