### PR TITLE
RTCC fixes

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.cpp
@@ -19022,13 +19022,6 @@ void RTCC::EMSEPH(int QUEID, StateVectorTableEntry &sv, int &L, double PresentGM
 			//Terminated on altitude
 			if (InTable.NIAuxOutputTable.TerminationCode == 3)
 			{
-				if (QUEID == 1)
-				{
-					//Unable to get state vector to present time, exit with an error indication
-					L = -L;
-					return;
-				}
-
 				//NI ended on altitude
 				int num;
 
@@ -19079,6 +19072,15 @@ void RTCC::EMSEPH(int QUEID, StateVectorTableEntry &sv, int &L, double PresentGM
 					}
 
 					IsKickout[num] = true;
+				}
+				else
+				{
+					if (QUEID == 1)
+					{
+						//Unable to get state vector to present time, exit with an error indication
+						L = -L;
+						return;
+					}
 				}
 			}
 			else
@@ -37426,7 +37428,22 @@ void RTCC::CMMRFMAT(int L, int id, int addr)
 	MATRIX3 a = refs.REFSMMAT;
 	block->REFSMMAT = a;
 
-	//sprintf(oapiDebugString(), "%f, %f, %f, %f, %f, %f, %f, %f, %f", a.m11, a.m12, a.m13, a.m21, a.m22, a.m23, a.m31, a.m32, a.m33);
+	if (block->SequenceNo == 0)
+	{
+		if (L == 1)
+		{
+			block->SequenceNo = 1201;
+		}
+		else
+		{
+			block->SequenceNo = 2301;
+		}
+	}
+	else
+	{
+		block->SequenceNo++;
+	}
+	block->GenGET = GETfromGMT(RTCCPresentTimeGMT());
 
 	block->Octals[0] = 24;
 	if (addr == 1)

--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -4944,7 +4944,7 @@ public:
 		int UpdateNo = 0;
 		int SequenceNo = 0;
 		std::string Site1, Site2;
-		double GET = 0.0;
+		double GenGET = 0.0;
 		int Verb = 71;
 		int Octals[20] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 };
 		int VehID = 0;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -4352,13 +4352,13 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		}
 		Line(skp, CW, CH * 3, CW * 42, CH * 3);
 		Line(skp, CW, CH * 4, CW * 42, CH * 4);
-		Line(skp, (CW * 15) / 2, CH * 3, (CW * 15) / 2, CH * 28);
-		Line(skp, (CW * 31) / 2, CH * 3, (CW * 31) / 2, CH * 28);
-		Line(skp, (CW * 49) / 2, CH * 3, (CW * 49) / 2, CH * 28);
+		Line(skp, (CW * 15) / 2, CH * 3, (CW * 15) / 2, CH * 25);
+		Line(skp, (CW * 31) / 2, CH * 3, (CW * 31) / 2, CH * 25);
+		Line(skp, (CW * 49) / 2, CH * 3, (CW * 49) / 2, CH * 25);
 		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
 		SetMOCRFont(skp, 3, true);
-		Text(skp, 13, 1, "%04d", block->UpdateNo);
-		Text_GET_HHHMMSS(skp, 31, 1, block->GET);
+		Text(skp, 13, 1, "%04d", block->SequenceNo);
+		Text_GET_HHHMMSS(skp, 31, 1, block->GenGET);
 		Text(skp, 11, 2, block->MatrixID);
 		Text(skp, 32, 2, block->MatrixType == 2 ? "DESIRED" : "ACTUAL");
 		for (int i = 0; i < 024; i++)
@@ -4369,7 +4369,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		{
 			Text(skp, 40, 6 + i * 2, "%+.8lf", block->REFSMMAT.data[i]);
 		}
-		Text(skp, 10, 26, block->error);
+		Text(skp, 30, 26, block->error);
 	}
 	break;
 	case 54:


### PR DESCRIPTION
-REFSMMAT uplink page shows load number and GET of generation
-Fix error message formatting on REFSMMAT uplink page
-Update of anchor vector to present time before a trajectory update is allowed to go through entry interface and only fails at the kickout altitude