### PR TITLE
IMU: update vessel rotation matrix in clbkPostCreation; fixes a bug where a gyro pulse from the AGC on the first timestep after scenario loading causes a sudden shift of the IMU attitude reference

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -1286,6 +1286,9 @@ void Saturn::clbkPostCreation()
 	hga.clbkPostCreation();
 	SPSEngine.clbkPostCreation();
 
+	//Set up systems
+	imu.clbkPostCreation();
+
 	// Connect to the Checklist controller.
 	checkControl.linktoVessel(this);
 

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -2125,6 +2125,9 @@ void LEM::clbkSetClassCaps (FILEHANDLE cfg) {
 
 void LEM::clbkPostCreation()
 {
+	//Set up systems
+	imu.clbkPostCreation();
+
 	//Find MCC, if it exists
 	pMCC = NULL;
 	hMCC = oapiGetVesselByName("MCC");

--- a/Orbitersdk/samples/ProjectApollo/src_sys/IMU.h
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/IMU.h
@@ -44,6 +44,7 @@ public:
 	void ChannelOutput(int address, ChannelValue value);
 	void Timestep(double simdt);
 	void SystemTimestep(double simdt);
+	void clbkPostCreation();
 	void TurnOn();
 	void TurnOff();
 	void DriveGimbals(double x, double y, double z);

--- a/Orbitersdk/samples/ProjectApollo/src_sys/imu.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_sys/imu.cpp
@@ -551,6 +551,11 @@ void IMU::SystemTimestep(double simdt)
 	}
 }
 
+void IMU::clbkPostCreation()
+{
+	//Get attitude
+	OurVessel->GetRotationMatrix(Orbiter.Attitude_v2g);
+}
 
 void IMU::PulsePIPA(int RegPIPA, int pulses) 
 


### PR DESCRIPTION
The AGC timestep happens before the IMU timestep. The vessel rotation matrix that the IMU class is using is only updated in the IMU timestep so far. When now the AGC sends a gyro pulse to the IMU on the first timestep after scenario load, the IMU attitude matrix is being used without having been updated to the current attitude of the vessel in the simulation. When the gyro pulse is taken into account, the now re-calculated IMU attitude reference can have a very large shift and the alignment is suddenly not valid.

The fix is to add an clbkPostCreation function to the IMU that updates the rotation matrix. This happens before any AGC timestep so that the gyro pulse is now processed correctly.

The bug can be seen in the attached scenario. Start the scenario in paused mode, switch to the CSM and see the IMU attitude shift suddenly. This does not happen with this PR.

[(Current state) 0003.scn.txt](https://github.com/user-attachments/files/27207515/Current.state.0003.scn.txt)
